### PR TITLE
Fix external location value to be editable on started scheduled event

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/managers/ScheduledEventManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/ScheduledEventManagerImpl.java
@@ -215,11 +215,9 @@ public class ScheduledEventManagerImpl extends ManagerBase<ScheduledEventManager
     {
         if (shouldUpdate(LOCATION))
         {
-            Checks.check(getScheduledEvent().getStatus() == ScheduledEvent.Status.SCHEDULED, "Cannot update location of non-scheduled event.");
+            Checks.check(getScheduledEvent().getStatus() == ScheduledEvent.Status.SCHEDULED || entityType == ScheduledEvent.Type.EXTERNAL, "Cannot update location of non-scheduled event.");
             if (entityType == ScheduledEvent.Type.EXTERNAL && endTime == null && getScheduledEvent().getEndTime() == null)
                 throw new IllegalStateException("Missing required parameter: End Time");
-            if (entityType == ScheduledEvent.Type.EXTERNAL)
-                Checks.check((endTime != null ? endTime : getScheduledEvent().getEndTime()).isAfter(startTime), "Cannot schedule event to end before starting!");
         }
 
         if (shouldUpdate(START_TIME))

--- a/src/main/java/net/dv8tion/jda/internal/managers/ScheduledEventManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/ScheduledEventManagerImpl.java
@@ -215,7 +215,7 @@ public class ScheduledEventManagerImpl extends ManagerBase<ScheduledEventManager
     {
         if (shouldUpdate(LOCATION))
         {
-            Checks.check(getScheduledEvent().getStatus() == ScheduledEvent.Status.SCHEDULED || entityType == ScheduledEvent.Type.EXTERNAL, "Cannot update location of non-scheduled event.");
+            Checks.check(getScheduledEvent().getStatus() == ScheduledEvent.Status.SCHEDULED || (entityType == ScheduledEvent.Type.EXTERNAL && getScheduledEvent().getType() == ScheduledEvent.Type.EXTERNAL), "Cannot update location type or location channel of non-scheduled event.");
             if (entityType == ScheduledEvent.Type.EXTERNAL && endTime == null && getScheduledEvent().getEndTime() == null)
                 throw new IllegalStateException("Missing required parameter: End Time");
         }


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____

Closes Issue: NaN

## Description

Previously JDA would throw when attempting to change the location of a started scheduled event with an external location. The API allows changing the external location to another external location. What it does not allow is changing the location type after the event has already started. It also does not allow to change the channel of a started event if the location type is set to voice or stage. This commit corrects this and now allows editing of the external location value for a started scheduled event.

I also removed a redundant check, I don't recall why I put it there in the first place but it is not needed, so I assume I did it by mistake.
