### PR TITLE
Fix handling of wrong length discriminators

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -144,7 +144,7 @@ public class EntityBuilder
                 .setMfaEnabled(self.getBoolean("mfa_enabled"))
                 .setName(self.getString("username"))
                 .setGlobalName(self.getString("global_name", null))
-                .setDiscriminator(self.getString("discriminator", "0"))
+                .setDiscriminator(Short.parseShort(self.getString("discriminator", "0")))
                 .setAvatarId(self.getString("avatar", null))
                 .setBot(self.getBoolean("bot"))
                 .setSystem(false);
@@ -453,7 +453,7 @@ public class EntityBuilder
             // Initial creation
             userObj.setName(user.getString("username"))
                    .setGlobalName(user.getString("global_name", null))
-                   .setDiscriminator(user.getString("discriminator", "0"))
+                   .setDiscriminator(Short.parseShort(user.getString("discriminator", "0")))
                    .setAvatarId(user.getString("avatar", null))
                    .setBot(user.getBoolean("bot"))
                    .setSystem(user.getBoolean("system"))
@@ -475,8 +475,8 @@ public class EntityBuilder
         String newName = user.getString("username");
         String oldGlobalName = userObj.getGlobalName();
         String newGlobalName = user.getString("global_name", null);
-        String oldDiscriminator = userObj.getDiscriminator();
-        String newDiscriminator = user.getString("discriminator", "0");
+        short oldDiscriminator = userObj.getDiscriminatorInt();
+        short newDiscriminator = Short.parseShort(user.getString("discriminator", "0"));
         String oldAvatar = userObj.getAvatarId();
         String newAvatar = user.getString("avatar", null);
         int oldFlags = userObj.getFlagsRaw();
@@ -502,13 +502,14 @@ public class EntityBuilder
                     userObj, oldGlobalName));
         }
 
-        if (!oldDiscriminator.equals(newDiscriminator))
+        if (oldDiscriminator != newDiscriminator)
         {
+            String oldDiscrimString = userObj.getDiscriminator();
             userObj.setDiscriminator(newDiscriminator);
             jda.handleEvent(
                 new UserUpdateDiscriminatorEvent(
                     jda, responseNumber,
-                    userObj, oldDiscriminator));
+                    userObj, oldDiscrimString));
         }
 
         if (!Objects.equals(oldAvatar, newAvatar))

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -549,7 +549,6 @@ public class EntityBuilder
             if (user.getMutualGuilds().isEmpty())
             {
                 // we no longer share any guilds/channels with this user so remove it from cache
-                user.setFake(true);
                 getJDA().getUsersView().remove(user.getIdLong());
             }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/SelfUserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/SelfUserImpl.java
@@ -111,7 +111,7 @@ public class SelfUserImpl extends UserImpl implements SelfUser
         selfUser.setName(other.name)
                 .setGlobalName(other.globalName)
                 .setAvatarId(other.avatarId)
-                .setDiscriminator(other.getDiscriminator())
+                .setDiscriminator(other.getDiscriminatorInt())
                 .setBot(other.bot);
         return selfUser
                 .setVerified(other.verified)

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -214,9 +214,9 @@ public class UserImpl extends UserSnowflakeImpl implements User
         return this;
     }
 
-    public UserImpl setDiscriminator(String discriminator)
+    public UserImpl setDiscriminator(short discriminator)
     {
-        this.discriminator = Short.parseShort(discriminator);
+        this.discriminator = discriminator;
         return this;
     }
 
@@ -261,6 +261,11 @@ public class UserImpl extends UserSnowflakeImpl implements User
     {
         this.flags = flags;
         return this;
+    }
+
+    public short getDiscriminatorInt()
+    {
+        return discriminator;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -49,7 +49,6 @@ public class UserImpl extends UserSnowflakeImpl implements User
     protected long privateChannelId = 0L;
     protected boolean bot;
     protected boolean system;
-    protected boolean fake = false;
     protected int flags;
 
     public UserImpl(long id, JDAImpl api)
@@ -251,12 +250,6 @@ public class UserImpl extends UserSnowflakeImpl implements User
         return this;
     }
 
-    public UserImpl setFake(boolean fake)
-    {
-        this.fake = fake;
-        return this;
-    }
-    
     public UserImpl setFlags(int flags)
     {
         this.flags = flags;


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Since discord now returns discriminators of length 1 our equality check was wrong. This caused update events to fire unintentionally.
