### PR TITLE
Fix automod execution errors from rules without an associated channel

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/automod/AutoModExecutionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/automod/AutoModExecutionImpl.java
@@ -39,7 +39,7 @@ public class AutoModExecutionImpl implements AutoModExecution
     public AutoModExecutionImpl(Guild guild, DataObject json)
     {
         this.guild = guild;
-        this.channel = guild.getChannelById(GuildMessageChannel.class, json.getUnsignedLong("channel_id"));
+        this.channel = guild.getChannelById(GuildMessageChannel.class, json.getUnsignedLong("channel_id", 0L));
         this.response = new AutoModResponseImpl(guild, json.getObject("action"));
         this.type = AutoModTriggerType.fromKey(json.getInt("rule_trigger_type", -1));
         this.userId = json.getUnsignedLong("user_id");


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2482

## Description

This fixes an issue where `AutoModExecutionImpl` did not account for automod rules without an associated `channel_id`
