### PR TITLE
Fix choices having an "options" prefix when automatically localizing

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/localization/LocalizationMapper.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/localization/LocalizationMapper.java
@@ -120,7 +120,7 @@ public class LocalizationMapper
 
                 //We need to differentiate subcommands/groups from options before inserting the "options" separator
                 final OptionType type = OptionType.fromKey(item.getInt("type", -1)); //-1 when the object isn't an option
-                final boolean isOption = type != OptionType.SUB_COMMAND && type != OptionType.SUB_COMMAND_GROUP;
+                final boolean isOption = type != OptionType.SUB_COMMAND && type != OptionType.SUB_COMMAND_GROUP && type != OptionType.UNKNOWN;
                 if (isOption) {
                     //At this point the key should look like "path.to.command",
                     // we can insert "options", and the keyExtractor would give option names

--- a/src/test/java/LocalizationTest.java
+++ b/src/test/java/LocalizationTest.java
@@ -119,10 +119,12 @@ public class LocalizationTest
     {
         DataObject o = data;
         for (String name : names)
+        {
             o = o.getArray("options").stream(DataArray::getObject)
                     .filter(s -> s.getString("name").equals(name))
                     .findAny()
                     .orElseThrow(() -> new IllegalArgumentException("Could not find an option with path: " + Arrays.toString(names)));
+        }
         return o;
     }
 

--- a/src/test/java/LocalizationTest.java
+++ b/src/test/java/LocalizationTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import net.dv8tion.jda.api.interactions.DiscordLocale;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.*;
+import net.dv8tion.jda.api.interactions.commands.localization.LocalizationFunction;
+import net.dv8tion.jda.api.interactions.commands.localization.ResourceBundleLocalizationFunction;
+import net.dv8tion.jda.api.utils.data.DataArray;
+import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.api.utils.data.DataPath;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LocalizationTest
+{
+    private static SlashCommandData slashCommandData;
+    private static DataObject data;
+
+    @BeforeAll
+    public static void setup()
+    {
+        final LocalizationFunction localizationFunction = ResourceBundleLocalizationFunction
+                .fromBundles("MyCommands", DiscordLocale.FRENCH)
+                .build();
+
+        slashCommandData = Commands.slash("ban", "Bans someone").addSubcommandGroups(
+                new SubcommandGroupData("user", "Bans a member").addSubcommands(
+                        new SubcommandData("perm", "Bans an user permanently").addOptions(
+                                new OptionData(OptionType.STRING, "user", "The user to ban"),
+                                new OptionData(OptionType.INTEGER, "del_days", "The amount of days to delete messages")
+                                        .addChoices(
+                                                new Command.Choice("1 Day", "1"),
+                                                new Command.Choice("7 Days", "7"),
+                                                new Command.Choice("14 Days", "14")
+                                        )
+                        ),
+                        new SubcommandData("temp", "Bans an user temporarily").addOptions(
+                                new OptionData(OptionType.STRING, "user", "The user to ban"),
+                                new OptionData(OptionType.INTEGER, "del_days", "The amount of days to delete messages")
+                                        .addChoices(
+                                                new Command.Choice("1 Day", "1"),
+                                                new Command.Choice("7 Days", "7"),
+                                                new Command.Choice("14 Days", "14")
+                                        )
+                        )
+                )
+        ).setLocalizationFunction(localizationFunction);
+
+        data = slashCommandData.toData();
+    }
+
+    @Test
+    public void commandLocalization()
+    {
+        assertEquals("ban", DataPath.getString(data, "name_localizations.fr"));
+        assertEquals("Bannis un utilisateur", DataPath.getString(data, "description_localizations.fr"));
+    }
+
+    @Test
+    public void subcommandLocalization()
+    {
+        assertEquals("utilisateur", navigateOptions("user").getObject("name_localizations").getString("fr"));
+        assertEquals("Bannis un utilisateur", navigateOptions("user").getObject("description_localizations").getString("fr"));
+    }
+
+    @Test
+    public void subcommandGroupLocalization()
+    {
+        assertEquals("permanent", navigateOptions("user", "perm").getObject("name_localizations").getString("fr"));
+        assertEquals("Bannis un utilisateur pour toujours", navigateOptions("user", "perm").getObject("description_localizations").getString("fr"));
+    }
+
+    @Test
+    public void optionLocalization()
+    {
+        assertEquals("utilisateur", navigateOptions("user", "perm", "user").getObject("name_localizations").getString("fr"));
+        assertEquals("L'utilisateur à bannir", navigateOptions("user", "perm", "user").getObject("description_localizations").getString("fr"));
+
+        assertEquals("nb_jours", navigateOptions("user", "perm", "del_days").getObject("name_localizations").getString("fr"));
+        assertEquals("Nombre de jours de messages à supprimer", navigateOptions("user", "perm", "del_days").getObject("description_localizations").getString("fr"));
+    }
+
+    @Test
+    public void choiceLocalization()
+    {
+        assertEquals("1 jour", navigateChoice("1 Day", "user", "perm", "del_days").getObject("name_localizations").getString("fr"));
+        assertEquals("7 jours", navigateChoice("7 Days", "user", "perm", "del_days").getObject("name_localizations").getString("fr"));
+        assertEquals("14 jours", navigateChoice("14 Days", "user", "perm", "del_days").getObject("name_localizations").getString("fr"));
+    }
+
+    @Test
+    public void reconstructData()
+    {
+        final DataObject data = slashCommandData.toData();
+        final DataObject reconstitutedData = CommandData.fromData(data).toData();
+        assertEquals(data.toMap(), reconstitutedData.toMap());
+    }
+
+    private DataObject navigateOptions(String... names)
+    {
+        DataObject o = data;
+        for (String name : names)
+            o = o.getArray("options").stream(DataArray::getObject)
+                    .filter(s -> s.getString("name").equals(name))
+                    .findAny()
+                    .orElseThrow(() -> new IllegalArgumentException("Could not find an option with path: " + Arrays.toString(names)));
+        return o;
+    }
+
+    private DataObject navigateChoice(String choiceName, String... names)
+    {
+        return navigateOptions(names)
+                .getArray("choices")
+                .stream(DataArray::getObject)
+                .filter(s -> s.getString("name").equals(choiceName))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("Could not find choice '" + choiceName + "' with path: " + Arrays.toString(names)));
+    }
+}

--- a/src/test/resources/MyCommands_fr.properties
+++ b/src/test/resources/MyCommands_fr.properties
@@ -1,0 +1,18 @@
+ban.name=ban
+ban.description=Bannis un utilisateur
+
+ban.user.name=utilisateur
+ban.user.description=Bannis un utilisateur
+
+ban.user.perm.name=permanent
+ban.user.perm.description=Bannis un utilisateur pour toujours
+
+ban.user.perm.options.user.name=utilisateur
+ban.user.perm.options.user.description=L'utilisateur à bannir
+
+ban.user.perm.options.del_days.name=nb_jours
+ban.user.perm.options.del_days.description=Nombre de jours de messages à supprimer
+
+ban.user.perm.options.del_days.choices.1_day.name=1 jour
+ban.user.perm.options.del_days.choices.7_days.name=7 jours
+ban.user.perm.options.del_days.choices.14_days.name=14 jours


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes automatic localization adding "options" before the choice name
