### PR TITLE
Add the message author id to message reaction events

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionAddEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionAddEvent.java
@@ -40,9 +40,34 @@ import javax.annotation.Nullable;
  */
 public class MessageReactionAddEvent extends GenericMessageReactionEvent
 {
+    private final long messageAuthorId;
+
     public MessageReactionAddEvent(@Nonnull JDA api, long responseNumber, @Nullable User user,
-                                   @Nullable Member member, @Nonnull MessageReaction reaction, long userId)
+                                   @Nullable Member member, @Nonnull MessageReaction reaction, long userId, long messageAuthorId)
     {
         super(api, responseNumber, user, member, reaction, userId);
+        this.messageAuthorId = messageAuthorId;
+    }
+
+    /**
+     * The user id of the original message author.
+     *
+     * @return The user id of the original message author.
+     */
+    @Nonnull
+    public String getMessageAuthorId()
+    {
+        return Long.toUnsignedString(messageAuthorId);
+    }
+
+
+    /**
+     * The user id of the original message author.
+     *
+     * @return The user id of the original message author.
+     */
+    public long getMessageAuthorIdLong()
+    {
+        return messageAuthorId;
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionAddEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionAddEvent.java
@@ -51,6 +51,7 @@ public class MessageReactionAddEvent extends GenericMessageReactionEvent
 
     /**
      * The user id of the original message author.
+     * <br>This might be 0 for webhook messages.
      *
      * @return The user id of the original message author.
      */
@@ -63,6 +64,7 @@ public class MessageReactionAddEvent extends GenericMessageReactionEvent
 
     /**
      * The user id of the original message author.
+     * <br>This might be 0 for webhook messages.
      *
      * @return The user id of the original message author.
      */

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionHandler.java
@@ -176,7 +176,7 @@ public class MessageReactionHandler extends SocketHandler
             api.handleEvent(
                 new MessageReactionAddEvent(
                     api, responseNumber,
-                    user, member, reaction, userId));
+                    user, member, reaction, userId, content.getUnsignedLong("message_author_id", 0L)));
         }
         else
         {


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This is now available on message reaction add events. And no, it is not present on other events.

Reference: https://github.com/discord/discord-api-docs/pull/6102
