### PR TITLE
Update Invite to accommodate Discord making only the `uses` field require expansion

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Invite.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Invite.java
@@ -236,45 +236,21 @@ public interface Invite
     /**
      * The max age of this invite in seconds.
      *
-     * <p>This works only for expanded invites and will throw a {@link IllegalStateException} otherwise!
-     *
-     * @throws IllegalStateException
-     *         if this invite is not expanded
-     *
      * @return The max age of this invite in seconds
-     *
-     * @see    #expand()
-     * @see    #isExpanded()
      */
     int getMaxAge();
 
     /**
     * The max uses of this invite. If there is no limit thus will return {@code 0}.
     *
-    * <p>This works only for expanded invites and will throw a {@link IllegalStateException} otherwise!
-    *
-    * @throws IllegalStateException
-     *        if this invite is not expanded
-    *
     * @return The max uses of this invite or {@code 0} if there is no limit
-    *
-    * @see    #expand()
-    * @see    #isExpanded()
     */
     int getMaxUses();
 
     /**
      * Returns creation date of this invite.
      *
-     * <p>This works only for expanded invites and will throw a {@link IllegalStateException} otherwise!
-     *
-     * @throws IllegalStateException
-     *         if this invite is not expanded
-     *
      * @return The creation date of this invite
-     *
-     * @see    #expand()
-     * @see    #isExpanded()
      */
     @Nonnull
     OffsetDateTime getTimeCreated();
@@ -312,15 +288,7 @@ public interface Invite
     /**
      * Whether this Invite grants only temporary access or not.
      *
-     * <p>This works only for expanded invites and will throw a {@link IllegalStateException} otherwise!
-     *
-     * @throws IllegalStateException
-     *         if this invite is not expanded
-     *
      * @return Whether this invite is temporary or not
-     *
-     * @see    #expand()
-     * @see    #isExpanded()
      */
     boolean isTemporary();
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -2264,21 +2264,18 @@ public class EntityBuilder
         if (object.hasKey("uses"))
         {
             expanded = true;
-            maxAge = object.getInt("max_age");
-            maxUses = object.getInt("max_uses");
             uses = object.getInt("uses");
-            temporary = object.getBoolean("temporary");
-            timeCreated = OffsetDateTime.parse(object.getString("created_at"));
         }
         else
         {
             expanded = false;
-            maxAge = -1;
-            maxUses = -1;
             uses = -1;
-            temporary = false;
-            timeCreated = null;
         }
+
+        maxAge = object.getInt("max_age");
+        maxUses = object.getInt("max_uses");
+        temporary = object.getBoolean("temporary");
+        timeCreated = OffsetDateTime.parse(object.getString("created_at"));
 
         return new InviteImpl(getJDA(), code, expanded, inviter,
                               maxAge, maxUses, temporary, timeCreated,

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -2261,7 +2261,7 @@ public class EntityBuilder
         final int uses;
         final boolean expanded;
 
-        if (object.hasKey("max_uses"))
+        if (object.hasKey("uses"))
         {
             expanded = true;
             maxAge = object.getInt("max_age");


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Discord made all the previous expanded Invite properties (max_uses, temporary, creation, etc...) except for uses accessible without authentication, so use uses instead of max_uses to check if an invite is expanded

Additionally, update docs to remove the outdated notice that certain fields require expansion