### PR TITLE
Fixed MarkdownSanitizer altering URL symbols

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -22,6 +22,7 @@ import net.dv8tion.jda.internal.utils.Checks;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -92,6 +93,8 @@ public class MarkdownSanitizer
         tokens.put(STRIKE, "~~");
     }
 
+    private Matcher urlMatcher;
+    private int urlReplacementIteration;
     private int ignored;
     private SanitizationStrategy strategy;
 
@@ -553,6 +556,11 @@ public class MarkdownSanitizer
     public String compute(@Nonnull String sequence)
     {
         Checks.notNull(sequence, "Input");
+
+        setUrlMatcher(sequence);
+        String[][] urlSubBox = getURLSubBox(sequence);
+        sequence = replaceURLs(sequence, urlSubBox, true);
+
         StringBuilder builder = new StringBuilder();
         String end = handleQuote(sequence);
         if (end != null) return end;
@@ -590,7 +598,10 @@ public class MarkdownSanitizer
             applyStrategy(nextRegion, handleRegion(i + delta, endRegion, sequence, nextRegion), builder);
             i = endRegion + delta;
         }
-        return builder.toString();
+
+        sequence = replaceURLs(builder.toString(), urlSubBox, false);
+
+        return sequence;
     }
 
     private String handleQuote(@Nonnull String sequence)
@@ -629,5 +640,57 @@ public class MarkdownSanitizer
          * <br>{@code "**Hello** World!" -> "\**Hello\** World!"}
          */
         ESCAPE,
+    }
+
+    //URL Handling Methods
+
+    private String[][] getURLSubBox(@Nonnull String sequence){
+        int urlCount = countURLs();
+        String[][] urlSubBox = new String[2][urlCount];
+        urlReplacementIteration = 10000000;
+        urlMatcher.reset();
+        for(int i = 0; i <= urlCount - 1; i++){
+            //System.out.println(i);
+            urlSubBox[1][i] = generateURLReplacement(sequence);
+            urlMatcher.find();
+            urlSubBox[0][i] = urlMatcher.group();
+        }
+        return urlSubBox;
+    }
+
+    private String replaceURLs(@Nonnull String sequence, String[][] subBox, boolean start){
+        StringBuilder builder = new StringBuilder(sequence);
+        String url;
+        for(int i = 0; i <= subBox[1].length - 1; i++){
+            url = subBox[start ? 0 : 1][i];
+            builder.replace(builder.indexOf(url), builder.indexOf(url) + url.length(), subBox[start ? 1 : 0][i]);
+        }
+        return builder.toString();
+    }
+
+    private int countURLs(){ //Returns true if there is a URL in the sequence
+        try {
+            int i = 0;
+            while(urlMatcher.find()){
+                i++;
+            }
+            return i;
+        } catch (RuntimeException e) {
+            return 0;
+        }
+    }
+
+    private void setUrlMatcher(@Nonnull String sequence){
+        String urlPattern = "(http|https)://[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,3}(/\\S*)?";
+        urlMatcher = Pattern.compile(urlPattern).matcher(sequence);
+    }
+
+    private String generateURLReplacement(@Nonnull String sequence){
+        String urlReplacement = "URL-" + (urlReplacementIteration);
+        if(sequence.contains(urlReplacement)){
+            urlReplacementIteration++;
+            return generateURLReplacement(sequence);
+        }
+        else return urlReplacement;
     }
 }

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -270,6 +270,22 @@ class EscapeMarkdownTest
 {
     private MarkdownSanitizer markdown;
 
+    @Test
+    public void testUrl()
+    {
+        //Tests Markdown sanitizer's reaction to URLs symbols
+        Assertions.assertEquals("https://www.google.com/", markdown.compute("https://www.google.com/"));
+        Assertions.assertEquals("https://www.google.com/search?q=_test_", markdown.compute("https://www.google.com/search?q=_test_"));
+        Assertions.assertEquals("https://www.google.com/search?q=__test__", markdown.compute("https://www.google.com/search?q=__test__"));
+        Assertions.assertEquals("https://www.google.com/search?q=*test*", markdown.compute("https://www.google.com/search?q=*test*"));
+        Assertions.assertEquals("https://www.google.com/search?q=**test**", markdown.compute("https://www.google.com/search?q=**test**"));
+        Assertions.assertEquals("https://www.google.com/search?q=***test***", markdown.compute("https://www.google.com/search?q=***test***"));
+        Assertions.assertEquals("https://www.google.com/search?q=~test~", markdown.compute("https://www.google.com/search?q=~test~"));
+        Assertions.assertEquals("\\*\\*Hello\\*\\* \\_\\_Hello\\_\\_ https://www.google.com/search?q=__test__", markdown.compute("**Hello** __Hello__ https://www.google.com/search?q=__test__"));
+        Assertions.assertEquals("\\*\\*Hello\\*\\* https://github.com/__discord-jda__/JDA/**issues**/2378_ Quick brown fox https://www.google.com/search?q=__test__ \\*Test\\* \\_\\_Test\\_\\_ https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork", markdown.compute("**Hello** https://github.com/__discord-jda__/JDA/**issues**/2378_ Quick brown fox https://www.google.com/search?q=__test__ *Test* __Test__ https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork"));
+        Assertions.assertEquals("URL-10000000 \\*\\*Hello\\*\\* https://www.google.com/search?q=**test**", markdown.compute("URL-10000000 **Hello** https://www.google.com/search?q=**test**"));
+    }
+
     @BeforeEach
     public void setup()
     {


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2378

## Description

- Previously, MarkdownSanitizer sanitizes symbols used in URLs, despite Discord ignoring them and not treating them as markdowns.

- The algorithm implemented searches and replaces all URLs by a placeholder, and replaces them back after the majority of the MarkdownSanitizer#compute method finishes. 

- A dedicated method had also been added to the MarkdownTest class to efficiently test this algorithm.
