### PR TITLE
Add supplier based FileUpload

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/utils/IOUtil.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/IOUtil.java
@@ -17,6 +17,7 @@
 package net.dv8tion.jda.internal.utils;
 
 import com.neovisionaries.ws.client.WebSocketFactory;
+import net.dv8tion.jda.internal.utils.requestbody.BufferedRequestBody;
 import okhttp3.ConnectionPool;
 import okhttp3.Dispatcher;
 import okhttp3.MediaType;

--- a/src/main/java/net/dv8tion/jda/internal/utils/requestbody/BufferedRequestBody.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/requestbody/BufferedRequestBody.java
@@ -14,29 +14,27 @@
  * limitations under the License.
  */
 
-package net.dv8tion.jda.internal.utils;
+package net.dv8tion.jda.internal.utils.requestbody;
 
+import net.dv8tion.jda.internal.utils.IOUtil;
 import okhttp3.MediaType;
-import okhttp3.RequestBody;
 import okio.BufferedSink;
 import okio.BufferedSource;
 import okio.Okio;
 import okio.Source;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 
-public class BufferedRequestBody extends RequestBody
+public class BufferedRequestBody extends TypedBody<BufferedRequestBody>
 {
     private final Source source;
-    private final MediaType type;
     private byte[] data;
 
     public BufferedRequestBody(Source source, MediaType type)
     {
+        super(type);
         this.source = source;
-        this.type = type;
     }
 
     @Nonnull
@@ -50,13 +48,6 @@ public class BufferedRequestBody extends RequestBody
             copy.data = data;
             return copy;
         }
-    }
-
-    @Nullable
-    @Override
-    public MediaType contentType()
-    {
-        return type;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/utils/requestbody/DataSupplierBody.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/requestbody/DataSupplierBody.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.utils.requestbody;
+
+import okhttp3.MediaType;
+import okio.BufferedSink;
+import okio.Source;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.function.Supplier;
+
+public class DataSupplierBody extends TypedBody<DataSupplierBody>
+{
+    private final Supplier<? extends Source> streamSupply;
+
+    public DataSupplierBody(MediaType type, Supplier<? extends Source> streamSupply)
+    {
+        super(type);
+        this.streamSupply = streamSupply;
+    }
+
+    @Nonnull
+    @Override
+    public DataSupplierBody withType(@Nonnull MediaType newType)
+    {
+        if (this.type.equals(newType))
+            return this;
+        return new DataSupplierBody(newType, streamSupply);
+    }
+
+    @Override
+    public void writeTo(@Nonnull BufferedSink bufferedSink) throws IOException
+    {
+        synchronized (streamSupply)
+        {
+            try (Source stream = streamSupply.get())
+            {
+                bufferedSink.writeAll(stream);
+            }
+        }
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/utils/requestbody/TypedBody.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/requestbody/TypedBody.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.utils.requestbody;
+
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public abstract class TypedBody<T extends TypedBody<T>> extends RequestBody
+{
+    protected final MediaType type;
+
+    protected TypedBody(MediaType type)
+    {
+        this.type = type;
+    }
+
+    @Nonnull
+    public abstract T withType(@Nonnull MediaType newType);
+
+    @Nullable
+    @Override
+    public MediaType contentType()
+    {
+        return type;
+    }
+}


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This adds support for uploading files using source suppliers.

### Motivation

When JDA reads a resource to upload files in a request, it always has to keep a copy in memory in case the request fails. This is because we might have to upload the same data again if the request fails due to a rate-limit or I/O error.

### Idea

This new supplier-based `FileUpload` instead creates a new readable source for each time it needs to upload the data. With this approach, we can avoid copying the entire resource into memory, and instead stream it in segments.

This optimization is especially useful if you try to upload multiple attachments or large files.