### PR TITLE
fix symmetricity of CustomEmojiImpl/RichCustomEmojiImpl#equals

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/emoji/CustomEmojiImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/emoji/CustomEmojiImpl.java
@@ -90,7 +90,7 @@ public class CustomEmojiImpl implements CustomEmoji, EmojiUnion
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, id, animated);
+        return Long.hashCode(id);
     }
 
     @Override
@@ -101,7 +101,7 @@ public class CustomEmojiImpl implements CustomEmoji, EmojiUnion
         if (!(obj instanceof CustomEmoji))
             return false;
         CustomEmoji other = (CustomEmoji) obj;
-        return this.id == other.getIdLong() && getName().equals(other.getName());
+        return this.id == other.getIdLong();
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/emoji/CustomEmojiImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/emoji/CustomEmojiImpl.java
@@ -101,7 +101,7 @@ public class CustomEmojiImpl implements CustomEmoji, EmojiUnion
         if (!(obj instanceof CustomEmoji))
             return false;
         CustomEmoji other = (CustomEmoji) obj;
-        return other.getIdLong() == id;
+        return this.id == other.getIdLong() && getName().equals(other.getName());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/emoji/RichCustomEmojiImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/emoji/RichCustomEmojiImpl.java
@@ -237,11 +237,11 @@ public class RichCustomEmojiImpl implements RichCustomEmoji, EmojiUnion
     {
         if (obj == this)
             return true;
-        if (!(obj instanceof RichCustomEmojiImpl))
+        if (!(obj instanceof CustomEmoji))
             return false;
 
-        RichCustomEmojiImpl other = (RichCustomEmojiImpl) obj;
-        return this.id == other.id && getName().equals(other.getName());
+        CustomEmoji other = (CustomEmoji) obj;
+        return this.id == other.getIdLong() && getName().equals(other.getName());
     }
 
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/emoji/RichCustomEmojiImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/emoji/RichCustomEmojiImpl.java
@@ -241,7 +241,7 @@ public class RichCustomEmojiImpl implements RichCustomEmoji, EmojiUnion
             return false;
 
         CustomEmoji other = (CustomEmoji) obj;
-        return this.id == other.getIdLong() && getName().equals(other.getName());
+        return this.id == other.getIdLong();
     }
 
 


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The contract of [`Object#equals`](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/lang/Object.html#equals(java.lang.Object)) specifies:
> It is _symmetric_: for any non-null reference values `x` and `y`, `x.equals(y)` should return `true` if and only if `y.equals(x)` returns true.

This should hold when calling `equals` on an instance of `RichCustomEmojiImpl` and `CustomEmojiImpl`.

This is because `CustomEmojiImpl` [allows any `CustomEmoji`](https://github.com/discord-jda/JDA/blob/c0582c5f397517d42bf73f156c1bf89147771aa4/src/main/java/net/dv8tion/jda/internal/entities/emoji/CustomEmojiImpl.java#L103) and checks the id while `RichCustomEmojiImpl` [expects a `RichCustomEmojiImpl`](https://github.com/discord-jda/JDA/blob/c0582c5f397517d42bf73f156c1bf89147771aa4/src/main/java/net/dv8tion/jda/internal/entities/emoji/RichCustomEmojiImpl.java#L243C8-L243C8).

```java
CustomEmoji a = new RichCustomEmojiImpl(123, someGuild);//using internal classes for demonstration
CustomEmoji b = new CustomEmojiImpl("a",123,true);
assert a.equals(b) == b.equals(a);//false
```

This PR changes `RichCustomEmojiImpl` to allow any `CustomEmoji` instances and `CustomEmoji` in order to check the emoji name just like `RichCustomEmojiImpl`.
This allows JDA users to easily compare two `CustomEmoji` instances.