### PR TITLE
Add custom status support for bots

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Activity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Activity.java
@@ -15,7 +15,6 @@
  */
 package net.dv8tion.jda.api.entities;
 
-import net.dv8tion.jda.annotations.Incubating;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.entities.emoji.EmojiUnion;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
@@ -194,11 +193,8 @@ public interface Activity
      *         if the specified name is null, empty, blank or longer than 128 characters
      *
      * @return A valid Activity instance with the provided name with {@link net.dv8tion.jda.api.entities.Activity.ActivityType#WATCHING}
-     *
-     * @incubating This feature is not yet confirmed for the official bot API
      */
     @Nonnull
-    @Incubating
     static Activity watching(@Nonnull String name)
     {
         Checks.notBlank(name, "Name");
@@ -354,18 +350,12 @@ public interface Activity
         /**
          * Used to indicate that the {@link Activity Activity} should display
          * as {@code Watching...} in the official client.
-         *
-         * @incubating This feature is not yet confirmed for the official bot API
          */
-        @Incubating
         WATCHING(3),
         /**
          * Used to indicate that the {@link Activity Activity} should display as a custom status
          * in the official client.
-         *
-         * @incubating This Activity type is <b>read-only</b> for bots
          */
-        @Incubating
         CUSTOM_STATUS(4),
 
         /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Activity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Activity.java
@@ -230,6 +230,20 @@ public interface Activity
         return EntityBuilder.createActivity(name, null, ActivityType.COMPETING);
     }
 
+    /**
+     * Creates a new Activity instance with the specified name.
+     * <br>This will display without a prefix in the official client
+     *
+     * @param  name
+     *         The not-null name of the newly created status
+     *
+     * @throws IllegalArgumentException
+     *         If the specified name is null, empty, blank or longer than 128 characters
+     *
+     * @return A valid Activity instance with the provided name with {@link net.dv8tion.jda.api.entities.Activity.ActivityType#CUSTOM_STATUS}
+     *
+     * @since  5.0.0
+     */
     @Nonnull
     static Activity customStatus(@Nonnull String name)
     {

--- a/src/main/java/net/dv8tion/jda/api/entities/Activity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Activity.java
@@ -237,8 +237,6 @@ public interface Activity
      *         If the specified name is null, empty, blank or longer than 128 characters
      *
      * @return A valid Activity instance with the provided name with {@link net.dv8tion.jda.api.entities.Activity.ActivityType#CUSTOM_STATUS}
-     *
-     * @since  5.0.0
      */
     @Nonnull
     static Activity customStatus(@Nonnull String name)

--- a/src/main/java/net/dv8tion/jda/api/entities/Activity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Activity.java
@@ -230,6 +230,15 @@ public interface Activity
         return EntityBuilder.createActivity(name, null, ActivityType.COMPETING);
     }
 
+    @Nonnull
+    static Activity customStatus(@Nonnull String name)
+    {
+        Checks.notBlank(name, "Name");
+        name = name.trim();
+        Checks.notLonger(name, 128, "Name");
+        return EntityBuilder.createActivity(name, null, ActivityType.CUSTOM_STATUS);
+    }
+
     /**
      * Creates a new Activity instance with the specified name.
      *

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -931,7 +931,7 @@ public class EntityBuilder
 
         if (type == Activity.ActivityType.CUSTOM_STATUS)
         {
-            if (gameJson.hasKey("state") && name.equalsIgnoreCase("Custom Status"))
+            if (gameJson.hasKey("state"))
             {
                 name = gameJson.getString("state", "");
                 gameJson = gameJson.remove("state");

--- a/src/main/java/net/dv8tion/jda/internal/managers/PresenceImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/PresenceImpl.java
@@ -184,7 +184,15 @@ public class PresenceImpl implements Presence
         if (activity == null || activity.getName() == null || activity.getType() == null)
             return null;
         DataObject gameObj = DataObject.empty();
-        gameObj.put("name", activity.getName());
+
+        if (activity.getType() == Activity.ActivityType.CUSTOM_STATUS)
+        {
+            gameObj.put("name", "Custom Status");
+            gameObj.put("state", activity.getName());
+        } else {
+            gameObj.put("name", activity.getName());
+        }
+
         gameObj.put("type", activity.getType().getKey());
         if (activity.getUrl() != null)
             gameObj.put("url", activity.getUrl());

--- a/src/main/java/net/dv8tion/jda/internal/managers/PresenceImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/PresenceImpl.java
@@ -189,7 +189,9 @@ public class PresenceImpl implements Presence
         {
             gameObj.put("name", "Custom Status");
             gameObj.put("state", activity.getName());
-        } else {
+        }
+        else
+        {
             gameObj.put("name", activity.getName());
         }
 


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____

Closes Issue: NaN

## Description

Implements support for custom status in bots. This was rolled out about an hour ago on the API side and I have tested it with my own bot.
