### PR TITLE
Rename MessageReceivedEvent to MessageCreateEvent

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/channel/middleman/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/middleman/MessageChannel.java
@@ -99,7 +99,7 @@ public interface MessageChannel extends Channel, Formattable
      * The id for the most recent message sent
      * in this current MessageChannel.
      *
-     * <p>This value is updated on each {@link net.dv8tion.jda.api.events.message.MessageReceivedEvent MessageReceivedEvent}
+     * <p>This value is updated on each {@link net.dv8tion.jda.api.events.message.MessageCreateEvent MessageCreateEvent}
      * and <u><b>the value might point to an already deleted message since the ID is not cleared when the message is deleted,
      * so calling {@link #retrieveMessageById(long)} with this id can result in an {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE} error</b></u>
      *
@@ -115,7 +115,7 @@ public interface MessageChannel extends Channel, Formattable
      * The id for the most recent message sent
      * in this current MessageChannel.
      *
-     * <p>This value is updated on each {@link net.dv8tion.jda.api.events.message.MessageReceivedEvent MessageReceivedEvent}
+     * <p>This value is updated on each {@link net.dv8tion.jda.api.events.message.MessageCreateEvent MessageCreateEvent}
      * and <u><b>the value might point to an already deleted message since the value is not cleared when the message is deleted,
      * so calling {@link #retrieveMessageById(long)} with this id can result in an {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE} error</b></u>
      *

--- a/src/main/java/net/dv8tion/jda/api/events/message/MessageCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/MessageCreateEvent.java
@@ -15,7 +15,6 @@
  */
 package net.dv8tion.jda.api.events.message;
 
-import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
@@ -30,7 +29,7 @@ import javax.annotation.Nullable;
 /**
  * Indicates that a Message was received in a {@link net.dv8tion.jda.api.entities.channel.middleman.MessageChannel MessageChannel}.
  * <br>This includes {@link TextChannel TextChannel} and {@link PrivateChannel PrivateChannel}!
- * 
+ *
  * <p>Can be used to detect that a Message is received in either a guild- or private channel. Providing a MessageChannel and Message.
  *
  * <p><b>Requirements</b><br>
@@ -40,22 +39,15 @@ import javax.annotation.Nullable;
  *     <li>{@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_MESSAGES GUILD_MESSAGES} to work in guild text channels</li>
  *     <li>{@link net.dv8tion.jda.api.requests.GatewayIntent#DIRECT_MESSAGES DIRECT_MESSAGES} to work in private channels</li>
  * </ul>
- *
- * @deprecated This event has been renamed to match standard Discord event naming.
- *             Interaction with this event is "redirected" to {@link net.dv8tion.jda.api.events.message.MessageCreateEvent MessageCreateEvent}.
- *             In fact, it's now a container for MessageCreateEvent.
-
  */
-@Deprecated
-@ReplaceWith("MessageCreateEvent")
-public class MessageReceivedEvent extends GenericMessageEvent
+public class MessageCreateEvent extends GenericMessageEvent
 {
-    private final MessageCreateEvent event;
+    private final Message message;
 
-    public MessageReceivedEvent(@Nonnull JDA api, long responseNumber, @Nonnull Message message)
+    public MessageCreateEvent(@Nonnull JDA api, long responseNumber, @Nonnull Message message)
     {
         super(api, responseNumber, message.getIdLong(), message.getChannel());
-        this.event = new MessageCreateEvent(api, responseNumber, message);
+        this.message = message;
     }
 
     /**
@@ -66,7 +58,7 @@ public class MessageReceivedEvent extends GenericMessageEvent
     @Nonnull
     public Message getMessage()
     {
-        return event.getMessage();
+        return message;
     }
 
     /**
@@ -81,7 +73,7 @@ public class MessageReceivedEvent extends GenericMessageEvent
     @Nonnull
     public User getAuthor()
     {
-        return event.getAuthor();
+        return message.getAuthor();
     }
 
     /**
@@ -92,12 +84,12 @@ public class MessageReceivedEvent extends GenericMessageEvent
      *
      * @return The Author of the Message as null-able Member object.
      *
-     * @see    #isWebhookMessage()
+     * @see #isWebhookMessage()
      */
     @Nullable
     public Member getMember()
     {
-        return event.getMember();
+        return message.getMember();
     }
 
     /**
@@ -108,6 +100,6 @@ public class MessageReceivedEvent extends GenericMessageEvent
      */
     public boolean isWebhookMessage()
     {
-        return event.isWebhookMessage();
+        return message.isWebhookMessage();
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/events/message/package-info.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/package-info.java
@@ -17,7 +17,7 @@
 /**
  * Events that are fired for {@link net.dv8tion.jda.api.entities.Message Messages} in
  * a {@link net.dv8tion.jda.api.entities.channel.middleman.MessageChannel MessageChannel}.
- * Such as {@link net.dv8tion.jda.api.events.message.MessageReceivedEvent receiving}.
+ * Such as {@link net.dv8tion.jda.api.events.message.MessageCreateEvent receiving}.
  *
  * <p>These events combine all {@link net.dv8tion.jda.api.entities.channel.middleman.MessageChannel MessageChannel}
  * messages but specifications can be found in subpackages.

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -16,6 +16,7 @@
 package net.dv8tion.jda.api.hooks;
 
 import net.dv8tion.jda.annotations.ForRemoval;
+import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.events.*;
 import net.dv8tion.jda.api.events.automod.AutoModExecutionEvent;
 import net.dv8tion.jda.api.events.automod.AutoModRuleCreateEvent;
@@ -178,7 +179,10 @@ public abstract class ListenerAdapter implements EventListener
     public void onSelfUpdateVerified(@Nonnull SelfUpdateVerifiedEvent event) {}
 
     //Message Events
+    @Deprecated
+    @ReplaceWith("onMessageCreate(MessageCreateEvent event)")
     public void onMessageReceived(@Nonnull MessageReceivedEvent event) {}
+    public void onMessageCreate(@Nonnull MessageCreateEvent event) {}
     public void onMessageUpdate(@Nonnull MessageUpdateEvent event) {}
     public void onMessageDelete(@Nonnull MessageDeleteEvent event) {}
     public void onMessageBulkDelete(@Nonnull MessageBulkDeleteEvent event) {}

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageCreateHandler.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.entities.MessageType;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.events.message.MessageCreateEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
@@ -133,7 +134,9 @@ public class MessageCreateHandler extends SocketHandler
             api.usedPrivateChannel(channel.getIdLong());
         }
 
-        jda.handleEvent(new MessageReceivedEvent( jda, responseNumber, message));
+        jda.handleEvent(new MessageCreateEvent(jda, responseNumber, message));
+        // TODO: Remove MessageReceivedEvent handling (in the future), because it deprecated
+        jda.handleEvent(new MessageReceivedEvent(jda, responseNumber, message));
         return null;
     }
 }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Rename `MessageReceivedEvent` to `MessageCreateEvent`.

I just found this todo while reading the source code (I hope I'm not too late):
```java
//TODO-v5: Consider renaming this to MessageCreateEvent to match standard event naming (and to match Discord naming!)
```
This PR deprecate (without breaking the library interface) `MessageReceivedEvent`. Also, when accessing the `MessageReceivedEvent`, there will be a "redirected" to the new event, so that when making changes to logic, we don't need to edit same code in 2 places
