### PR TITLE
Allow override of headers applied by default

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
@@ -306,7 +306,7 @@ public class Requester
         if (apiRequest.getHeaders() != null)
         {
             for (Entry<String, String> header : apiRequest.getHeaders().entrySet())
-                builder.addHeader(header.getKey(), header.getValue());
+                builder.header(header.getKey(), header.getValue());
         }
     }
 


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Changed the ```applyHeaders``` method in the ```Requester``` class, so that custom headers with the same name in custom requests override the headers applied by default. This is useful if you want to override the "Authorization" header for example in a custom OAuth2 request, that needs another value for this header. The previous behaviour in this case caused there to be two "Authorization" headers in the request, which in turn lead to a HTTP 400 error being returned by the Discord API.