### PR TITLE
Fix createCopy not copying DefaultValues

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/EntitySelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/EntitySelectMenu.java
@@ -143,6 +143,7 @@ public interface EntitySelectMenu extends SelectMenu
         builder.setRequiredRange(getMinValues(), getMaxValues());
         builder.setPlaceholder(getPlaceholder());
         builder.setDisabled(isDisabled());
+        builder.setDefaultValues(getDefaultValues());
         return builder;
     }
 


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description
Fixed that `EntitySelectMenu#createCopy` didn't copy `DefaultValues`, 