### PR TITLE
Fix outdated links in .github

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Based on the current `master` changes!
         - Follow the guides provided at [JDA Structure Guide](https://jda.wiki/contributing/structure-guide/)
         - Compare your code style to the one used all over JDA and ensure you
           do not break the consistency (if you find issues in the JDA style you can include and update it)
-    - Do not remove existing functionality, use deprecation instead (for reference [deprecation policy](https://github.com/DV8FromTheWorld/JDA#deprecation-policy))
+    - Do not remove existing functionality, use deprecation instead (for reference [deprecation policy](https://github.com/discord-jda/JDA?tab=readme-ov-file#versioning-and-deprecation-policy))
 
 2. Making a Commit
     - While having multiple commits can help the reader understand your changes, it might sometimes be
@@ -23,8 +23,8 @@ Based on the current `master` changes!
 
 3. Updating your Fork
     - Before you start committing make sure your fork is updated.
-      (See [Syncing a Fork](https://help.github.com/articles/syncing-a-fork/)
-      or [Keeping a Fork Updated](https://robots.thoughtbot.com/keeping-a-github-fork-updated))
+      (See [Syncing a Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork)
+      or [Keeping a Fork Updated](https://thoughtbot.com/blog/keeping-a-github-fork-updated))
       
 4. Only open Pull Requests to master
     - Look at the [Repository Structure](https://jda.wiki/contributing/repository-structure/) for further details

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,10 +4,10 @@ body:
 - type: markdown
   attributes:
     value: |-
-      Please join the [Discord Server](https://discord.gg/0hMr4ce0tIl3SLv5) for questions or ask them in [our Discussions](https://github.com/DV8FromTheWorld/JDA/discussions).
+      Please join the [Discord Server](https://discord.gg/0hMr4ce0tIl3SLv5) for questions or ask them in [our Discussions](https://github.com/discord-jda/JDA/discussions).
       
       Keep in mind that this isn't the place to learn Java.  
-      Please head over to [StackOverflow](https://stackoverflow.com/questions/tagged/java) for your general programming questions.
+      Please head over to [Stack Overflow](https://stackoverflow.com/questions/tagged/java) for your general programming questions.
 - type: checkboxes
   attributes:
     label: General Troubleshooting

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,18 +3,21 @@ contact_links:
   - name: Discord
     url: https://discord.gg/0hMr4ce0tIk3pSjp
     about: The JDA Discord is the best place to receive fast support for your questions.
+  - name: Questions
+    url: https://github.com/discord-jda/JDA/discussions
+    about: You can ask questions about JDA and find useful information in our Discussions.
   - name: Javadoc
     url: https://docs.jda.wiki/
     about: The Javadoc is the perfect place to retrieve information about various methods within JDA.
-  - name: Jenkins
-    url: https://ci.dv8tion.net/job/JDA5/
-    about: You can find the latest Dev Builds on the Jenkins CI Server.
   - name: Wiki
     url: https://jda.wiki/
     about: You can find answers to common questions on our Wiki. Make sure to read the FAQ page!
   - name: Releases
     url: https://github.com/discord-jda/JDA/releases
     about: You can find the latest releases here on GitHub and on Bintray.
-  - name: Questions
-    url: https://github.com/discord-jda/JDA/discussions
-    about: You can ask questions about JDA and find useful information in our Discussions.
+  - name: Snapshots
+    url: https://jitpack.io/#discord-jda/JDA
+    about: You can find the latest dev builds on JitPack.
+  - name: Jenkins
+    url: https://ci.dv8tion.net/job/JDA5/
+    about: Dev builds also available on the Jenkins CI Server.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,17 +4,17 @@ contact_links:
     url: https://discord.gg/0hMr4ce0tIk3pSjp
     about: The JDA Discord is the best place to receive fast support for your questions.
   - name: Javadoc
-    url: https://ci.dv8tion.net/job/JDA/javadoc/
+    url: https://docs.jda.wiki/
     about: The Javadoc is the perfect place to retrieve information about various methods within JDA.
   - name: Jenkins
-    url: https://ci.dv8tion.net/job/JDA/
+    url: https://ci.dv8tion.net/job/JDA5/
     about: You can find the latest Dev Builds on the Jenkins CI Server.
   - name: Wiki
-    url: https://jda.wiki
+    url: https://jda.wiki/
     about: You can find answers to common questions on our Wiki. Make sure to read the FAQ page!
   - name: Releases
-    url: https://github.com/DV8FromTheWorld/JDA/releases
+    url: https://github.com/discord-jda/JDA/releases
     about: You can find the latest releases here on GitHub and on Bintray.
   - name: Questions
-    url: https://github.com/DV8FromTheWorld/JDA/discussions
+    url: https://github.com/discord-jda/JDA/discussions
     about: You can ask questions about JDA and find useful information in our Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,7 +4,7 @@ body:
 - type: markdown
   attributes:
     value: |-
-      Please join the [Discord Server](https://discord.gg/0hMr4ce0tIl3SLv5) for questions or ask them in [our Discussions](https://github.com/DV8FromTheWorld/JDA/discussions).
+      Please join the [Discord Server](https://discord.gg/0hMr4ce0tIl3SLv5) for questions or ask them in [our Discussions](https://github.com/discord-jda/JDA/discussions).
       
       Keep in mind that this isn't the place to learn Java.  
       Please head over to [StackOverflow](https://stackoverflow.com/questions/tagged/java) for your general programming questions.
@@ -15,7 +15,7 @@ body:
     options:
       - label: I have checked for similar issues on the Issue-tracker.
         required: true
-      - label: I have updated to the [latest JDA version](https://ci.dv8tion.net/job/JDA/lastSuccessfulBuild/)
+      - label: I have updated to the [latest JDA version](https://github.com/discord-jda/JDA/releases/latest)
         required: true
       - label: I have checked the branches or the maintainers' PRs for upcoming features.
         required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,7 @@ body:
       Please join the [Discord Server](https://discord.gg/0hMr4ce0tIl3SLv5) for questions or ask them in [our Discussions](https://github.com/discord-jda/JDA/discussions).
       
       Keep in mind that this isn't the place to learn Java.  
-      Please head over to [StackOverflow](https://stackoverflow.com/questions/tagged/java) for your general programming questions.
+      Please head over to [Stack Overflow](https://stackoverflow.com/questions/tagged/java) for your general programming questions.
 - type: checkboxes
   attributes:
     label: General Troubleshooting

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,5 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
 name: Pull Request Validation
 


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR corrects some links in `.github`:
* `https://github.com/DV8FromTheWorld/JDA` -> `https://github.com/discord-jda/JDA`
* `https://ci.dv8tion.net/job/JDA/` -> `https://ci.dv8tion.net/job/JDA5/`
* `https://help.github.com/*` -> `https://docs.github.com/*`
* Other

One of the main problems is outdated documentation (`https://ci.dv8tion.net/job/JDA/javadoc/`) in issue templates config and a redirects some `https://help.github.com/*` links to `https://support.github.com/` main page.