### PR TITLE
Fix webhook send & edit where the thread ID was set

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageCreateActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageCreateActionImpl.java
@@ -150,10 +150,6 @@ public class WebhookMessageCreateActionImpl<T>
             if (avatar != null)
                 json.put("avatar_url", avatar);
 
-            if (threadId != null)
-            {
-                json.put("thread_id", threadId);
-            }
             else if (threadMetadata != null)
             {
                 json.put("thread_name", threadMetadata.getName());
@@ -164,6 +160,16 @@ public class WebhookMessageCreateActionImpl<T>
 
             return getMultipartBody(files, json);
         }
+    }
+
+    @Override
+    protected Route.CompiledRoute finalizeRoute()
+    {
+        Route.CompiledRoute route = super.finalizeRoute();
+        if (threadId != null)
+           route = route.withQueryParams("");
+
+        return route;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageCreateActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageCreateActionImpl.java
@@ -167,7 +167,7 @@ public class WebhookMessageCreateActionImpl<T>
     {
         Route.CompiledRoute route = super.finalizeRoute();
         if (threadId != null)
-           route = route.withQueryParams("");
+           route = route.withQueryParams("thread_id", threadId);
 
         return route;
     }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageEditActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageEditActionImpl.java
@@ -54,10 +54,17 @@ public class WebhookMessageEditActionImpl<T>
         try (MessageEditData data = builder.build())
         {
             DataObject payload = data.toData();
-            if (threadId != null)
-                payload.put("thread_id", threadId);
             return getMultipartBody(data.getFiles(), payload);
         }
+    }
+
+    @Override
+    protected Route.CompiledRoute finalizeRoute()
+    {
+        Route.CompiledRoute route = super.finalizeRoute();
+        if (threadId != null)
+            route = route.withQueryParams("thread_id", threadId);
+        return route;
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Fixes: #2571

## Description

Webhooks set `thread_id` in the request body when it's actually a route query param.
