### PR TITLE
Fix else if for threadMetadata being on avatarUrl after #2572

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageCreateActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageCreateActionImpl.java
@@ -150,7 +150,7 @@ public class WebhookMessageCreateActionImpl<T>
             if (avatar != null)
                 json.put("avatar_url", avatar);
 
-            if (threadMetadata != null)
+            if (threadId == null && threadMetadata != null)
             {
                 json.put("thread_name", threadMetadata.getName());
                 List<ForumTagSnowflake> tags = threadMetadata.getAppliedTags();

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageCreateActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageCreateActionImpl.java
@@ -150,7 +150,7 @@ public class WebhookMessageCreateActionImpl<T>
             if (avatar != null)
                 json.put("avatar_url", avatar);
 
-            else if (threadMetadata != null)
+            if (threadMetadata != null)
             {
                 json.put("thread_name", threadMetadata.getName());
                 List<ForumTagSnowflake> tags = threadMetadata.getAppliedTags();


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

https://github.com/discord-jda/JDA/pull/2572 didn't remove the `else` from the `threadMetadata` if-block when it should've
