### PR TITLE
Add additional methods to get the target of an audit-log entry

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/audit/AuditLogEntry.java
+++ b/src/main/java/net/dv8tion/jda/api/audit/AuditLogEntry.java
@@ -19,12 +19,16 @@ package net.dv8tion.jda.api.audit;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.ISnowflake;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.ScheduledEvent;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.Webhook;
+import net.dv8tion.jda.api.entities.automod.AutoModRule;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.UserImpl;
-import net.dv8tion.jda.internal.entities.WebhookImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EntityString;
 
@@ -47,7 +51,7 @@ public class AuditLogEntry implements ISnowflake
     protected final long userId;
     protected final GuildImpl guild;
     protected final UserImpl user;
-    protected final WebhookImpl webhook;
+    protected final ISnowflake target;
     protected final String reason;
 
     protected final Map<String, AuditLogChange> changes;
@@ -55,7 +59,7 @@ public class AuditLogEntry implements ISnowflake
     protected final ActionType type;
     protected final int rawType;
 
-    public AuditLogEntry(ActionType type, int rawType, long id, long userId, long targetId, GuildImpl guild, UserImpl user, WebhookImpl webhook,
+    public AuditLogEntry(ActionType type, int rawType, long id, long userId, long targetId, GuildImpl guild, UserImpl user, ISnowflake target,
                          String reason, Map<String, AuditLogChange> changes, Map<String, Object> options)
     {
         this.type = type;
@@ -65,7 +69,7 @@ public class AuditLogEntry implements ISnowflake
         this.targetId = targetId;
         this.guild = guild;
         this.user = user;
-        this.webhook = webhook;
+        this.target = target;
         this.reason = reason;
         this.changes = changes != null && !changes.isEmpty()
                 ? Collections.unmodifiableMap(changes)
@@ -105,6 +109,61 @@ public class AuditLogEntry implements ISnowflake
     {
         return Long.toUnsignedString(targetId);
     }
+    
+    /**
+     * The {@link AutoModRule} that the target id of this audit-log entry refers to
+     *
+     * @return Possibly-null AutoModRule instance
+     */
+    @Nullable
+    public AutoModRule getAutoModRule()
+    {
+        return type.getTargetType() != TargetType.AUTO_MODERATION_RULE ? null : (AutoModRule) target;
+    }
+    
+    /**
+     * The {@link GuildChannel} that the target id of this audit-log entry refers to
+     *
+     * @return Possibly-null GuildChannel instance
+     */
+    @Nullable
+    public GuildChannel getGuildChannel()
+    {
+        return type.getTargetType() != TargetType.CHANNEL ? null : (GuildChannel) target;
+    }
+    
+    /**
+     * The {@link Member} that the target id of this audit-log entry refers to
+     *
+     * @return Possibly-null Member instance
+     */
+    @Nullable
+    public Member getMember()
+    {
+        return type.getTargetType() != TargetType.MEMBER ? null : (Member) target;
+    }
+    
+    /**
+     * The {@link ScheduledEvent} that the target id of this audit-log entry refers to
+     *
+     * @return Possibly-null ScheduledEvent instance
+     */
+    @Nullable
+    public ScheduledEvent getScheduledEvent()
+    {
+        return type.getTargetType() != TargetType.SCHEDULED_EVENT ? null : (ScheduledEvent) target;
+    }
+    
+    /**
+     * The {@link ThreadChannel} that the target id of this audit-log entry refers to
+     *
+     * @return Possibly-null ThreadChannel instance
+     */
+    @Nullable
+    public ThreadChannel getThread()
+    {
+        return type.getTargetType() != TargetType.THREAD ? null : (ThreadChannel) target;
+    }
 
     /**
      * The {@link net.dv8tion.jda.api.entities.Webhook Webhook} that the target id of this audit-log entry refers to
@@ -114,7 +173,7 @@ public class AuditLogEntry implements ISnowflake
     @Nullable
     public Webhook getWebhook()
     {
-        return webhook;
+        return type.getTargetType() != TargetType.WEBHOOK ? null : (Webhook) target;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -57,6 +57,7 @@ import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
+import net.dv8tion.jda.internal.entities.automod.AutoModRuleImpl;
 import net.dv8tion.jda.internal.entities.channel.concrete.*;
 import net.dv8tion.jda.internal.entities.channel.mixin.attribute.IPermissionContainerMixin;
 import net.dv8tion.jda.internal.entities.channel.mixin.attribute.IPostContainerMixin;
@@ -2513,7 +2514,8 @@ public class EntityBuilder
         return new ApplicationTeamImpl(iconId, members, id, ownerId);
     }
 
-    public AuditLogEntry createAuditLogEntry(GuildImpl guild, DataObject entryJson, DataObject userJson, DataObject webhookJson)
+    public AuditLogEntry createAuditLogEntry(GuildImpl guild, DataObject entryJson, TLongObjectMap<DataObject> userMap, TLongObjectMap<DataObject> webhookMap,
+            TLongObjectMap<DataObject> threadMap, TLongObjectMap<DataObject> scheduledEventMap, TLongObjectMap<DataObject> autoModerationRulesMap)
     {
         final long targetId = entryJson.getLong("target_id", 0);
         final long userId = entryJson.getLong("user_id", 0);
@@ -2523,10 +2525,39 @@ public class EntityBuilder
         final DataObject options = entryJson.isNull("options") ? null : entryJson.getObject("options");
         final String reason = entryJson.getString("reason", null);
 
+        final DataObject userJson = userMap == null ? null : userMap.get(userId);
         final UserImpl user = userJson == null ? null : createUser(userJson);
-        final WebhookImpl webhook = webhookJson == null ? null : createWebhook(webhookJson);
         final Set<AuditLogChange> changesList;
         final ActionType type = ActionType.from(typeKey);
+
+        ISnowflake target;
+        DataObject targetJson;
+        switch (type.getTargetType()) {
+        case AUTO_MODERATION_RULE:
+            targetJson = autoModerationRulesMap == null ? null : autoModerationRulesMap.get(targetId);
+            target = targetJson == null ? null : AutoModRuleImpl.fromData(guild, targetJson);
+            break;
+        case CHANNEL:
+            target = guild.getGuildChannelById(targetId);
+            break;
+        case MEMBER:
+            target = guild.getMemberById(targetId);
+            break;
+        case SCHEDULED_EVENT:
+            targetJson = scheduledEventMap == null ? null : scheduledEventMap.get(targetId);
+            target = targetJson == null ? null : createScheduledEvent(guild, targetJson);
+            break;
+        case THREAD:
+            targetJson = threadMap == null ? null : threadMap.get(targetId);
+            target = targetJson == null ? null : createThreadChannel(guild, targetJson, guild.getIdLong());
+            break;
+        case WEBHOOK:
+            targetJson = webhookMap == null ? null : webhookMap.get(targetId);
+            target = targetJson == null ? null : createWebhook(targetJson);
+            break;
+        default:
+            target = null;
+        }
 
         if (changes != null)
         {
@@ -2547,7 +2578,7 @@ public class EntityBuilder
         CaseInsensitiveMap<String, Object> optionMap = options != null
                 ? new CaseInsensitiveMap<>(options.toMap()) : null;
 
-        return new AuditLogEntry(type, typeKey, id, userId, targetId, guild, user, webhook, reason, changeMap, optionMap);
+        return new AuditLogEntry(type, typeKey, id, userId, targetId, guild, user, target, reason, changeMap, optionMap);
     }
 
     public AuditLogChange createAuditLogChange(DataObject change)

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildAuditLogEntryCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildAuditLogEntryCreateHandler.java
@@ -44,7 +44,7 @@ public class GuildAuditLogEntryCreateHandler extends SocketHandler
             return null;
         }
 
-        AuditLogEntry entry = api.getEntityBuilder().createAuditLogEntry(guild, content, null, null);
+        AuditLogEntry entry = api.getEntityBuilder().createAuditLogEntry(guild, content, null, null, null, null, null);
 
         api.handleEvent(
             new GuildAuditLogEntryCreateEvent(


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds multiple methods to get the target of an `AuditLogEntry`. This includes methods for auto-mod rules, channels, members, scheduled events and threads.
The `integrations` field returned by Discord's `audit-logs` endpoint (https://discord.com/developers/docs/resources/audit-log) is currently being ignored because I don't think JDA has any API for integrations (please correct me if I'm wrong).