### PR TITLE
Fix orphaned rate-limit buckets

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/SequentialRestRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/SequentialRestRateLimiter.java
@@ -231,8 +231,8 @@ public final class SequentialRestRateLimiter implements RestRateLimiter
             return;
         // Schedule a new bucket worker if no worker is running
         MiscUtil.locked(lock, () ->
-                rateLimitQueue.computeIfAbsent(bucket,
-                        (k) -> config.getPool().schedule(bucket, bucket.getRateLimit(), TimeUnit.MILLISECONDS)));
+            rateLimitQueue.computeIfAbsent(bucket,
+                k -> config.getPool().schedule(bucket, bucket.getRateLimit(), TimeUnit.MILLISECONDS)));
     }
 
     private long parseLong(String input)
@@ -252,9 +252,9 @@ public final class SequentialRestRateLimiter implements RestRateLimiter
         return System.currentTimeMillis();
     }
 
-    private void updateBucket(Route.CompiledRoute route, Response response)
+    private Bucket updateBucket(Route.CompiledRoute route, Response response)
     {
-        MiscUtil.locked(lock, () ->
+        return MiscUtil.locked(lock, () ->
         {
             try
             {
@@ -302,7 +302,7 @@ public final class SequentialRestRateLimiter implements RestRateLimiter
                         boolean firstHit = hitRatelimit.add(baseRoute) && retryAfter < 60000;
                         // Update the bucket to the new information
                         bucket.remaining = 0;
-                        bucket.reset = getNow() + retryAfter;
+                        bucket.reset = now + retryAfter;
                         // don't log warning if we hit the rate limit for the first time, likely due to initialization of the bucket
                         // unless its a long retry-after delay (more than a minute)
                         if (firstHit)
@@ -310,6 +310,8 @@ public final class SequentialRestRateLimiter implements RestRateLimiter
                         else
                             log.warn("Encountered 429 on route {} with bucket {} Retry-After: {} ms Scope: {}", baseRoute, bucket.bucketId, retryAfter, scope);
                     }
+
+                    log.trace("Updated bucket {} to retry after {}", bucket.bucketId, bucket.reset - now);
                     return bucket;
                 }
 
@@ -367,7 +369,8 @@ public final class SequentialRestRateLimiter implements RestRateLimiter
 
         public void retry(Work request)
         {
-            requests.addFirst(request);
+            if (!moveRequest(request))
+                requests.addFirst(request);
         }
 
         public long getReset()
@@ -423,7 +426,7 @@ public final class SequentialRestRateLimiter implements RestRateLimiter
             return requests;
         }
 
-        protected Boolean moveRequest(Work request)
+        protected boolean moveRequest(Work request)
         {
             return MiscUtil.locked(lock, () ->
             {
@@ -433,9 +436,8 @@ public final class SequentialRestRateLimiter implements RestRateLimiter
                 {
                     bucket.enqueue(request);
                     runBucket(bucket);
-                    return true;
                 }
-                return false;
+                return bucket != this;
             });
         }
 
@@ -477,15 +479,8 @@ public final class SequentialRestRateLimiter implements RestRateLimiter
                 }
 
                 Work request = requests.removeFirst();
-                if (request.isSkipped())
+                if (request.isSkipped() || moveRequest(request))
                     continue;
-
-                // Check if a bucket has been discovered and initialized for this route
-                if (isUninit())
-                {
-                    boolean shouldSkip = moveRequest(request);
-                    if (shouldSkip) continue;
-                }
 
                 if (execute(request)) break;
             }

--- a/src/main/java/net/dv8tion/jda/api/requests/SequentialRestRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/SequentialRestRateLimiter.java
@@ -179,7 +179,7 @@ public final class SequentialRestRateLimiter implements RestRateLimiter
                 bucket.requests.removeIf(Work::isSkipped); // Remove cancelled requests
 
                 // Check if the bucket is empty
-                if (bucket.requests.isEmpty())
+                if (bucket.requests.isEmpty() && !rateLimitQueue.containsKey(bucket))
                 {
                     // remove uninit if requests are empty
                     if (bucket.isUninit())
@@ -479,7 +479,10 @@ public final class SequentialRestRateLimiter implements RestRateLimiter
                 }
 
                 Work request = requests.removeFirst();
-                if (request.isSkipped() || moveRequest(request))
+                if (request.isSkipped())
+                    continue;
+
+                if (isUninit() && moveRequest(request))
                     continue;
 
                 if (execute(request)) break;


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

It seems that sometimes buckets are no longer reachable and still handling a request. This ensures that requests are always moved into a reachable bucket after encountering a rate-limit.
