### PR TITLE
Document event data passthrough issues in extended events

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/GenericEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/GenericEvent.java
@@ -53,8 +53,7 @@ public interface GenericEvent
      * <h3>Event extensions</h3>
      * Classes extending JDA events may not keep their passthrough data,
      * as the data is retrieved from a {@link ThreadLocal},
-     * the passthrough data will only be found in instances constructed in the same thread as where the event was originally created,
-     * or in newly created child threads.
+     * the passthrough data will only be found in instances constructed in the same thread as where the event was originally created.
      * <br>This means that existing threads (such as in thread pools) will <b>not</b> contain the passthrough data.
      *
      * <p>To fix this issue, you may override this method, and get the passthrough data from the original event.

--- a/src/main/java/net/dv8tion/jda/api/events/GenericEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/GenericEvent.java
@@ -52,7 +52,7 @@ public interface GenericEvent
      *
      * <h3>Event extensions</h3>
      * Classes extending JDA events may not keep their passthrough data,
-     * as the data is retrieved from an {@link InheritableThreadLocal},
+     * as the data is retrieved from a {@link ThreadLocal},
      * the passthrough data will only be found in instances constructed in the same thread as where the event was originally created,
      * or in newly created child threads.
      * <br>This means that existing threads (such as in thread pools) will <b>not</b> contain the passthrough data.

--- a/src/main/java/net/dv8tion/jda/api/events/GenericEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/GenericEvent.java
@@ -50,6 +50,15 @@ public interface GenericEvent
      * <br>This provides the full gateway message payload, including sequence, event name and dispatch type.
      * For details, read the official <a href="https://discord.dev/topics/gateway" target="_blank">Discord Documentation</a>.
      *
+     * <h3>Event extensions</h3>
+     * Classes extending JDA events may not keep their passthrough data,
+     * as the data is retrieved from an {@link InheritableThreadLocal},
+     * the passthrough data will only be found in instances constructed in the same thread as where the event was originally created,
+     * or in newly created child threads.
+     * <br>This means that existing threads (such as in thread pools) will <b>not</b> contain the passthrough data.
+     *
+     * <p>To fix this issue, you may override this method, and get the passthrough data from the original event.
+     *
      * @throws IllegalStateException
      *         If event passthrough was not enabled, see {@link net.dv8tion.jda.api.JDABuilder#setEventPassthrough(boolean) JDABuilder#setEventPassthrough(boolean)}
      *

--- a/src/main/java/net/dv8tion/jda/internal/handle/SocketHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/SocketHandler.java
@@ -20,7 +20,7 @@ import net.dv8tion.jda.internal.JDAImpl;
 
 public abstract class SocketHandler
 {
-    public static final ThreadLocal<DataObject> CURRENT_EVENT = new ThreadLocal<>();
+    public static final InheritableThreadLocal<DataObject> CURRENT_EVENT = new InheritableThreadLocal<>();
 
     protected final JDAImpl api;
     protected long responseNumber;

--- a/src/main/java/net/dv8tion/jda/internal/handle/SocketHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/SocketHandler.java
@@ -20,7 +20,7 @@ import net.dv8tion.jda.internal.JDAImpl;
 
 public abstract class SocketHandler
 {
-    public static final InheritableThreadLocal<DataObject> CURRENT_EVENT = new InheritableThreadLocal<>();
+    public static final ThreadLocal<DataObject> CURRENT_EVENT = new ThreadLocal<>();
 
     protected final JDAImpl api;
     protected long responseNumber;


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR document issues with event data passthrough when reconstructing the event from other threads