### PR TITLE
Fix incorrect index used in attachment update requests

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/messages/MessageEditData.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/messages/MessageEditData.java
@@ -328,9 +328,16 @@ public class MessageEditData implements MessageData, AutoCloseable, Serializable
         if (isSet(ATTACHMENTS))
         {
             DataArray attachments = DataArray.empty();
+
+            int fileUploadCount = 0;
+            for (AttachedFile file : files)
+            {
+                attachments.add(file.toAttachmentData(fileUploadCount));
+                if (file instanceof FileUpload)
+                    fileUploadCount++;
+            }
+
             json.put("attachments", attachments);
-            for (int i = 0; i < files.size(); i++)
-                attachments.add(files.get(i).toAttachmentData(i));
         }
 
         return json;


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This was using the wrong indexing, which resulted in update failures.
