### PR TITLE
Add check for max number of fields in EmbedBuilder

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -155,7 +155,15 @@ public class EmbedBuilder
      * that has been checked as being valid for sending.
      *
      * @throws java.lang.IllegalStateException
-     *         If the embed is empty. Can be checked with {@link #isEmpty()}.
+     *         <ul>
+     *             <li>If the embed is empty. Can be checked with {@link #isEmpty()}.</li>
+     *             <li>If the character limit for {@code description}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#DESCRIPTION_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#DESCRIPTION_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the embed's total length, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#EMBED_MAX_LENGTH_BOT} as {@value net.dv8tion.jda.api.entities.MessageEmbed#EMBED_MAX_LENGTH_BOT},
+     *             is exceeded.</li>
+     *             <li>If the embed's number of embed fields, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#MAX_FIELD_AMOUNT} as {@value net.dv8tion.jda.api.entities.MessageEmbed#MAX_FIELD_AMOUNT},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return the built, sendable {@link net.dv8tion.jda.api.entities.MessageEmbed}
      */
@@ -167,7 +175,9 @@ public class EmbedBuilder
         if (description.length() > MessageEmbed.DESCRIPTION_MAX_LENGTH)
             throw new IllegalStateException(Helpers.format("Description is longer than %d! Please limit your input!", MessageEmbed.DESCRIPTION_MAX_LENGTH));
         if (length() > MessageEmbed.EMBED_MAX_LENGTH_BOT)
-            throw new IllegalStateException("Cannot build an embed with more than " + MessageEmbed.EMBED_MAX_LENGTH_BOT + " characters!");
+            throw new IllegalStateException(String.format("Cannot build an embed with more than %d characters!", MessageEmbed.EMBED_MAX_LENGTH_BOT));
+        if (fields.size() > MessageEmbed.MAX_FIELD_AMOUNT)
+            throw new IllegalStateException(String.format("Cannot build an embed with more than %d embed fields set!", MessageEmbed.MAX_FIELD_AMOUNT));
         final String description = this.description.length() < 1 ? null : this.description.toString();
 
         return EntityBuilder.createMessageEmbed(url, title, description, EmbedType.RICH, timestamp,

--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -175,9 +175,9 @@ public class EmbedBuilder
         if (description.length() > MessageEmbed.DESCRIPTION_MAX_LENGTH)
             throw new IllegalStateException(Helpers.format("Description is longer than %d! Please limit your input!", MessageEmbed.DESCRIPTION_MAX_LENGTH));
         if (length() > MessageEmbed.EMBED_MAX_LENGTH_BOT)
-            throw new IllegalStateException(String.format("Cannot build an embed with more than %d characters!", MessageEmbed.EMBED_MAX_LENGTH_BOT));
+            throw new IllegalStateException(Helpers.format("Cannot build an embed with more than %d characters!", MessageEmbed.EMBED_MAX_LENGTH_BOT));
         if (fields.size() > MessageEmbed.MAX_FIELD_AMOUNT)
-            throw new IllegalStateException(String.format("Cannot build an embed with more than %d embed fields set!", MessageEmbed.MAX_FIELD_AMOUNT));
+            throw new IllegalStateException(Helpers.format("Cannot build an embed with more than %d embed fields set!", MessageEmbed.MAX_FIELD_AMOUNT));
         final String description = this.description.length() < 1 ? null : this.description.toString();
 
         return EntityBuilder.createMessageEmbed(url, title, description, EmbedType.RICH, timestamp,

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -115,6 +115,13 @@ public class MessageEmbed implements SerializableData
     @ForRemoval
     public static final int EMBED_MAX_LENGTH_CLIENT = 2000;
 
+    /**
+     * The maximum amount of total embed fields the embed can hold
+     * 
+     * @see net.dv8tion.jda.api.EmbedBuilder#addField(String, String, boolean) 
+     */
+    public static final int MAX_FIELD_AMOUNT = 25;
+
     protected final Object mutex = new Object();
 
     protected final String url;


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Discord changed their API in regards to embed fields. It will now return errors when you send JSON with more than 25 fields defined.
This PR adds two things:

1. It adds a new `MAX_FIELD_AMOUNT` constant set to 25
2. It adds a check in `EmbedBuilder#build()` for if the number is above the max allowed, at which point it throws an `IllegalStateException`
