### PR TITLE
Return immutable lists when documented

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -904,7 +904,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * <p>This will only check cached members!
      * <br>See {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
      *
-     * @return Possibly-immutable list of members who boost this guild
+     * @return Immutable list of members who boost this guild
      */
     @Nonnull
     List<Member> getBoosters();

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -60,6 +60,7 @@ import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.ReceivedMessage;
 import net.dv8tion.jda.internal.requests.FunctionalCallback;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.IOUtil;
 import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
@@ -698,7 +699,7 @@ public interface Message extends ISnowflake, Formattable
                 .stream()
                 .filter(ActionRow.class::isInstance)
                 .map(ActionRow.class::cast)
-                .collect(Collectors.toList());
+                .collect(Helpers.toUnmodifiableList());
     }
 
     /**
@@ -714,7 +715,7 @@ public interface Message extends ISnowflake, Formattable
         return getComponents().stream()
                 .map(LayoutComponent::getButtons)
                 .flatMap(List::stream)
-                .collect(Collectors.toList());
+                .collect(Helpers.toUnmodifiableList());
     }
 
     /**
@@ -765,7 +766,7 @@ public interface Message extends ISnowflake, Formattable
             filter = b -> label.equals(b.getLabel());
         return getButtons().stream()
                 .filter(filter)
-                .collect(Collectors.toList());
+                .collect(Helpers.toUnmodifiableList());
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/StageInstance.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/StageInstance.java
@@ -21,12 +21,11 @@ import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.entities.channel.concrete.StageChannel;
 import net.dv8tion.jda.api.managers.StageInstanceManager;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * A Stage Instance holds information about a live stage.
@@ -77,15 +76,15 @@ public interface StageInstance extends ISnowflake
      * <p>Only {@link StageChannel#isModerator(Member) stage moderators} can promote or invite speakers.
      * A stage moderator can move between speaker and audience at any time.
      *
-     * @return {@link List} of {@link Member Members} which can speak in this stage instance
+     * @return Immutable {@link List} of {@link Member Members} which can speak in this stage instance
      */
     @Nonnull
     default List<Member> getSpeakers()
     {
-        return Collections.unmodifiableList(getChannel().getMembers()
+        return getChannel().getMembers()
                 .stream()
                 .filter(member -> !member.getVoiceState().isSuppressed()) // voice states should not be null since getMembers() checks only for connected members in the channel
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
     }
 
     /**
@@ -98,15 +97,15 @@ public interface StageInstance extends ISnowflake
      * <p>Only {@link StageChannel#isModerator(Member) stage moderators} can promote or invite speakers.
      * A stage moderator can move between speaker and audience at any time.
      *
-     * @return {@link List} of {@link Member Members} which cannot speak in this stage instance
+     * @return Immutable {@link List} of {@link Member Members} which cannot speak in this stage instance
      */
     @Nonnull
     default List<Member> getAudience()
     {
-        return Collections.unmodifiableList(getChannel().getMembers()
+        return getChannel().getMembers()
                 .stream()
                 .filter(member -> member.getVoiceState().isSuppressed()) // voice states should not be null since getMembers() checks only for connected members in the channel
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IPermissionContainer.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IPermissionContainer.java
@@ -21,13 +21,12 @@ import net.dv8tion.jda.api.entities.PermissionOverride;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.managers.channel.attribute.IPermissionContainerManager;
 import net.dv8tion.jda.api.requests.restaction.PermissionOverrideAction;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Represents a {@link GuildChannel} that uses {@link net.dv8tion.jda.api.entities.PermissionOverride Permission Overrides}.
@@ -89,9 +88,9 @@ public interface IPermissionContainer extends GuildChannel
     @Nonnull
     default List<PermissionOverride> getMemberPermissionOverrides()
     {
-        return Collections.unmodifiableList(getPermissionOverrides().stream()
+        return getPermissionOverrides().stream()
                 .filter(PermissionOverride::isMemberOverride)
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
     }
 
     /**
@@ -105,9 +104,9 @@ public interface IPermissionContainer extends GuildChannel
     @Nonnull
     default List<PermissionOverride> getRolePermissionOverrides()
     {
-        return Collections.unmodifiableList(getPermissionOverrides().stream()
+        return getPermissionOverrides().stream()
                 .filter(PermissionOverride::isRoleOverride)
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IThreadContainer.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IThreadContainer.java
@@ -26,12 +26,11 @@ import net.dv8tion.jda.api.requests.restaction.ThreadChannelAction;
 import net.dv8tion.jda.api.requests.restaction.pagination.ThreadChannelPaginationAction;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Abstraction of all channel types, which can contain or manage {@link ThreadChannel ThreadChannels}.
@@ -59,11 +58,10 @@ public interface IThreadContainer extends GuildChannel, IPermissionContainer
     @Nonnull
     default List<ThreadChannel> getThreadChannels()
     {
-        return Collections.unmodifiableList(
-            getGuild().getThreadChannelCache().applyStream(stream ->
-                stream.filter(thread -> thread.getParentChannel() == this)
-                      .collect(Collectors.toList())
-            ));
+        return getGuild().getThreadChannelCache().applyStream(stream ->
+            stream.filter(thread -> thread.getParentChannel() == this)
+                  .collect(Helpers.toUnmodifiableList())
+        );
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/Category.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/Category.java
@@ -32,9 +32,7 @@ import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Represents a channel category in the official Discord API.
@@ -80,11 +78,11 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
     @Nonnull
     default List<TextChannel> getTextChannels()
     {
-        return Collections.unmodifiableList(getGuild().getTextChannelCache().applyStream(stream ->
+        return getGuild().getTextChannelCache().applyStream(stream ->
             stream.filter(channel -> equals(channel.getParentCategory()))
                   .sorted()
-                  .collect(Collectors.toList())
-        ));
+                  .collect(Helpers.toUnmodifiableList())
+        );
     }
 
     /**
@@ -96,11 +94,11 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
     @Nonnull
     default List<NewsChannel> getNewsChannels()
     {
-        return Collections.unmodifiableList(getGuild().getNewsChannelCache().applyStream(stream ->
+        return getGuild().getNewsChannelCache().applyStream(stream ->
             stream.filter(channel -> equals(channel.getParentCategory()))
                   .sorted()
-                  .collect(Collectors.toList())
-        ));
+                  .collect(Helpers.toUnmodifiableList())
+        );
     }
 
     /**
@@ -111,11 +109,11 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
     @Nonnull
     default List<ForumChannel> getForumChannels()
     {
-        return Collections.unmodifiableList(getGuild().getForumChannelCache().applyStream(stream ->
+        return getGuild().getForumChannelCache().applyStream(stream ->
             stream.filter(channel -> equals(channel.getParentCategory()))
                   .sorted()
-                  .collect(Collectors.toList())
-        ));
+                  .collect(Helpers.toUnmodifiableList())
+        );
     }
 
     /**
@@ -126,11 +124,11 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
     @Nonnull
     default List<MediaChannel> getMediaChannels()
     {
-        return Collections.unmodifiableList(getGuild().getMediaChannelCache().applyStream(stream ->
+        return getGuild().getMediaChannelCache().applyStream(stream ->
                 stream.filter(channel -> equals(channel.getParentCategory()))
                         .sorted()
-                        .collect(Collectors.toList())
-        ));
+                        .collect(Helpers.toUnmodifiableList())
+        );
     }
 
     /**
@@ -142,11 +140,11 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
     @Nonnull
     default List<VoiceChannel> getVoiceChannels()
     {
-        return Collections.unmodifiableList(getGuild().getVoiceChannelCache().applyStream(stream ->
+        return getGuild().getVoiceChannelCache().applyStream(stream ->
             stream.filter(channel -> equals(channel.getParentCategory()))
                   .sorted()
-                  .collect(Collectors.toList())
-        ));
+                  .collect(Helpers.toUnmodifiableList())
+        );
     }
 
     /**
@@ -158,11 +156,11 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
     @Nonnull
     default List<StageChannel> getStageChannels()
     {
-        return Collections.unmodifiableList(getGuild().getStageChannelCache().applyStream(stream ->
+        return getGuild().getStageChannelCache().applyStream(stream ->
             stream.filter(channel -> equals(channel.getParentCategory()))
                   .sorted()
-                  .collect(Collectors.toList())
-        ));
+                  .collect(Helpers.toUnmodifiableList())
+        );
     }
 
     /**
@@ -447,13 +445,13 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
     @Override
     default List<Member> getMembers()
     {
-        return Collections.unmodifiableList(getChannels().stream()
+        return getChannels().stream()
             .filter(IMemberContainer.class::isInstance)
             .map(IMemberContainer.class::cast)
             .map(IMemberContainer::getMembers)
             .flatMap(List::stream)
             .distinct()
-            .collect(Collectors.toList()));
+            .collect(Helpers.toUnmodifiableList());
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/LayoutComponent.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/LayoutComponent.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.utils.data.SerializableData;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -74,7 +75,7 @@ public interface LayoutComponent extends SerializableData, Iterable<ItemComponen
         return getComponents().stream()
                 .filter(ActionComponent.class::isInstance)
                 .map(ActionComponent.class::cast)
-                .collect(Collectors.toList());
+                .collect(Helpers.toUnmodifiableList());
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/LayoutComponent.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/LayoutComponent.java
@@ -86,11 +86,10 @@ public interface LayoutComponent extends SerializableData, Iterable<ItemComponen
     @Nonnull
     default List<Button> getButtons()
     {
-        return Collections.unmodifiableList(
-            getComponents().stream()
+        return getComponents().stream()
                 .filter(Button.class::isInstance)
                 .map(Button.class::cast)
-                    .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/StringSelectInteraction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/StringSelectInteraction.java
@@ -17,10 +17,10 @@
 package net.dv8tion.jda.api.interactions.components.selections;
 
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Component Interaction for a {@link StringSelectMenu}.
@@ -42,7 +42,7 @@ public interface StringSelectInteraction extends SelectMenuInteraction<String, S
      * This resolves the selected {@link #getValues() values} to the representative {@link SelectOption SelectOption} instances.
      * <br>It is recommended to check {@link #getValues()} directly instead of using the options.
      *
-     * @return {@link List} of the selected options
+     * @return Immutable {@link List} of the selected options
      */
     @Nonnull
     default List<SelectOption> getSelectedOptions()
@@ -52,6 +52,6 @@ public interface StringSelectInteraction extends SelectMenuInteraction<String, S
         return menu.getOptions()
                 .stream()
                 .filter(it -> values.contains(it.getValue()))
-                .collect(Collectors.toList());
+                .collect(Helpers.toUnmodifiableList());
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -39,6 +39,7 @@ import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.cache.UnifiedChannelCacheView;
 
 import javax.annotation.CheckReturnValue;
@@ -428,11 +429,10 @@ public interface ShardManager extends IGuildChannelContainer
     default List<Guild> getMutualGuilds(@Nonnull final Collection<User> users)
     {
         Checks.noneNull(users, "users");
-        return Collections.unmodifiableList(
-                this.getGuildCache().stream()
+        return this.getGuildCache().stream()
                 .filter(guild -> users.stream()
                         .allMatch(guild::isMember))
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/utils/messages/MessageEditData.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/messages/MessageEditData.java
@@ -25,11 +25,11 @@ import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.api.utils.data.SerializableData;
+import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.IOUtil;
 
 import javax.annotation.Nonnull;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static net.dv8tion.jda.api.utils.messages.MessageEditBuilder.*;
 
@@ -351,12 +351,10 @@ public class MessageEditData implements MessageData, AutoCloseable, Serializable
     @Nonnull
     public synchronized List<FileUpload> getFiles()
     {
-        return Collections.unmodifiableList(
-            files.stream()
-                 .filter(FileUpload.class::isInstance)
-                 .map(FileUpload.class::cast)
-                 .collect(Collectors.toList())
-        );
+        return files.stream()
+                .filter(FileUpload.class::isInstance)
+                .map(FileUpload.class::cast)
+                .collect(Helpers.toUnmodifiableList());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -615,9 +615,9 @@ public class JDAImpl implements JDA
         Checks.notNull(users, "users");
         for(User u : users)
             Checks.notNull(u, "All users");
-        return Collections.unmodifiableList(getGuilds().stream()
+        return getGuilds().stream()
                 .filter(guild -> users.stream().allMatch(guild::isMember))
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -92,7 +92,6 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -537,7 +536,7 @@ public class GuildImpl implements Guild
         return memberCache.applyStream((members) ->
             members.filter(m -> m.getTimeBoosted() != null)
                    .sorted(Comparator.comparing(Member::getTimeBoosted))
-                   .collect(Collectors.toList()));
+                   .collect(Helpers.toUnmodifiableList()));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1147,11 +1147,10 @@ public class GuildImpl implements Guild
     @Override
     public List<GuildVoiceState> getVoiceStates()
     {
-        return Collections.unmodifiableList(
-                getMembersView().stream()
-                    .map(Member::getVoiceState)
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList()));
+        return getMembersView().stream()
+                .map(Member::getVoiceState)
+                .filter(Objects::nonNull)
+                .collect(Helpers.toUnmodifiableList());
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/ForumChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/ForumChannelImpl.java
@@ -40,14 +40,13 @@ import net.dv8tion.jda.internal.entities.channel.mixin.middleman.StandardGuildCh
 import net.dv8tion.jda.internal.entities.emoji.CustomEmojiImpl;
 import net.dv8tion.jda.internal.managers.channel.concrete.ForumChannelManagerImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.cache.SortedSnowflakeCacheViewImpl;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ForumChannelImpl extends AbstractGuildChannelImpl<ForumChannelImpl>
         implements ForumChannel,
@@ -89,10 +88,10 @@ public class ForumChannelImpl extends AbstractGuildChannelImpl<ForumChannelImpl>
     @Override
     public List<Member> getMembers()
     {
-        return Collections.unmodifiableList(getGuild().getMembers()
+        return getGuild().getMembers()
                 .stream()
                 .filter(m -> m.hasPermission(this, Permission.VIEW_CHANNEL))
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/MediaChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/MediaChannelImpl.java
@@ -40,14 +40,13 @@ import net.dv8tion.jda.internal.entities.channel.mixin.middleman.StandardGuildCh
 import net.dv8tion.jda.internal.entities.emoji.CustomEmojiImpl;
 import net.dv8tion.jda.internal.managers.channel.concrete.MediaChannelManagerImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.cache.SortedSnowflakeCacheViewImpl;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class MediaChannelImpl extends AbstractGuildChannelImpl<MediaChannelImpl>
     implements MediaChannel,
@@ -88,10 +87,10 @@ public class MediaChannelImpl extends AbstractGuildChannelImpl<MediaChannelImpl>
     @Override
     public List<Member> getMembers()
     {
-        return Collections.unmodifiableList(getGuild().getMembers()
+        return getGuild().getMembers()
                 .stream()
                 .filter(m -> m.hasPermission(this, Permission.VIEW_CHANNEL))
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/NewsChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/NewsChannelImpl.java
@@ -35,11 +35,10 @@ import net.dv8tion.jda.internal.entities.channel.middleman.AbstractStandardGuild
 import net.dv8tion.jda.internal.managers.channel.concrete.NewsChannelManagerImpl;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class NewsChannelImpl extends AbstractStandardGuildMessageChannelImpl<NewsChannelImpl>
         implements NewsChannel,
@@ -61,9 +60,9 @@ public class NewsChannelImpl extends AbstractStandardGuildMessageChannelImpl<New
     @Override
     public List<Member> getMembers()
     {
-        return Collections.unmodifiableList(getGuild().getMembersView().stream()
+        return getGuild().getMembersView().stream()
             .filter(m -> m.hasPermission(this, Permission.VIEW_CHANNEL))
-            .collect(Collectors.toList()));
+            .collect(Helpers.toUnmodifiableList());
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/TextChannelImpl.java
@@ -31,11 +31,10 @@ import net.dv8tion.jda.internal.entities.channel.middleman.AbstractStandardGuild
 import net.dv8tion.jda.internal.entities.channel.mixin.attribute.ISlowmodeChannelMixin;
 import net.dv8tion.jda.internal.managers.channel.concrete.TextChannelManagerImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class TextChannelImpl extends AbstractStandardGuildMessageChannelImpl<TextChannelImpl> implements
         TextChannel,
@@ -60,9 +59,9 @@ public class TextChannelImpl extends AbstractStandardGuildMessageChannelImpl<Tex
     @Override
     public List<Member> getMembers()
     {
-        return Collections.unmodifiableList(getGuild().getMembersView().stream()
+        return getGuild().getMembersView().stream()
             .filter(m -> m.hasPermission(this, Permission.VIEW_CHANNEL))
-            .collect(Collectors.toList()));
+            .collect(Helpers.toUnmodifiableList());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/ChannelCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/ChannelCacheViewImpl.java
@@ -193,7 +193,7 @@ public class ChannelCacheViewImpl<T extends Channel> extends ReadWriteLockCache<
         return applyStream(stream ->
             stream
                 .filter((channel) -> Helpers.equals(channel.getName(), name, ignoreCase))
-                .collect(Collectors.toList())
+                .collect(Helpers.toUnmodifiableList())
         );
     }
 
@@ -340,7 +340,7 @@ public class ChannelCacheViewImpl<T extends Channel> extends ReadWriteLockCache<
             return applyStream(stream ->
                 stream
                     .filter(channel -> Helpers.equals(channel.getName(), name, ignoreCase))
-                    .collect(Collectors.toList())
+                    .collect(Helpers.toUnmodifiableList())
             );
         }
 

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/ShardCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/ShardCacheViewImpl.java
@@ -27,6 +27,7 @@ import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.cache.ShardCacheView;
 import net.dv8tion.jda.internal.utils.ChainedClosableIterator;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.UnlockHook;
 import org.apache.commons.collections4.iterators.ObjectArrayIterator;
 
@@ -35,7 +36,6 @@ import java.util.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -314,9 +314,9 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
         @Override
         public List<JDA> getElementsByName(@Nonnull String name, boolean ignoreCase)
         {
-            return Collections.unmodifiableList(distinctStream()
+            return distinctStream()
                 .flatMap(view -> view.getElementsByName(name, ignoreCase).stream())
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
         }
 
         @Override

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
@@ -25,13 +25,13 @@ import net.dv8tion.jda.api.utils.cache.MemberCacheView;
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
 import net.dv8tion.jda.api.utils.cache.UnifiedMemberCacheView;
 import net.dv8tion.jda.internal.utils.ChainedClosableIterator;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheView<T>
@@ -100,10 +100,10 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
     @Override
     public List<T> getElementsByName(@Nonnull String name, boolean ignoreCase)
     {
-        return Collections.unmodifiableList(distinctStream()
+        return distinctStream()
                 .flatMap(view -> view.getElementsByName(name, ignoreCase).stream())
                 .distinct()
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
     }
 
     @Nonnull
@@ -163,46 +163,46 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
         @Override
         public List<Member> getElementsById(long id)
         {
-            return Collections.unmodifiableList(distinctStream()
+            return distinctStream()
                 .map(view -> view.getElementById(id))
                 .filter(Objects::nonNull)
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
         }
 
         @Nonnull
         @Override
         public List<Member> getElementsByUsername(@Nonnull String name, boolean ignoreCase)
         {
-            return Collections.unmodifiableList(distinctStream()
+            return distinctStream()
                 .flatMap(view -> view.getElementsByUsername(name, ignoreCase).stream())
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
         }
 
         @Nonnull
         @Override
         public List<Member> getElementsByNickname(@Nullable String name, boolean ignoreCase)
         {
-            return Collections.unmodifiableList(distinctStream()
+            return distinctStream()
                 .flatMap(view -> view.getElementsByNickname(name, ignoreCase).stream())
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
         }
 
         @Nonnull
         @Override
         public List<Member> getElementsWithRoles(@Nonnull Role... roles)
         {
-            return Collections.unmodifiableList(distinctStream()
+            return distinctStream()
                 .flatMap(view -> view.getElementsWithRoles(roles).stream())
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
         }
 
         @Nonnull
         @Override
         public List<Member> getElementsWithRoles(@Nonnull Collection<Role> roles)
         {
-            return Collections.unmodifiableList(distinctStream()
+            return distinctStream()
                 .flatMap(view -> view.getElementsWithRoles(roles).stream())
-                .collect(Collectors.toList()));
+                .collect(Helpers.toUnmodifiableList());
         }
     }
 }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Prevents users from mutating returned lists, as they may think it does something

* Return unmodifiable lists where documented
* Replace `Collections.unmodifiableList` with the `Helpers.toUnmodifiableCollection` collector
* Return unmodifiable lists in `StringSelectInteraction#getSelectedOptions` ([previously undocumented](https://github.com/discord-jda/JDA/commit/67f2e6287e3b349814ee5db7856fcd86c8211266#diff-0d53ea747f80e12f1598e5f987916b1ce28054cf7a3ca5eefaf12d8427b0babeL45-R55)) and `Guild#getBoosters`