### PR TITLE
Add missing generic type to shardmanager

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -60,7 +60,7 @@ import java.util.stream.Collectors;
  * @since  3.4
  * @author Aljoscha Grebe
  */
-public interface ShardManager extends IGuildChannelContainer
+public interface ShardManager extends IGuildChannelContainer<Channel>
 {
     /**
      * Adds all provided listeners to the event-listeners that will be used to handle events.
@@ -969,7 +969,7 @@ public interface ShardManager extends IGuildChannelContainer
 
     /**
      * Restarts all shards, shutting old ones down first.
-     * 
+     *
      * <p>As all shards need to connect to discord again this will take equally long as the startup of a new ShardManager
      * (using the 5000ms + backoff as delay between starting new JDA instances).
      *


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

the `JDA` interface has the generic type set for the dependency on `IGuildChannelContainer`, the ShardManager interface however, does not have this causing the following compile error when using `ShardManager#getChannelById`

![](https://i.entered.space/LiRPM5TqjZ.png)
