### PR TITLE
Add support for enforce_nonce

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageCreateAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageCreateAction.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.sticker.GuildSticker;
 import net.dv8tion.jda.api.entities.sticker.Sticker;
 import net.dv8tion.jda.api.entities.sticker.StickerSnowflake;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.requests.FluentRestAction;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import net.dv8tion.jda.api.utils.messages.MessageCreateRequest;
@@ -54,14 +55,14 @@ public interface MessageCreateAction extends MessageCreateRequest<MessageCreateA
     }
 
     /**
-     * Unique string/number used to identify messages using {@link Message#getNonce()} in events.
-     * <br>This can be useful to handle round-trip messages.
+     * Unique string/number used to identify messages using {@link Message#getNonce()} in {@link MessageReceivedEvent}.
      *
-     * <p>Discord also uses the nonce to dedupe messages for users, but this is not currently supported for bots.
-     * However, for future proofing, it is highly recommended to use a unique nonce for each message.
+     * <p>The nonce can be used for deduping messages and marking them for use with {@link MessageReceivedEvent}.
+     * JDA will automatically generate a unique nonce per message, it is not necessary to do this manually.
      *
      * @param  nonce
-     *         The nonce string to use
+     *         The nonce string to use, must be unique per message.
+     *         A unique nonce will be generated automatically if this is null.
      *
      * @throws IllegalArgumentException
      *         If the provided nonce is longer than {@value Message#MAX_NONCE_LENGTH} characters

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageCreateActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageCreateActionImpl.java
@@ -35,6 +35,7 @@ import okhttp3.RequestBody;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -43,6 +44,7 @@ import java.util.stream.Collectors;
 
 public class MessageCreateActionImpl extends RestActionImpl<Message> implements MessageCreateAction, MessageCreateBuilderMixin<MessageCreateAction>
 {
+    protected static final SecureRandom nonceGenerator = new SecureRandom();
     protected static boolean defaultFailOnInvalidReply = false;
 
     private final MessageChannel channel;
@@ -83,8 +85,11 @@ public class MessageCreateActionImpl extends RestActionImpl<Message> implements 
         try (MessageCreateData data = builder.build())
         {
             DataObject json = data.toData();
-            if (nonce != null)
+            json.put("enforce_nonce", true);
+            if (nonce != null && !nonce.isEmpty())
                 json.put("nonce", nonce);
+            else
+                json.put("nonce", Long.toUnsignedString(nonceGenerator.nextLong()));
             if (stickers != null && !stickers.isEmpty())
                 json.put("sticker_ids", stickers);
             if (messageReferenceId != null)


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds support for the new `enforce_nonce` field on the message create endpoint. This enables automatic deduping of messages sent to channels. JDA will now automatically set a unique random nonce on every message, unless a user defined nonce is specified instead.

Reference: https://github.com/discord/discord-api-docs/pull/6647