### PR TITLE
Add missing proxy url field to the MessageEmbed.VideoInfo class

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.api.entities;
 import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.utils.AttachmentProxy;
+import net.dv8tion.jda.api.utils.FileProxy;
 import net.dv8tion.jda.api.utils.ImageProxy;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
@@ -691,17 +692,17 @@ public class MessageEmbed implements SerializableData
         }
 
         /**
-         * Returns an {@link AttachmentProxy} for this embed video.
+         * Returns a {@link FileProxy} for this embed video.
          *
-         * @return Possibly-null {@link AttachmentProxy} of this embed video
+         * @return Possibly-null {@link FileProxy} of this embed video
          *
          * @see    #getProxyUrl()
          */
         @Nullable
-        public AttachmentProxy getProxy()
+        public FileProxy getProxy()
         {
             final String proxyUrl = getProxyUrl();
-            return proxyUrl == null ? null : new AttachmentProxy(proxyUrl);
+            return proxyUrl == null ? null : new FileProxy(proxyUrl);
         }
 
         /**

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -655,12 +655,14 @@ public class MessageEmbed implements SerializableData
     public static class VideoInfo
     {
         protected final String url;
+        protected final String proxyUrl;
         protected final int width;
         protected final int height;
 
-        public VideoInfo(String url, int width, int height)
+        public VideoInfo(String url, String proxyUrl, int width, int height)
         {
             this.url = url;
+            this.proxyUrl = proxyUrl;
             this.width = width;
             this.height = height;
         }
@@ -674,6 +676,32 @@ public class MessageEmbed implements SerializableData
         public String getUrl()
         {
             return url;
+        }
+
+        /**
+         * The url of the video, proxied by Discord
+         * <br>This url is used to access the video through Discord instead of directly to prevent ip scraping.
+         *
+         * @return Possibly-null String containing the proxied video url.
+         */
+        @Nullable
+        public String getProxyUrl()
+        {
+            return proxyUrl;
+        }
+
+        /**
+         * Returns an {@link AttachmentProxy} for this embed video.
+         *
+         * @return Possibly-null {@link AttachmentProxy} of this embed video
+         *
+         * @see    #getProxyUrl()
+         */
+        @Nullable
+        public AttachmentProxy getProxy()
+        {
+            final String proxyUrl = getProxyUrl();
+            return proxyUrl == null ? null : new AttachmentProxy(proxyUrl);
         }
 
         /**

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1991,6 +1991,7 @@ public class EntityBuilder
         {
             DataObject obj = content.getObject("video");
             video = new VideoInfo(obj.getString("url", null),
+                                  obj.getString("proxy_url", null),
                                   obj.getInt("width", -1),
                                   obj.getInt("height", -1));
         }


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

Adds a field to the `MessageEmbed.VideoInfo` class containing the proxied video url.