### PR TITLE
Unit Test Cases: cleanup, static imports for Assertions

### DIFF
--- a/src/test/java/CommandDataTest.java
+++ b/src/test/java/CommandDataTest.java
@@ -25,11 +25,12 @@ import net.dv8tion.jda.api.interactions.commands.build.SubcommandGroupData;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.interactions.CommandDataImpl;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CommandDataTest
 {
@@ -44,27 +45,27 @@ public class CommandDataTest
                 .addOption(OptionType.INTEGER, "days", "The duration of the ban", false); // test with explicit false
 
         DataObject data = command.toData();
-        Assertions.assertEquals("ban", data.getString("name"));
-        Assertions.assertEquals("Ban a user from this server", data.getString("description"));
-        Assertions.assertFalse(data.getBoolean("dm_permission"));
-        Assertions.assertEquals(Permission.BAN_MEMBERS.getRawValue(), data.getUnsignedLong("default_member_permissions"));
+        assertEquals("ban", data.getString("name"));
+        assertEquals("Ban a user from this server", data.getString("description"));
+        assertFalse(data.getBoolean("dm_permission"));
+        assertEquals(Permission.BAN_MEMBERS.getRawValue(), data.getUnsignedLong("default_member_permissions"));
 
         DataArray options = data.getArray("options");
 
         DataObject option = options.getObject(0);
-        Assertions.assertTrue(option.getBoolean("required"));
-        Assertions.assertEquals("user", option.getString("name"));
-        Assertions.assertEquals("The user to ban", option.getString("description"));
+        assertTrue(option.getBoolean("required"));
+        assertEquals("user", option.getString("name"));
+        assertEquals("The user to ban", option.getString("description"));
 
         option = options.getObject(1);
-        Assertions.assertFalse(option.getBoolean("required"));
-        Assertions.assertEquals("reason", option.getString("name"));
-        Assertions.assertEquals("The ban reason", option.getString("description"));
+        assertFalse(option.getBoolean("required"));
+        assertEquals("reason", option.getString("name"));
+        assertEquals("The ban reason", option.getString("description"));
 
         option = options.getObject(2);
-        Assertions.assertFalse(option.getBoolean("required"));
-        Assertions.assertEquals("days", option.getString("name"));
-        Assertions.assertEquals("The duration of the ban", option.getString("description"));
+        assertFalse(option.getBoolean("required"));
+        assertEquals("days", option.getString("name"));
+        assertEquals("The duration of the ban", option.getString("description"));
     }
 
     @Test
@@ -74,11 +75,11 @@ public class CommandDataTest
                 .setDefaultPermissions(DefaultMemberPermissions.DISABLED);
         DataObject data = command.toData();
 
-        Assertions.assertEquals(0, data.getUnsignedLong("default_member_permissions"));
+        assertEquals(0, data.getUnsignedLong("default_member_permissions"));
 
         command.setDefaultPermissions(DefaultMemberPermissions.ENABLED);
         data = command.toData();
-        Assertions.assertTrue(data.isNull("default_member_permissions"));
+        assertTrue(data.isNull("default_member_permissions"));
     }
 
     @Test
@@ -91,29 +92,29 @@ public class CommandDataTest
                     .addOption(OptionType.INTEGER, "days", "The duration of the ban", false)); // test with explicit false
 
         DataObject data = command.toData();
-        Assertions.assertEquals("mod", data.getString("name"));
-        Assertions.assertEquals("Moderation commands", data.getString("description"));
+        assertEquals("mod", data.getString("name"));
+        assertEquals("Moderation commands", data.getString("description"));
 
         DataObject subdata = data.getArray("options").getObject(0);
-        Assertions.assertEquals("ban", subdata.getString("name"));
-        Assertions.assertEquals("Ban a user from this server", subdata.getString("description"));
+        assertEquals("ban", subdata.getString("name"));
+        assertEquals("Ban a user from this server", subdata.getString("description"));
 
         DataArray options = subdata.getArray("options");
 
         DataObject option = options.getObject(0);
-        Assertions.assertTrue(option.getBoolean("required"));
-        Assertions.assertEquals("user", option.getString("name"));
-        Assertions.assertEquals("The user to ban", option.getString("description"));
+        assertTrue(option.getBoolean("required"));
+        assertEquals("user", option.getString("name"));
+        assertEquals("The user to ban", option.getString("description"));
 
         option = options.getObject(1);
-        Assertions.assertFalse(option.getBoolean("required"));
-        Assertions.assertEquals("reason", option.getString("name"));
-        Assertions.assertEquals("The ban reason", option.getString("description"));
+        assertFalse(option.getBoolean("required"));
+        assertEquals("reason", option.getString("name"));
+        assertEquals("The ban reason", option.getString("description"));
 
         option = options.getObject(2);
-        Assertions.assertFalse(option.getBoolean("required"));
-        Assertions.assertEquals("days", option.getString("name"));
-        Assertions.assertEquals("The duration of the ban", option.getString("description"));
+        assertFalse(option.getBoolean("required"));
+        assertEquals("days", option.getString("name"));
+        assertEquals("The duration of the ban", option.getString("description"));
     }
 
     @Test
@@ -127,32 +128,32 @@ public class CommandDataTest
                         .addOption(OptionType.INTEGER, "days", "The duration of the ban", false))); // test with explicit false
 
         DataObject data = command.toData();
-        Assertions.assertEquals("mod", data.getString("name"));
-        Assertions.assertEquals("Moderation commands", data.getString("description"));
+        assertEquals("mod", data.getString("name"));
+        assertEquals("Moderation commands", data.getString("description"));
 
         DataObject group = data.getArray("options").getObject(0);
-        Assertions.assertEquals("ban", group.getString("name"));
-        Assertions.assertEquals("Ban or unban a user from this server", group.getString("description"));
+        assertEquals("ban", group.getString("name"));
+        assertEquals("Ban or unban a user from this server", group.getString("description"));
 
         DataObject subdata = group.getArray("options").getObject(0);
-        Assertions.assertEquals("add", subdata.getString("name"));
-        Assertions.assertEquals("Ban a user from this server", subdata.getString("description"));
+        assertEquals("add", subdata.getString("name"));
+        assertEquals("Ban a user from this server", subdata.getString("description"));
         DataArray options = subdata.getArray("options");
 
         DataObject option = options.getObject(0);
-        Assertions.assertTrue(option.getBoolean("required"));
-        Assertions.assertEquals("user", option.getString("name"));
-        Assertions.assertEquals("The user to ban", option.getString("description"));
+        assertTrue(option.getBoolean("required"));
+        assertEquals("user", option.getString("name"));
+        assertEquals("The user to ban", option.getString("description"));
 
         option = options.getObject(1);
-        Assertions.assertFalse(option.getBoolean("required"));
-        Assertions.assertEquals("reason", option.getString("name"));
-        Assertions.assertEquals("The ban reason", option.getString("description"));
+        assertFalse(option.getBoolean("required"));
+        assertEquals("reason", option.getString("name"));
+        assertEquals("The ban reason", option.getString("description"));
 
         option = options.getObject(2);
-        Assertions.assertFalse(option.getBoolean("required"));
-        Assertions.assertEquals("days", option.getString("name"));
-        Assertions.assertEquals("The duration of the ban", option.getString("description"));
+        assertFalse(option.getBoolean("required"));
+        assertEquals("days", option.getString("name"));
+        assertEquals("The duration of the ban", option.getString("description"));
     }
 
     @Test
@@ -161,36 +162,36 @@ public class CommandDataTest
         CommandDataImpl command = new CommandDataImpl("ban", "Simple ban command");
         command.addOption(OptionType.STRING, "opt", "desc");
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> command.addOption(OptionType.STRING, "other", "desc", true));
+        assertThrows(IllegalArgumentException.class, () -> command.addOption(OptionType.STRING, "other", "desc", true));
 
         SubcommandData subcommand = new SubcommandData("sub", "Simple subcommand");
         subcommand.addOption(OptionType.STRING, "opt", "desc");
-        Assertions.assertThrows(IllegalArgumentException.class, () -> subcommand.addOption(OptionType.STRING, "other", "desc", true));
+        assertThrows(IllegalArgumentException.class, () -> subcommand.addOption(OptionType.STRING, "other", "desc", true));
     }
 
     @Test
     public void testNameChecks()
     {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new CommandDataImpl("invalid name", "Valid description"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new CommandDataImpl("invalidName", "Valid description"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new CommandDataImpl("valid_name", ""));
+        assertThrows(IllegalArgumentException.class, () -> new CommandDataImpl("invalid name", "Valid description"));
+        assertThrows(IllegalArgumentException.class, () -> new CommandDataImpl("invalidName", "Valid description"));
+        assertThrows(IllegalArgumentException.class, () -> new CommandDataImpl("valid_name", ""));
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new SubcommandData("invalid name", "Valid description"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new SubcommandData("invalidName", "Valid description"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new SubcommandData("valid_name", ""));
+        assertThrows(IllegalArgumentException.class, () -> new SubcommandData("invalid name", "Valid description"));
+        assertThrows(IllegalArgumentException.class, () -> new SubcommandData("invalidName", "Valid description"));
+        assertThrows(IllegalArgumentException.class, () -> new SubcommandData("valid_name", ""));
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new SubcommandGroupData("invalid name", "Valid description"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new SubcommandGroupData("invalidName", "Valid description"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new SubcommandGroupData("valid_name", ""));
+        assertThrows(IllegalArgumentException.class, () -> new SubcommandGroupData("invalid name", "Valid description"));
+        assertThrows(IllegalArgumentException.class, () -> new SubcommandGroupData("invalidName", "Valid description"));
+        assertThrows(IllegalArgumentException.class, () -> new SubcommandGroupData("valid_name", ""));
     }
 
     @Test
     public void testChoices()
     {
         OptionData option = new OptionData(OptionType.INTEGER, "choice", "Option with choices!");
-        Assertions.assertThrows(IllegalArgumentException.class, () -> option.addChoice("invalid name", "Valid description"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> option.addChoice("invalidName", "Valid description"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> option.addChoice("valid_name", ""));
+        assertThrows(IllegalArgumentException.class, () -> option.addChoice("invalid name", "Valid description"));
+        assertThrows(IllegalArgumentException.class, () -> option.addChoice("invalidName", "Valid description"));
+        assertThrows(IllegalArgumentException.class, () -> option.addChoice("valid_name", ""));
 
         List<Command.Choice> choices = new ArrayList<>();
         for (int i = 0; i < 25; i++)
@@ -198,8 +199,8 @@ public class CommandDataTest
             option.addChoice("choice_" + i, i);
             choices.add(new Command.Choice("choice_" + i, i));
         }
-        Assertions.assertThrows(IllegalArgumentException.class, () -> option.addChoice("name", 100));
-        Assertions.assertEquals(25, option.getChoices().size());
-        Assertions.assertEquals(choices, option.getChoices());
+        assertThrows(IllegalArgumentException.class, () -> option.addChoice("name", 100));
+        assertEquals(25, option.getChoices().size());
+        assertEquals(choices, option.getChoices());
     }
 }

--- a/src/test/java/DataPathTest.java
+++ b/src/test/java/DataPathTest.java
@@ -18,8 +18,9 @@ import net.dv8tion.jda.api.exceptions.ParsingException;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.api.utils.data.DataPath;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DataPathTest
 {
@@ -29,10 +30,10 @@ public class DataPathTest
         DataObject object = DataObject.empty()
                 .put("foo", "10"); // string to also test parsing
 
-        Assertions.assertEquals(10, DataPath.getInt(object, "foo"));
+        assertEquals(10, DataPath.getInt(object, "foo"));
 
         DataArray array = DataArray.empty().add("20");
-        Assertions.assertEquals(20, DataPath.getInt(array, "[0]"));
+        assertEquals(20, DataPath.getInt(array, "[0]"));
     }
 
     @Test
@@ -40,13 +41,13 @@ public class DataPathTest
     {
         DataObject object = DataObject.empty();
 
-        Assertions.assertEquals(0L, DataPath.getLong(object, "foo?", 0));
-        Assertions.assertThrows(ParsingException.class, () -> DataPath.getLong(object, "foo"));
+        assertEquals(0L, DataPath.getLong(object, "foo?", 0));
+        assertThrows(ParsingException.class, () -> DataPath.getLong(object, "foo"));
 
         DataArray array = DataArray.empty();
 
-        Assertions.assertTrue(DataPath.getBoolean(array, "[0]?", true));
-        Assertions.assertThrows(ParsingException.class, () -> DataPath.getObject(array, "[0]"));
+        assertTrue(DataPath.getBoolean(array, "[0]?", true));
+        assertThrows(ParsingException.class, () -> DataPath.getObject(array, "[0]"));
     }
 
     @Test
@@ -55,9 +56,9 @@ public class DataPathTest
         DataObject object = DataObject.empty().put("foo", 10.0);
         DataArray array = DataArray.empty().add(object);
 
-        Assertions.assertEquals(10.0, DataPath.getDouble(array, "[0].foo"));
-        Assertions.assertEquals(20.0, DataPath.getDouble(array, "[1]?.foo", 20.0));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> DataPath.getDouble(array, "[1].foo"));
+        assertEquals(10.0, DataPath.getDouble(array, "[0].foo"));
+        assertEquals(20.0, DataPath.getDouble(array, "[1]?.foo", 20.0));
+        assertThrows(IndexOutOfBoundsException.class, () -> DataPath.getDouble(array, "[1].foo"));
     }
 
     @Test
@@ -66,9 +67,9 @@ public class DataPathTest
         DataArray array = DataArray.empty().add("hello");
         DataObject object = DataObject.empty().put("foo", array);
 
-        Assertions.assertEquals("hello", DataPath.getString(object, "foo[0]"));
-        Assertions.assertEquals("world", DataPath.getString(object, "foo[1]?", "world"));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> DataPath.getString(object, "foo[1]"));
+        assertEquals("hello", DataPath.getString(object, "foo[0]"));
+        assertEquals("world", DataPath.getString(object, "foo[1]?", "world"));
+        assertThrows(IndexOutOfBoundsException.class, () -> DataPath.getString(object, "foo[1]"));
     }
 
     @Test
@@ -76,13 +77,13 @@ public class DataPathTest
     {
         DataArray array = DataArray.empty().add(DataArray.empty().add("10"));
 
-        Assertions.assertEquals(10, DataPath.getUnsignedInt(array, "[0][0]"));
-        Assertions.assertEquals(20, DataPath.getUnsignedInt(array, "[0][1]?", 20));
-        Assertions.assertEquals(20, DataPath.getUnsignedInt(array, "[1]?[0]", 20));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> DataPath.getUnsignedInt(array, "[0][1]"));
-        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> DataPath.getUnsignedInt(array, "[1][0]"));
-        Assertions.assertThrows(ParsingException.class, () -> DataPath.getUnsignedInt(array, "[0][1]?"));
-        Assertions.assertThrows(ParsingException.class, () -> DataPath.getUnsignedInt(array, "[1]?[0]"));
+        assertEquals(10, DataPath.getUnsignedInt(array, "[0][0]"));
+        assertEquals(20, DataPath.getUnsignedInt(array, "[0][1]?", 20));
+        assertEquals(20, DataPath.getUnsignedInt(array, "[1]?[0]", 20));
+        assertThrows(IndexOutOfBoundsException.class, () -> DataPath.getUnsignedInt(array, "[0][1]"));
+        assertThrows(IndexOutOfBoundsException.class, () -> DataPath.getUnsignedInt(array, "[1][0]"));
+        assertThrows(ParsingException.class, () -> DataPath.getUnsignedInt(array, "[0][1]?"));
+        assertThrows(ParsingException.class, () -> DataPath.getUnsignedInt(array, "[1]?[0]"));
     }
 
     @Test
@@ -94,8 +95,8 @@ public class DataPathTest
                         .put("foo", DataObject.empty()
                             .put("bar", "hello"))));
 
-        Assertions.assertEquals("hello", DataPath.getString(object, "array[0].foo.bar"));
-        Assertions.assertEquals("world", DataPath.getString(object, "array[0].wrong?.bar", "world"));
-        Assertions.assertThrows(ParsingException.class, () -> DataPath.getString(object, "array[0].wrong?.bar"));
+        assertEquals("hello", DataPath.getString(object, "array[0].foo.bar"));
+        assertEquals("world", DataPath.getString(object, "array[0].wrong?.bar", "world"));
+        assertThrows(ParsingException.class, () -> DataPath.getString(object, "array[0].wrong?.bar"));
     }
 }

--- a/src/test/java/HelpersTest.java
+++ b/src/test/java/HelpersTest.java
@@ -15,92 +15,93 @@
  */
 
 import net.dv8tion.jda.internal.utils.Helpers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class HelpersTest
 {
     @Test
     public void testIsEmpty()
     {
-        Assertions.assertTrue(Helpers.isEmpty(null));
-        Assertions.assertTrue(Helpers.isEmpty(""));
-        Assertions.assertFalse(Helpers.isEmpty("null"));
-        Assertions.assertFalse(Helpers.isEmpty("testing with spaces"));
+        assertTrue(Helpers.isEmpty(null));
+        assertTrue(Helpers.isEmpty(""));
+        assertFalse(Helpers.isEmpty("null"));
+        assertFalse(Helpers.isEmpty("testing with spaces"));
     }
 
     @Test
     public void testContainsWhitespace()
     {
-        Assertions.assertTrue(Helpers.containsWhitespace(" "));
-        Assertions.assertTrue(Helpers.containsWhitespace("testing with spaces"));
-        Assertions.assertFalse(Helpers.containsWhitespace(null));
-        Assertions.assertFalse(Helpers.containsWhitespace(""));
-        Assertions.assertFalse(Helpers.containsWhitespace("null"));
+        assertTrue(Helpers.containsWhitespace(" "));
+        assertTrue(Helpers.containsWhitespace("testing with spaces"));
+        assertFalse(Helpers.containsWhitespace(null));
+        assertFalse(Helpers.containsWhitespace(""));
+        assertFalse(Helpers.containsWhitespace("null"));
     }
 
     @Test
     public void testIsBlank()
     {
-        Assertions.assertTrue(Helpers.isBlank(" "));
-        Assertions.assertTrue(Helpers.isBlank(null));
-        Assertions.assertTrue(Helpers.isBlank(""));
-        Assertions.assertFalse(Helpers.isBlank("testing with spaces"));
-        Assertions.assertFalse(Helpers.isBlank("null"));
+        assertTrue(Helpers.isBlank(" "));
+        assertTrue(Helpers.isBlank(null));
+        assertTrue(Helpers.isBlank(""));
+        assertFalse(Helpers.isBlank("testing with spaces"));
+        assertFalse(Helpers.isBlank("null"));
     }
 
     @Test
     public void testCountMatches()
     {
-        Assertions.assertEquals(3, Helpers.countMatches("Hello World", 'l'));
-        Assertions.assertEquals(1, Helpers.countMatches("Hello World", ' '));
-        Assertions.assertEquals(0, Helpers.countMatches("Hello World", '_'));
-        Assertions.assertEquals(0, Helpers.countMatches("", '!'));
-        Assertions.assertEquals(0, Helpers.countMatches(null, '?'));
+        assertEquals(3, Helpers.countMatches("Hello World", 'l'));
+        assertEquals(1, Helpers.countMatches("Hello World", ' '));
+        assertEquals(0, Helpers.countMatches("Hello World", '_'));
+        assertEquals(0, Helpers.countMatches("", '!'));
+        assertEquals(0, Helpers.countMatches(null, '?'));
     }
 
     @Test
     public void testTruncate()
     {
-        Assertions.assertEquals("Hello", Helpers.truncate("Hello World", 5));
-        Assertions.assertEquals("Hello", Helpers.truncate("Hello", 5));
-        Assertions.assertEquals("Hello", Helpers.truncate("Hello", 10));
-        Assertions.assertEquals("", Helpers.truncate("", 10));
-        Assertions.assertEquals("", Helpers.truncate("Test", 0));
-        Assertions.assertNull(Helpers.truncate(null, 10));
+        assertEquals("Hello", Helpers.truncate("Hello World", 5));
+        assertEquals("Hello", Helpers.truncate("Hello", 5));
+        assertEquals("Hello", Helpers.truncate("Hello", 10));
+        assertEquals("", Helpers.truncate("", 10));
+        assertEquals("", Helpers.truncate("Test", 0));
+        assertNull(Helpers.truncate(null, 10));
     }
 
     @Test
     public void testRightPad()
     {
-        Assertions.assertEquals("Hello    ", Helpers.rightPad("Hello", 9));
-        Assertions.assertEquals("Hello World", Helpers.rightPad("Hello World", 9));
-        Assertions.assertEquals("Hello", Helpers.rightPad("Hello", 5));
+        assertEquals("Hello    ", Helpers.rightPad("Hello", 9));
+        assertEquals("Hello World", Helpers.rightPad("Hello World", 9));
+        assertEquals("Hello", Helpers.rightPad("Hello", 5));
     }
 
     @Test
     public void testLeftPad()
     {
-        Assertions.assertEquals("    Hello", Helpers.leftPad("Hello", 9));
-        Assertions.assertEquals("Hello World", Helpers.leftPad("Hello World", 9));
-        Assertions.assertEquals("Hello", Helpers.leftPad("Hello", 5));
+        assertEquals("    Hello", Helpers.leftPad("Hello", 9));
+        assertEquals("Hello World", Helpers.leftPad("Hello World", 9));
+        assertEquals("Hello", Helpers.leftPad("Hello", 5));
     }
 
     @Test
     public void testIsNumeric()
     {
-        Assertions.assertTrue(Helpers.isNumeric("10"));
-        Assertions.assertTrue(Helpers.isNumeric("1"));
-        Assertions.assertTrue(Helpers.isNumeric("0"));
-        Assertions.assertTrue(Helpers.isNumeric(String.valueOf(Long.MAX_VALUE)));
-        Assertions.assertFalse(Helpers.isNumeric(null));
-        Assertions.assertFalse(Helpers.isNumeric(""));
-        Assertions.assertFalse(Helpers.isNumeric("Test"));
-        Assertions.assertFalse(Helpers.isNumeric("1.0"));
-        Assertions.assertFalse(Helpers.isNumeric("1e10"));
+        assertTrue(Helpers.isNumeric("10"));
+        assertTrue(Helpers.isNumeric("1"));
+        assertTrue(Helpers.isNumeric("0"));
+        assertTrue(Helpers.isNumeric(String.valueOf(Long.MAX_VALUE)));
+        assertFalse(Helpers.isNumeric(null));
+        assertFalse(Helpers.isNumeric(""));
+        assertFalse(Helpers.isNumeric("Test"));
+        assertFalse(Helpers.isNumeric("1.0"));
+        assertFalse(Helpers.isNumeric("1e10"));
     }
 
     @Test
@@ -111,11 +112,11 @@ public class HelpersTest
         List<String> c = Arrays.asList("A", "B");
         List<String> d = Arrays.asList("A", "B", "C");
 
-        Assertions.assertTrue(Helpers.deepEquals(a, a));
-        Assertions.assertTrue(Helpers.deepEquals(a, d));
-        Assertions.assertTrue(Helpers.deepEqualsUnordered(a, b));
-        Assertions.assertFalse(Helpers.deepEquals(a, b));
-        Assertions.assertFalse(Helpers.deepEquals(a, c));
-        Assertions.assertFalse(Helpers.deepEqualsUnordered(b, c));
+        assertTrue(Helpers.deepEquals(a, a));
+        assertTrue(Helpers.deepEquals(a, d));
+        assertTrue(Helpers.deepEqualsUnordered(a, b));
+        assertFalse(Helpers.deepEquals(a, b));
+        assertFalse(Helpers.deepEquals(a, c));
+        assertFalse(Helpers.deepEqualsUnordered(b, c));
     }
 }

--- a/src/test/java/JsonTest.java
+++ b/src/test/java/JsonTest.java
@@ -15,8 +15,9 @@
  */
 
 import net.dv8tion.jda.api.utils.data.DataObject;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JsonTest
 {
@@ -26,10 +27,10 @@ public class JsonTest
     public void testParse()
     {
         DataObject object = DataObject.fromJson(json);
-        Assertions.assertEquals(10, object.getInt("int", 0));
-        Assertions.assertEquals(100, object.getLong("long", 0));
-        Assertions.assertEquals(true, object.getBoolean("boolean", false));
-        Assertions.assertEquals("test", object.getString("string", null));
+        assertEquals(10, object.getInt("int", 0));
+        assertEquals(100, object.getLong("long", 0));
+        assertEquals(true, object.getBoolean("boolean", false));
+        assertEquals("test", object.getString("string", null));
     }
 
     @Test
@@ -38,6 +39,6 @@ public class JsonTest
         DataObject object = DataObject.fromJson(json);
         String result = object.toString();
         DataObject symmetric = DataObject.fromJson(result);
-        Assertions.assertEquals(object.toMap(), symmetric.toMap()); // lucky that this works here :)
+        assertEquals(object.toMap(), symmetric.toMap()); // lucky that this works here :)
     }
 }

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -15,9 +15,10 @@
  */
 
 import net.dv8tion.jda.api.utils.MarkdownSanitizer;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MarkdownTest
 {
@@ -32,125 +33,125 @@ class MarkdownTest
     @Test
     public void testComplex()
     {
-        Assertions.assertEquals("ABCDEF", markdown.compute("**A_B||C~~D__E`F`__~~||_**"));
+        assertEquals("ABCDEF", markdown.compute("**A_B||C~~D__E`F`__~~||_**"));
     }
 
     @Test
     public void testTrivial()
     {
-        Assertions.assertEquals("", markdown.compute(""));
-        Assertions.assertEquals("Hello World ~~~~", markdown.compute("Hello World ~~~~"));
-        Assertions.assertEquals("Hello World ~", markdown.compute("Hello World ~~~~~"));
+        assertEquals("", markdown.compute(""));
+        assertEquals("Hello World ~~~~", markdown.compute("Hello World ~~~~"));
+        assertEquals("Hello World ~", markdown.compute("Hello World ~~~~~"));
     }
 
     @Test
     public void testBold()
     {
-        Assertions.assertEquals("Hello", markdown.compute("**Hello**"));
-        Assertions.assertEquals("**Hello", markdown.compute("**Hello"));
-        Assertions.assertEquals("\\**Hello**", markdown.compute("\\**Hello**"));
+        assertEquals("Hello", markdown.compute("**Hello**"));
+        assertEquals("**Hello", markdown.compute("**Hello"));
+        assertEquals("\\**Hello**", markdown.compute("\\**Hello**"));
     }
 
     @Test
     public void testItalics()
     {
-        Assertions.assertEquals("Hello", markdown.compute("*Hello*"));
-        Assertions.assertEquals("Hello", markdown.compute("_Hello_"));
+        assertEquals("Hello", markdown.compute("*Hello*"));
+        assertEquals("Hello", markdown.compute("_Hello_"));
 
-        Assertions.assertEquals("*Hello", markdown.compute("*Hello"));
-        Assertions.assertEquals("_Hello", markdown.compute("_Hello"));
+        assertEquals("*Hello", markdown.compute("*Hello"));
+        assertEquals("_Hello", markdown.compute("_Hello"));
 
-        Assertions.assertEquals("\\*Hello*", markdown.compute("\\*Hello*"));
-        Assertions.assertEquals("\\_Hello_", markdown.compute("\\_Hello_"));
+        assertEquals("\\*Hello*", markdown.compute("\\*Hello*"));
+        assertEquals("\\_Hello_", markdown.compute("\\_Hello_"));
     }
 
     @Test
     public void testBoldItalics()
     {
-        Assertions.assertEquals("Hello", markdown.compute("***Hello***"));
-        Assertions.assertEquals("***Hello", markdown.compute("***Hello"));
-        Assertions.assertEquals("\\***Hello***", markdown.compute("\\***Hello***"));
+        assertEquals("Hello", markdown.compute("***Hello***"));
+        assertEquals("***Hello", markdown.compute("***Hello"));
+        assertEquals("\\***Hello***", markdown.compute("\\***Hello***"));
     }
 
     @Test
     public void testUnderline()
     {
-        Assertions.assertEquals("Hello", markdown.compute("__Hello__"));
-        Assertions.assertEquals("__Hello", markdown.compute("__Hello"));
-        Assertions.assertEquals("\\__Hello__", markdown.compute("\\__Hello__"));
+        assertEquals("Hello", markdown.compute("__Hello__"));
+        assertEquals("__Hello", markdown.compute("__Hello"));
+        assertEquals("\\__Hello__", markdown.compute("\\__Hello__"));
     }
 
     @Test
     public void testStrike()
     {
-        Assertions.assertEquals("Hello", markdown.compute("~~Hello~~"));
-        Assertions.assertEquals("~~Hello", markdown.compute("~~Hello"));
-        Assertions.assertEquals("\\~~Hello~~", markdown.compute("\\~~Hello~~"));
+        assertEquals("Hello", markdown.compute("~~Hello~~"));
+        assertEquals("~~Hello", markdown.compute("~~Hello"));
+        assertEquals("\\~~Hello~~", markdown.compute("\\~~Hello~~"));
     }
 
     @Test
     public void testSpoiler()
     {
-        Assertions.assertEquals("Hello", markdown.compute("||Hello||"));
-        Assertions.assertEquals("||Hello", markdown.compute("||Hello"));
-        Assertions.assertEquals("\\||Hello||", markdown.compute("\\||Hello||"));
+        assertEquals("Hello", markdown.compute("||Hello||"));
+        assertEquals("||Hello", markdown.compute("||Hello"));
+        assertEquals("\\||Hello||", markdown.compute("\\||Hello||"));
     }
 
     @Test
     public void testMono()
     {
-        Assertions.assertEquals("Hello", markdown.compute("`Hello`"));
-        Assertions.assertEquals("`Hello", markdown.compute("`Hello"));
-        Assertions.assertEquals("\\`Hello`", markdown.compute("\\`Hello`"));
+        assertEquals("Hello", markdown.compute("`Hello`"));
+        assertEquals("`Hello", markdown.compute("`Hello"));
+        assertEquals("\\`Hello`", markdown.compute("\\`Hello`"));
 
-        Assertions.assertEquals("Hello **World**", markdown.compute("`Hello **World**`"));
-        Assertions.assertEquals("`Hello World", markdown.compute("`Hello **World**"));
-        Assertions.assertEquals("\\`Hello World`", markdown.compute("\\`Hello **World**`"));
+        assertEquals("Hello **World**", markdown.compute("`Hello **World**`"));
+        assertEquals("`Hello World", markdown.compute("`Hello **World**"));
+        assertEquals("\\`Hello World`", markdown.compute("\\`Hello **World**`"));
     }
 
     @Test
     public void testMonoTwo()
     {
-        Assertions.assertEquals("Hello", markdown.compute("``Hello``"));
-        Assertions.assertEquals("``Hello", markdown.compute("``Hello"));
-        Assertions.assertEquals("\\``Hello``", markdown.compute("\\``Hello``"));
+        assertEquals("Hello", markdown.compute("``Hello``"));
+        assertEquals("``Hello", markdown.compute("``Hello"));
+        assertEquals("\\``Hello``", markdown.compute("\\``Hello``"));
 
-        Assertions.assertEquals("Hello **World**", markdown.compute("``Hello **World**``"));
-        Assertions.assertEquals("``Hello World", markdown.compute("``Hello **World**"));
-        Assertions.assertEquals("\\``Hello World``", markdown.compute("\\``Hello **World**``"));
+        assertEquals("Hello **World**", markdown.compute("``Hello **World**``"));
+        assertEquals("``Hello World", markdown.compute("``Hello **World**"));
+        assertEquals("\\``Hello World``", markdown.compute("\\``Hello **World**``"));
 
-        Assertions.assertEquals("Hello `to` World", markdown.compute("``Hello `to` World``"));
-        Assertions.assertEquals("``Hello to World", markdown.compute("``Hello `to` World"));
-        Assertions.assertEquals("\\``Hello to World``", markdown.compute("\\``Hello `to` World``"));
+        assertEquals("Hello `to` World", markdown.compute("``Hello `to` World``"));
+        assertEquals("``Hello to World", markdown.compute("``Hello `to` World"));
+        assertEquals("\\``Hello to World``", markdown.compute("\\``Hello `to` World``"));
     }
 
     @Test
     public void testBlock()
     {
-        Assertions.assertEquals("Hello", markdown.compute("```Hello```"));
-        Assertions.assertEquals("```Hello", markdown.compute("```Hello"));
-        Assertions.assertEquals("\\```Hello```", markdown.compute("\\```Hello```"));
+        assertEquals("Hello", markdown.compute("```Hello```"));
+        assertEquals("```Hello", markdown.compute("```Hello"));
+        assertEquals("\\```Hello```", markdown.compute("\\```Hello```"));
 
-        Assertions.assertEquals("Hello **World**", markdown.compute("```Hello **World**```"));
-        Assertions.assertEquals("```Hello World", markdown.compute("```Hello **World**"));
-        Assertions.assertEquals("\\```Hello World```", markdown.compute("\\```Hello **World**```"));
+        assertEquals("Hello **World**", markdown.compute("```Hello **World**```"));
+        assertEquals("```Hello World", markdown.compute("```Hello **World**"));
+        assertEquals("\\```Hello World```", markdown.compute("\\```Hello **World**```"));
 
-        Assertions.assertEquals("Hello `to` World", markdown.compute("```Hello `to` World```"));
-        Assertions.assertEquals("```Hello to World", markdown.compute("```Hello `to` World"));
-        Assertions.assertEquals("\\```Hello to World```", markdown.compute("\\```Hello `to` World```"));
+        assertEquals("Hello `to` World", markdown.compute("```Hello `to` World```"));
+        assertEquals("```Hello to World", markdown.compute("```Hello `to` World"));
+        assertEquals("\\```Hello to World```", markdown.compute("\\```Hello `to` World```"));
 
-        Assertions.assertEquals("Test", markdown.compute("```java\nTest```"));
+        assertEquals("Test", markdown.compute("```java\nTest```"));
     }
 
     @Test
     public void testQuote()
     {
-        Assertions.assertEquals("Hello > World", markdown.compute("> Hello > World"));
-        Assertions.assertEquals("Hello\nWorld", markdown.compute("> Hello\n> World"));
-        Assertions.assertEquals("Hello\nWorld", markdown.compute(">>> Hello\nWorld"));
-        Assertions.assertEquals("Hello\nWorld", markdown.compute(">>>\nHello\nWorld"));
-        Assertions.assertEquals("Hello > World", markdown.compute(">>>\nHello > World"));
-        Assertions.assertEquals("Hello\n World", markdown.compute("Hello\n > World"));
+        assertEquals("Hello > World", markdown.compute("> Hello > World"));
+        assertEquals("Hello\nWorld", markdown.compute("> Hello\n> World"));
+        assertEquals("Hello\nWorld", markdown.compute(">>> Hello\nWorld"));
+        assertEquals("Hello\nWorld", markdown.compute(">>>\nHello\nWorld"));
+        assertEquals("Hello > World", markdown.compute(">>>\nHello > World"));
+        assertEquals("Hello\n World", markdown.compute("Hello\n > World"));
     }
 }
 
@@ -167,102 +168,102 @@ class IgnoreMarkdownTest
     @Test
     public void testComplex()
     {
-        Assertions.assertEquals("**A_B||C~~D__E`F`__~~||_**", markdown.compute("**A_B||C~~D__E`F`__~~||_**"));
+        assertEquals("**A_B||C~~D__E`F`__~~||_**", markdown.compute("**A_B||C~~D__E`F`__~~||_**"));
     }
 
     @Test
     public void testBold()
     {
-        Assertions.assertEquals("**Hello**", markdown.compute("**Hello**"));
-        Assertions.assertEquals("**Hello", markdown.compute("**Hello"));
+        assertEquals("**Hello**", markdown.compute("**Hello**"));
+        assertEquals("**Hello", markdown.compute("**Hello"));
     }
 
     @Test
     public void testItalics()
     {
-        Assertions.assertEquals("*Hello*", markdown.compute("*Hello*"));
-        Assertions.assertEquals("_Hello_", markdown.compute("_Hello_"));
+        assertEquals("*Hello*", markdown.compute("*Hello*"));
+        assertEquals("_Hello_", markdown.compute("_Hello_"));
 
-        Assertions.assertEquals("*Hello", markdown.compute("*Hello"));
-        Assertions.assertEquals("_Hello", markdown.compute("_Hello"));
+        assertEquals("*Hello", markdown.compute("*Hello"));
+        assertEquals("_Hello", markdown.compute("_Hello"));
     }
 
     @Test
     public void testBoldItalics()
     {
-        Assertions.assertEquals("***Hello***", markdown.compute("***Hello***"));
-        Assertions.assertEquals("***Hello", markdown.compute("***Hello"));
-        Assertions.assertEquals("\\***Hello***", markdown.compute("\\***Hello***"));
+        assertEquals("***Hello***", markdown.compute("***Hello***"));
+        assertEquals("***Hello", markdown.compute("***Hello"));
+        assertEquals("\\***Hello***", markdown.compute("\\***Hello***"));
     }
 
     @Test
     public void testUnderline()
     {
-        Assertions.assertEquals("__Hello__", markdown.compute("__Hello__"));
-        Assertions.assertEquals("__Hello", markdown.compute("__Hello"));
+        assertEquals("__Hello__", markdown.compute("__Hello__"));
+        assertEquals("__Hello", markdown.compute("__Hello"));
     }
 
     @Test
     public void testStrike()
     {
-        Assertions.assertEquals("~~Hello~~", markdown.compute("~~Hello~~"));
-        Assertions.assertEquals("~~Hello", markdown.compute("~~Hello"));
+        assertEquals("~~Hello~~", markdown.compute("~~Hello~~"));
+        assertEquals("~~Hello", markdown.compute("~~Hello"));
     }
 
     @Test
     public void testSpoiler()
     {
-        Assertions.assertEquals("||Hello||", markdown.compute("||Hello||"));
-        Assertions.assertEquals("||Hello", markdown.compute("||Hello"));
+        assertEquals("||Hello||", markdown.compute("||Hello||"));
+        assertEquals("||Hello", markdown.compute("||Hello"));
     }
 
     @Test
     public void testMono()
     {
-        Assertions.assertEquals("`Hello`", markdown.compute("`Hello`"));
-        Assertions.assertEquals("`Hello", markdown.compute("`Hello"));
+        assertEquals("`Hello`", markdown.compute("`Hello`"));
+        assertEquals("`Hello", markdown.compute("`Hello"));
 
-        Assertions.assertEquals("`Hello **World**`", markdown.compute("`Hello **World**`"));
-        Assertions.assertEquals("`Hello **World**", markdown.compute("`Hello **World**"));
+        assertEquals("`Hello **World**`", markdown.compute("`Hello **World**`"));
+        assertEquals("`Hello **World**", markdown.compute("`Hello **World**"));
     }
 
     @Test
     public void testMonoTwo()
     {
-        Assertions.assertEquals("``Hello``", markdown.compute("``Hello``"));
-        Assertions.assertEquals("``Hello", markdown.compute("``Hello"));
+        assertEquals("``Hello``", markdown.compute("``Hello``"));
+        assertEquals("``Hello", markdown.compute("``Hello"));
 
-        Assertions.assertEquals("``Hello **World**``", markdown.compute("``Hello **World**``"));
-        Assertions.assertEquals("``Hello **World**", markdown.compute("``Hello **World**"));
+        assertEquals("``Hello **World**``", markdown.compute("``Hello **World**``"));
+        assertEquals("``Hello **World**", markdown.compute("``Hello **World**"));
 
-        Assertions.assertEquals("``Hello `to` World``", markdown.compute("``Hello `to` World``"));
-        Assertions.assertEquals("``Hello `to` World", markdown.compute("``Hello `to` World"));
+        assertEquals("``Hello `to` World``", markdown.compute("``Hello `to` World``"));
+        assertEquals("``Hello `to` World", markdown.compute("``Hello `to` World"));
     }
 
     @Test
     public void testBlock()
     {
-        Assertions.assertEquals("```Hello```", markdown.compute("```Hello```"));
-        Assertions.assertEquals("```Hello", markdown.compute("```Hello"));
+        assertEquals("```Hello```", markdown.compute("```Hello```"));
+        assertEquals("```Hello", markdown.compute("```Hello"));
 
-        Assertions.assertEquals("```Hello **World**```", markdown.compute("```Hello **World**```"));
-        Assertions.assertEquals("```Hello **World**", markdown.compute("```Hello **World**"));
+        assertEquals("```Hello **World**```", markdown.compute("```Hello **World**```"));
+        assertEquals("```Hello **World**", markdown.compute("```Hello **World**"));
 
-        Assertions.assertEquals("```Hello `to` World```", markdown.compute("```Hello `to` World```"));
-        Assertions.assertEquals("```Hello `to` World", markdown.compute("```Hello `to` World"));
+        assertEquals("```Hello `to` World```", markdown.compute("```Hello `to` World```"));
+        assertEquals("```Hello `to` World", markdown.compute("```Hello `to` World"));
 
-        Assertions.assertEquals("```java\nTest```", markdown.compute("```java\nTest```"));
+        assertEquals("```java\nTest```", markdown.compute("```java\nTest```"));
     }
 
     @Test
     public void testQuote()
     {
-        Assertions.assertEquals("> Hello > World", markdown.compute("> Hello > World"));
-        Assertions.assertEquals("> Hello\n> World", markdown.compute("> Hello\n> World"));
-        Assertions.assertEquals(">>> Hello\nWorld", markdown.compute(">>> Hello\nWorld"));
-        Assertions.assertEquals(">>>\nHello\nWorld", markdown.compute(">>>\nHello\nWorld"));
-        Assertions.assertEquals(">>>\nHello > World", markdown.compute(">>>\nHello > World"));
-        Assertions.assertEquals("Hello\n > World", markdown.compute("Hello\n > World"));
+        assertEquals("> Hello > World", markdown.compute("> Hello > World"));
+        assertEquals("> Hello\n> World", markdown.compute("> Hello\n> World"));
+        assertEquals(">>> Hello\nWorld", markdown.compute(">>> Hello\nWorld"));
+        assertEquals(">>>\nHello\nWorld", markdown.compute(">>>\nHello\nWorld"));
+        assertEquals(">>>\nHello > World", markdown.compute(">>>\nHello > World"));
+        assertEquals("Hello\n > World", markdown.compute("Hello\n > World"));
     }
 }
 
@@ -279,119 +280,119 @@ class EscapeMarkdownTest
     @Test
     public void testComplex()
     {
-        Assertions.assertEquals("\\*\\*A\\_B\\||C\\~~D\\_\\_E\\`F\\`\\_\\_\\~~\\||\\_\\*\\*", markdown.compute("**A_B||C~~D__E`F`__~~||_**"));
+        assertEquals("\\*\\*A\\_B\\||C\\~~D\\_\\_E\\`F\\`\\_\\_\\~~\\||\\_\\*\\*", markdown.compute("**A_B||C~~D__E`F`__~~||_**"));
     }
 
     @Test
     public void testBold()
     {
-        Assertions.assertEquals("\\*\\*Hello\\*\\*", markdown.compute("**Hello**"));
-        Assertions.assertEquals("**Hello", markdown.compute("**Hello"));
-        Assertions.assertEquals("\\**Hello**", markdown.compute("\\**Hello**"));
+        assertEquals("\\*\\*Hello\\*\\*", markdown.compute("**Hello**"));
+        assertEquals("**Hello", markdown.compute("**Hello"));
+        assertEquals("\\**Hello**", markdown.compute("\\**Hello**"));
     }
 
     @Test
     public void testItalics()
     {
-        Assertions.assertEquals("\\*Hello\\*", markdown.compute("*Hello*"));
-        Assertions.assertEquals("\\_Hello\\_", markdown.compute("_Hello_"));
+        assertEquals("\\*Hello\\*", markdown.compute("*Hello*"));
+        assertEquals("\\_Hello\\_", markdown.compute("_Hello_"));
 
-        Assertions.assertEquals("*Hello", markdown.compute("*Hello"));
-        Assertions.assertEquals("_Hello", markdown.compute("_Hello"));
+        assertEquals("*Hello", markdown.compute("*Hello"));
+        assertEquals("_Hello", markdown.compute("_Hello"));
 
-        Assertions.assertEquals("\\*Hello*", markdown.compute("\\*Hello*"));
-        Assertions.assertEquals("\\_Hello_", markdown.compute("\\_Hello_"));
+        assertEquals("\\*Hello*", markdown.compute("\\*Hello*"));
+        assertEquals("\\_Hello_", markdown.compute("\\_Hello_"));
     }
 
     @Test
     public void testBoldItalics()
     {
-        Assertions.assertEquals("\\*\\*\\*Hello\\*\\*\\*", markdown.compute("***Hello***"));
-        Assertions.assertEquals("***Hello", markdown.compute("***Hello"));
-        Assertions.assertEquals("\\***Hello***", markdown.compute("\\***Hello***"));
+        assertEquals("\\*\\*\\*Hello\\*\\*\\*", markdown.compute("***Hello***"));
+        assertEquals("***Hello", markdown.compute("***Hello"));
+        assertEquals("\\***Hello***", markdown.compute("\\***Hello***"));
     }
 
     @Test
     public void testUnderline()
     {
-        Assertions.assertEquals("\\_\\_Hello\\_\\_", markdown.compute("__Hello__"));
-        Assertions.assertEquals("__Hello", markdown.compute("__Hello"));
-        Assertions.assertEquals("\\__Hello__", markdown.compute("\\__Hello__"));
+        assertEquals("\\_\\_Hello\\_\\_", markdown.compute("__Hello__"));
+        assertEquals("__Hello", markdown.compute("__Hello"));
+        assertEquals("\\__Hello__", markdown.compute("\\__Hello__"));
     }
 
     @Test
     public void testStrike()
     {
-        Assertions.assertEquals("\\~~Hello\\~~", markdown.compute("~~Hello~~"));
-        Assertions.assertEquals("~~Hello", markdown.compute("~~Hello"));
-        Assertions.assertEquals("\\~~Hello~~", markdown.compute("\\~~Hello~~"));
+        assertEquals("\\~~Hello\\~~", markdown.compute("~~Hello~~"));
+        assertEquals("~~Hello", markdown.compute("~~Hello"));
+        assertEquals("\\~~Hello~~", markdown.compute("\\~~Hello~~"));
     }
 
     @Test
     public void testSpoiler()
     {
-        Assertions.assertEquals("\\||Hello\\||", markdown.compute("||Hello||"));
-        Assertions.assertEquals("||Hello", markdown.compute("||Hello"));
-        Assertions.assertEquals("\\||Hello||", markdown.compute("\\||Hello||"));
+        assertEquals("\\||Hello\\||", markdown.compute("||Hello||"));
+        assertEquals("||Hello", markdown.compute("||Hello"));
+        assertEquals("\\||Hello||", markdown.compute("\\||Hello||"));
     }
 
     @Test
     public void testMono()
     {
-        Assertions.assertEquals("\\`Hello\\`", markdown.compute("`Hello`"));
-        Assertions.assertEquals("`Hello", markdown.compute("`Hello"));
-        Assertions.assertEquals("\\`Hello`", markdown.compute("\\`Hello`"));
+        assertEquals("\\`Hello\\`", markdown.compute("`Hello`"));
+        assertEquals("`Hello", markdown.compute("`Hello"));
+        assertEquals("\\`Hello`", markdown.compute("\\`Hello`"));
 
-        Assertions.assertEquals("\\`Hello **World**\\`", markdown.compute("`Hello **World**`"));
-        Assertions.assertEquals("`Hello \\*\\*World\\*\\*", markdown.compute("`Hello **World**"));
-        Assertions.assertEquals("\\`Hello \\*\\*World\\*\\*`", markdown.compute("\\`Hello **World**`"));
+        assertEquals("\\`Hello **World**\\`", markdown.compute("`Hello **World**`"));
+        assertEquals("`Hello \\*\\*World\\*\\*", markdown.compute("`Hello **World**"));
+        assertEquals("\\`Hello \\*\\*World\\*\\*`", markdown.compute("\\`Hello **World**`"));
 
     }
 
     @Test
     public void testMonoTwo()
     {
-        Assertions.assertEquals("\\``Hello\\``", markdown.compute("``Hello``"));
-        Assertions.assertEquals("``Hello", markdown.compute("``Hello"));
-        Assertions.assertEquals("\\``Hello``", markdown.compute("\\``Hello``"));
+        assertEquals("\\``Hello\\``", markdown.compute("``Hello``"));
+        assertEquals("``Hello", markdown.compute("``Hello"));
+        assertEquals("\\``Hello``", markdown.compute("\\``Hello``"));
 
-        Assertions.assertEquals("\\``Hello **World**\\``", markdown.compute("``Hello **World**``"));
-        Assertions.assertEquals("``Hello \\*\\*World\\*\\*", markdown.compute("``Hello **World**"));
-        Assertions.assertEquals("\\``Hello \\*\\*World\\*\\*``", markdown.compute("\\``Hello **World**``"));
+        assertEquals("\\``Hello **World**\\``", markdown.compute("``Hello **World**``"));
+        assertEquals("``Hello \\*\\*World\\*\\*", markdown.compute("``Hello **World**"));
+        assertEquals("\\``Hello \\*\\*World\\*\\*``", markdown.compute("\\``Hello **World**``"));
 
-        Assertions.assertEquals("\\``Hello `to` World\\``", markdown.compute("``Hello `to` World``"));
-        Assertions.assertEquals("``Hello \\`to\\` World", markdown.compute("``Hello `to` World"));
-        Assertions.assertEquals("\\``Hello \\`to\\` World", markdown.compute("\\``Hello `to` World"));
+        assertEquals("\\``Hello `to` World\\``", markdown.compute("``Hello `to` World``"));
+        assertEquals("``Hello \\`to\\` World", markdown.compute("``Hello `to` World"));
+        assertEquals("\\``Hello \\`to\\` World", markdown.compute("\\``Hello `to` World"));
     }
 
     @Test
     public void testBlock()
     {
-        Assertions.assertEquals("\\```Hello\\```", markdown.compute("```Hello```"));
-        Assertions.assertEquals("```Hello", markdown.compute("```Hello"));
-        Assertions.assertEquals("\\```Hello", markdown.compute("\\```Hello"));
+        assertEquals("\\```Hello\\```", markdown.compute("```Hello```"));
+        assertEquals("```Hello", markdown.compute("```Hello"));
+        assertEquals("\\```Hello", markdown.compute("\\```Hello"));
 
-        Assertions.assertEquals("\\```Hello **World**\\```", markdown.compute("```Hello **World**```"));
-        Assertions.assertEquals("```Hello \\*\\*World\\*\\*", markdown.compute("```Hello **World**"));
-        Assertions.assertEquals("\\```Hello \\*\\*World\\*\\*", markdown.compute("\\```Hello **World**"));
+        assertEquals("\\```Hello **World**\\```", markdown.compute("```Hello **World**```"));
+        assertEquals("```Hello \\*\\*World\\*\\*", markdown.compute("```Hello **World**"));
+        assertEquals("\\```Hello \\*\\*World\\*\\*", markdown.compute("\\```Hello **World**"));
 
-        Assertions.assertEquals("\\```Hello `to` World\\```", markdown.compute("```Hello `to` World```"));
-        Assertions.assertEquals("```Hello \\`to\\` World", markdown.compute("```Hello `to` World"));
-        Assertions.assertEquals("\\```Hello \\`to\\` World", markdown.compute("\\```Hello `to` World"));
+        assertEquals("\\```Hello `to` World\\```", markdown.compute("```Hello `to` World```"));
+        assertEquals("```Hello \\`to\\` World", markdown.compute("```Hello `to` World"));
+        assertEquals("\\```Hello \\`to\\` World", markdown.compute("\\```Hello `to` World"));
 
-        Assertions.assertEquals("\\```java\nTest\\```", markdown.compute("```java\nTest```"));
+        assertEquals("\\```java\nTest\\```", markdown.compute("```java\nTest```"));
     }
 
     @Test
     public void testQuote()
     {
-        Assertions.assertEquals("\\> Hello > World", markdown.compute("> Hello > World"));
-        Assertions.assertEquals("\\> Hello\n\\> World", markdown.compute("> Hello\n> World"));
-        Assertions.assertEquals("\\>>> Hello\nWorld", markdown.compute(">>> Hello\nWorld"));
-        Assertions.assertEquals("\\>>>\nHello\nWorld", markdown.compute(">>>\nHello\nWorld"));
-        Assertions.assertEquals("\\>>>\nHello > World", markdown.compute(">>>\nHello > World"));
-        Assertions.assertEquals("\\> \\_Hello \n\\> World\\_", markdown.compute("> _Hello \n> World_"));
-        Assertions.assertEquals("Hello\n \\> World", markdown.compute("Hello\n > World"));
+        assertEquals("\\> Hello > World", markdown.compute("> Hello > World"));
+        assertEquals("\\> Hello\n\\> World", markdown.compute("> Hello\n> World"));
+        assertEquals("\\>>> Hello\nWorld", markdown.compute(">>> Hello\nWorld"));
+        assertEquals("\\>>>\nHello\nWorld", markdown.compute(">>>\nHello\nWorld"));
+        assertEquals("\\>>>\nHello > World", markdown.compute(">>>\nHello > World"));
+        assertEquals("\\> \\_Hello \n\\> World\\_", markdown.compute("> _Hello \n> World_"));
+        assertEquals("Hello\n \\> World", markdown.compute("Hello\n > World"));
     }
 }
 
@@ -400,69 +401,69 @@ class EscapeMarkdownAllTest
     @Test
     public void testAsterisk()
     {
-        Assertions.assertEquals("Hello\\*World", MarkdownSanitizer.escape("Hello*World", true));
-        Assertions.assertEquals("Hello\\*\\*World", MarkdownSanitizer.escape("Hello**World", true));
-        Assertions.assertEquals("Hello\\*\\*\\*World", MarkdownSanitizer.escape("Hello***World", true));
+        assertEquals("Hello\\*World", MarkdownSanitizer.escape("Hello*World", true));
+        assertEquals("Hello\\*\\*World", MarkdownSanitizer.escape("Hello**World", true));
+        assertEquals("Hello\\*\\*\\*World", MarkdownSanitizer.escape("Hello***World", true));
 
-        Assertions.assertEquals("Hello\\*World", MarkdownSanitizer.escape("Hello\\*World", true));
-        Assertions.assertEquals("Hello\\*\\*World", MarkdownSanitizer.escape("Hello\\*\\*World", true));
-        Assertions.assertEquals("Hello\\*\\*\\*World", MarkdownSanitizer.escape("Hello\\*\\*\\*World", true));
+        assertEquals("Hello\\*World", MarkdownSanitizer.escape("Hello\\*World", true));
+        assertEquals("Hello\\*\\*World", MarkdownSanitizer.escape("Hello\\*\\*World", true));
+        assertEquals("Hello\\*\\*\\*World", MarkdownSanitizer.escape("Hello\\*\\*\\*World", true));
     }
 
     @Test
     public void testUnderscore()
     {
-        Assertions.assertEquals("Hello\\_World", MarkdownSanitizer.escape("Hello_World", true));
-        Assertions.assertEquals("Hello\\_\\_World", MarkdownSanitizer.escape("Hello__World", true));
-        Assertions.assertEquals("Hello\\_\\_\\_World", MarkdownSanitizer.escape("Hello___World", true));
+        assertEquals("Hello\\_World", MarkdownSanitizer.escape("Hello_World", true));
+        assertEquals("Hello\\_\\_World", MarkdownSanitizer.escape("Hello__World", true));
+        assertEquals("Hello\\_\\_\\_World", MarkdownSanitizer.escape("Hello___World", true));
 
-        Assertions.assertEquals("Hello\\_World", MarkdownSanitizer.escape("Hello\\_World", true));
-        Assertions.assertEquals("Hello\\_\\_World", MarkdownSanitizer.escape("Hello\\_\\_World", true));
-        Assertions.assertEquals("Hello\\_\\_\\_World", MarkdownSanitizer.escape("Hello\\_\\_\\_World", true));
+        assertEquals("Hello\\_World", MarkdownSanitizer.escape("Hello\\_World", true));
+        assertEquals("Hello\\_\\_World", MarkdownSanitizer.escape("Hello\\_\\_World", true));
+        assertEquals("Hello\\_\\_\\_World", MarkdownSanitizer.escape("Hello\\_\\_\\_World", true));
     }
 
     @Test
     public void testCodeBlock()
     {
-        Assertions.assertEquals("Hello\\`World", MarkdownSanitizer.escape("Hello`World", true));
-        Assertions.assertEquals("Hello\\`\\`World", MarkdownSanitizer.escape("Hello``World", true));
-        Assertions.assertEquals("Hello\\`\\`\\`World", MarkdownSanitizer.escape("Hello```World", true));
+        assertEquals("Hello\\`World", MarkdownSanitizer.escape("Hello`World", true));
+        assertEquals("Hello\\`\\`World", MarkdownSanitizer.escape("Hello``World", true));
+        assertEquals("Hello\\`\\`\\`World", MarkdownSanitizer.escape("Hello```World", true));
 
-        Assertions.assertEquals("Hello\\`World", MarkdownSanitizer.escape("Hello\\`World", true));
-        Assertions.assertEquals("Hello\\`\\`World", MarkdownSanitizer.escape("Hello\\`\\`World", true));
-        Assertions.assertEquals("Hello\\`\\`\\`World", MarkdownSanitizer.escape("Hello\\`\\`\\`World", true));
+        assertEquals("Hello\\`World", MarkdownSanitizer.escape("Hello\\`World", true));
+        assertEquals("Hello\\`\\`World", MarkdownSanitizer.escape("Hello\\`\\`World", true));
+        assertEquals("Hello\\`\\`\\`World", MarkdownSanitizer.escape("Hello\\`\\`\\`World", true));
     }
 
     @Test
     public void testSpoiler()
     {
-        Assertions.assertEquals("Hello\\|\\|World", MarkdownSanitizer.escape("Hello||World", true));
-        Assertions.assertEquals("Hello|World", MarkdownSanitizer.escape("Hello|World", true));
+        assertEquals("Hello\\|\\|World", MarkdownSanitizer.escape("Hello||World", true));
+        assertEquals("Hello|World", MarkdownSanitizer.escape("Hello|World", true));
 
-        Assertions.assertEquals("Hello\\|\\|World", MarkdownSanitizer.escape("Hello\\|\\|World", true));
-        Assertions.assertEquals("Hello\\|World", MarkdownSanitizer.escape("Hello\\|World", true));
+        assertEquals("Hello\\|\\|World", MarkdownSanitizer.escape("Hello\\|\\|World", true));
+        assertEquals("Hello\\|World", MarkdownSanitizer.escape("Hello\\|World", true));
     }
 
     @Test
     public void testStrike()
     {
-        Assertions.assertEquals("Hello\\~\\~World", MarkdownSanitizer.escape("Hello~~World", true));
-        Assertions.assertEquals("Hello\\~\\~World", MarkdownSanitizer.escape("Hello\\~\\~World", true));
+        assertEquals("Hello\\~\\~World", MarkdownSanitizer.escape("Hello~~World", true));
+        assertEquals("Hello\\~\\~World", MarkdownSanitizer.escape("Hello\\~\\~World", true));
     }
 
     @Test
     public void testQuote()
     {
-        Assertions.assertEquals("\\> Hello World", MarkdownSanitizer.escape("> Hello World", true));
-        Assertions.assertEquals(">Hello World", MarkdownSanitizer.escape(">Hello World", true));
-        Assertions.assertEquals("\\>\\>\\> Hello World", MarkdownSanitizer.escape(">>> Hello World", true));
-        Assertions.assertEquals(">>>Hello World", MarkdownSanitizer.escape(">>>Hello World", true));
-        Assertions.assertEquals("\\>\\>\\> Hello > World\n\\> Hello >>> World\n<@12345> > Hello\n \\> Hello world", MarkdownSanitizer.escape(">>> Hello > World\n> Hello >>> World\n<@12345> > Hello\n > Hello world", true));
+        assertEquals("\\> Hello World", MarkdownSanitizer.escape("> Hello World", true));
+        assertEquals(">Hello World", MarkdownSanitizer.escape(">Hello World", true));
+        assertEquals("\\>\\>\\> Hello World", MarkdownSanitizer.escape(">>> Hello World", true));
+        assertEquals(">>>Hello World", MarkdownSanitizer.escape(">>>Hello World", true));
+        assertEquals("\\>\\>\\> Hello > World\n\\> Hello >>> World\n<@12345> > Hello\n \\> Hello world", MarkdownSanitizer.escape(">>> Hello > World\n> Hello >>> World\n<@12345> > Hello\n > Hello world", true));
 
-        Assertions.assertEquals("\\> Hello World", MarkdownSanitizer.escape("\\> Hello World", true));
-        Assertions.assertEquals("\\>\\>\\> Hello World", MarkdownSanitizer.escape("\\>\\>\\> Hello World", true));
-        Assertions.assertEquals("Hello > World", MarkdownSanitizer.escape("Hello > World"));
-        Assertions.assertEquals("Hello\n \\> World", MarkdownSanitizer.escape("Hello\n > World"));
-        Assertions.assertEquals("Hello\n\\> World", MarkdownSanitizer.escape("Hello\n> World"));
+        assertEquals("\\> Hello World", MarkdownSanitizer.escape("\\> Hello World", true));
+        assertEquals("\\>\\>\\> Hello World", MarkdownSanitizer.escape("\\>\\>\\> Hello World", true));
+        assertEquals("Hello > World", MarkdownSanitizer.escape("Hello > World"));
+        assertEquals("Hello\n \\> World", MarkdownSanitizer.escape("Hello\n > World"));
+        assertEquals("Hello\n\\> World", MarkdownSanitizer.escape("Hello\n> World"));
     }
 }

--- a/src/test/java/MarkdownUtilTest.java
+++ b/src/test/java/MarkdownUtilTest.java
@@ -14,93 +14,93 @@
  * limitations under the License.
  */
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static net.dv8tion.jda.api.utils.MarkdownUtil.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MarkdownUtilTest
 {
     @Test
     public void testBold()
     {
-        Assertions.assertEquals("**Hello World**", bold("Hello World"));
-        Assertions.assertEquals("**Hello \\*\\*Test\\*\\* World**", bold("Hello **Test** World"));
-        Assertions.assertEquals("**Hello *Test* World**", bold("Hello *Test* World"));
+        assertEquals("**Hello World**", bold("Hello World"));
+        assertEquals("**Hello \\*\\*Test\\*\\* World**", bold("Hello **Test** World"));
+        assertEquals("**Hello *Test* World**", bold("Hello *Test* World"));
     }
 
     @Test
     public void testItalics()
     {
-        Assertions.assertEquals("_Hello World_", italics("Hello World"));
-        Assertions.assertEquals("_Hello \\_Test\\_ World_", italics("Hello _Test_ World"));
-        Assertions.assertEquals("_Hello __Test__ World_", italics("Hello __Test__ World"));
+        assertEquals("_Hello World_", italics("Hello World"));
+        assertEquals("_Hello \\_Test\\_ World_", italics("Hello _Test_ World"));
+        assertEquals("_Hello __Test__ World_", italics("Hello __Test__ World"));
     }
 
     @Test
     public void testUnderline()
     {
-        Assertions.assertEquals("__Hello World__", underline("Hello World"));
-        Assertions.assertEquals("__Hello \\_\\_Test\\_\\_ World__", underline("Hello __Test__ World"));
-        Assertions.assertEquals("__Hello _Test_ World__", underline("Hello _Test_ World"));
+        assertEquals("__Hello World__", underline("Hello World"));
+        assertEquals("__Hello \\_\\_Test\\_\\_ World__", underline("Hello __Test__ World"));
+        assertEquals("__Hello _Test_ World__", underline("Hello _Test_ World"));
     }
 
     @Test
     public void testMonospace()
     {
-        Assertions.assertEquals("`Hello World`", monospace("Hello World"));
-        Assertions.assertEquals("`Hello \\`Test\\` World`", monospace("Hello `Test` World"));
-        Assertions.assertEquals("`Hello ``Test`` World`", monospace("Hello ``Test`` World"));
+        assertEquals("`Hello World`", monospace("Hello World"));
+        assertEquals("`Hello \\`Test\\` World`", monospace("Hello `Test` World"));
+        assertEquals("`Hello ``Test`` World`", monospace("Hello ``Test`` World"));
     }
 
     @Test
     public void testCodeblock()
     {
-        Assertions.assertEquals("```java\nHello World```", codeblock("java", "Hello World"));
-        Assertions.assertEquals("```java\nHello \\```java\nTest\\``` World```", codeblock("java", "Hello ```java\nTest``` World"));
-        Assertions.assertEquals("```java\nHello `Test` World```", codeblock("java", "Hello `Test` World"));
+        assertEquals("```java\nHello World```", codeblock("java", "Hello World"));
+        assertEquals("```java\nHello \\```java\nTest\\``` World```", codeblock("java", "Hello ```java\nTest``` World"));
+        assertEquals("```java\nHello `Test` World```", codeblock("java", "Hello `Test` World"));
 
-        Assertions.assertEquals("```Hello World```", codeblock("Hello World"));
-        Assertions.assertEquals("```Hello \\```java\nTest\\``` World```", codeblock("Hello ```java\nTest``` World"));
-        Assertions.assertEquals("```Hello `Test` World```", codeblock("Hello `Test` World"));
+        assertEquals("```Hello World```", codeblock("Hello World"));
+        assertEquals("```Hello \\```java\nTest\\``` World```", codeblock("Hello ```java\nTest``` World"));
+        assertEquals("```Hello `Test` World```", codeblock("Hello `Test` World"));
     }
 
     @Test
     public void testSpoiler()
     {
-        Assertions.assertEquals("||Hello World||", spoiler("Hello World"));
-        Assertions.assertEquals("||Hello \\||Test\\|| World||", spoiler("Hello ||Test|| World"));
-        Assertions.assertEquals("||Hello |Test| World||", spoiler("Hello |Test| World"));
+        assertEquals("||Hello World||", spoiler("Hello World"));
+        assertEquals("||Hello \\||Test\\|| World||", spoiler("Hello ||Test|| World"));
+        assertEquals("||Hello |Test| World||", spoiler("Hello |Test| World"));
     }
 
     @Test
     public void testStrike()
     {
-        Assertions.assertEquals("~~Hello World~~", strike("Hello World"));
-        Assertions.assertEquals("~~Hello \\~~Test\\~~ World~~", strike("Hello ~~Test~~ World"));
-        Assertions.assertEquals("~~Hello ~Test~ World~~", strike("Hello ~Test~ World"));
+        assertEquals("~~Hello World~~", strike("Hello World"));
+        assertEquals("~~Hello \\~~Test\\~~ World~~", strike("Hello ~~Test~~ World"));
+        assertEquals("~~Hello ~Test~ World~~", strike("Hello ~Test~ World"));
     }
 
     @Test
     public void testQuote()
     {
-        Assertions.assertEquals("> Hello World", quote("Hello World"));
-        Assertions.assertEquals("> Hello \n> \\> Test World", quote("Hello \n> Test World"));
-        Assertions.assertEquals("> Hello > Test World", quote("Hello > Test World"));
+        assertEquals("> Hello World", quote("Hello World"));
+        assertEquals("> Hello \n> \\> Test World", quote("Hello \n> Test World"));
+        assertEquals("> Hello > Test World", quote("Hello > Test World"));
     }
 
     @Test
     public void testQuoteBlock()
     {
-        Assertions.assertEquals(">>> Hello World", quoteBlock("Hello World"));
-        Assertions.assertEquals(">>> Hello \n>>> Test World", quoteBlock("Hello \n>>> Test World"));
+        assertEquals(">>> Hello World", quoteBlock("Hello World"));
+        assertEquals(">>> Hello \n>>> Test World", quoteBlock("Hello \n>>> Test World"));
     }
 
     @Test
     public void testMaskedLink()
     {
-        Assertions.assertEquals("[Hello](World)", maskedLink("Hello", "World"));
-        Assertions.assertEquals("[Hello](World%29)", maskedLink("Hello", "World)"));
-        Assertions.assertEquals("[Hello\\]](World%29)", maskedLink("Hello]", "World)"));
+        assertEquals("[Hello](World)", maskedLink("Hello", "World"));
+        assertEquals("[Hello](World%29)", maskedLink("Hello", "World)"));
+        assertEquals("[Hello\\]](World%29)", maskedLink("Hello]", "World)"));
     }
 }

--- a/src/test/java/net/dv8tion/jda/ChannelConsistencyTest.java
+++ b/src/test/java/net/dv8tion/jda/ChannelConsistencyTest.java
@@ -30,6 +30,8 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 public class ChannelConsistencyTest
 {
     private static Set<String> getMethodNames(Class<?> clazz)
@@ -57,7 +59,7 @@ public class ChannelConsistencyTest
         {
             String channelName = getChannelName(type);
             String methodName = "create" + channelName + "Channel";
-            Assertions.assertTrue(guildMethods.contains(methodName), "Missing method Guild#" + methodName);
+            assertTrue(guildMethods.contains(methodName), "Missing method Guild#" + methodName);
         }
 
         Set<String> categoryMethods = getMethodNames(Category.class);
@@ -66,7 +68,7 @@ public class ChannelConsistencyTest
         {
             String channelName = getChannelName(type);
             String methodName = "create" + channelName + "Channel";
-            Assertions.assertTrue(categoryMethods.contains(methodName), "Missing method Category#" + methodName);
+            assertTrue(categoryMethods.contains(methodName), "Missing method Category#" + methodName);
         }
     }
 
@@ -87,17 +89,17 @@ public class ChannelConsistencyTest
             String channelName = getChannelName(type);
 
             String methodName = "get" + channelName + "ChannelCache";
-            Assertions.assertTrue(jdaMethods.contains(methodName), "Missing method IGuildChannelContainer#" + methodName);
+            assertTrue(jdaMethods.contains(methodName), "Missing method IGuildChannelContainer#" + methodName);
 
             methodName = "get" + channelName + "ChannelsByName";
-            Assertions.assertTrue(jdaMethods.contains(methodName), "Missing method IGuildChannelContainer#" + methodName);
+            assertTrue(jdaMethods.contains(methodName), "Missing method IGuildChannelContainer#" + methodName);
 
             methodName = "get" + channelName + "ChannelById";
-            Assertions.assertTrue(jdaMethods.contains(methodName), "Missing method IGuildChannelContainer#" + methodName);
+            assertTrue(jdaMethods.contains(methodName), "Missing method IGuildChannelContainer#" + methodName);
 
             methodName = "get" + channelName + "Channels";
-            Assertions.assertTrue(jdaMethods.contains(methodName), "Missing method IGuildChannelContainer#" + methodName);
-            Assertions.assertTrue(categoryMethods.contains(methodName), "Missing method Category#" + methodName);
+            assertTrue(jdaMethods.contains(methodName), "Missing method IGuildChannelContainer#" + methodName);
+            assertTrue(categoryMethods.contains(methodName), "Missing method Category#" + methodName);
         }
     }
 
@@ -114,7 +116,7 @@ public class ChannelConsistencyTest
         {
             String channelName = getChannelName(type);
 
-            Assertions.assertDoesNotThrow(() -> {
+            assertDoesNotThrow(() -> {
                 Class.forName("net.dv8tion.jda.api.managers.channel.concrete." + channelName + "ChannelManager");
             }, "Missing manager interface for ChannelType." + type);
         }

--- a/src/test/java/net/dv8tion/jda/entities/MessageSerializationTest.java
+++ b/src/test/java/net/dv8tion/jda/entities/MessageSerializationTest.java
@@ -19,8 +19,9 @@ package net.dv8tion.jda.entities;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.EmbedType;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MessageSerializationTest
 {
@@ -42,39 +43,39 @@ public class MessageSerializationTest
 
         MessageEmbed dataEmbed = EmbedBuilder.fromData(embed.toData()).build();
 
-        Assertions.assertEquals(embed.getType(), dataEmbed.getType());
-        Assertions.assertEquals(EmbedType.RICH, embed.getType());
+        assertEquals(embed.getType(), dataEmbed.getType());
+        assertEquals(EmbedType.RICH, embed.getType());
 
-        Assertions.assertEquals(embed.getDescription(), dataEmbed.getDescription());
-        Assertions.assertEquals(embed.getTitle(), dataEmbed.getTitle());
-        Assertions.assertEquals(embed.getUrl(), dataEmbed.getUrl());
-        Assertions.assertEquals(embed.getAuthor(), dataEmbed.getAuthor());
-        Assertions.assertEquals(embed.getFooter(), dataEmbed.getFooter());
-        Assertions.assertEquals(embed.getImage(), dataEmbed.getImage());
-        Assertions.assertEquals(embed.getThumbnail(), dataEmbed.getThumbnail());
-        Assertions.assertEquals(embed.getFields(), dataEmbed.getFields());
+        assertEquals(embed.getDescription(), dataEmbed.getDescription());
+        assertEquals(embed.getTitle(), dataEmbed.getTitle());
+        assertEquals(embed.getUrl(), dataEmbed.getUrl());
+        assertEquals(embed.getAuthor(), dataEmbed.getAuthor());
+        assertEquals(embed.getFooter(), dataEmbed.getFooter());
+        assertEquals(embed.getImage(), dataEmbed.getImage());
+        assertEquals(embed.getThumbnail(), dataEmbed.getThumbnail());
+        assertEquals(embed.getFields(), dataEmbed.getFields());
 
-        Assertions.assertEquals(embed, dataEmbed);
+        assertEquals(embed, dataEmbed);
 
-        Assertions.assertEquals("Description Text", dataEmbed.getDescription());
-        Assertions.assertEquals("Title Text", dataEmbed.getTitle());
-        Assertions.assertEquals("https://example.com/title", dataEmbed.getUrl());
-        Assertions.assertEquals("Author Text", dataEmbed.getAuthor().getName());
-        Assertions.assertEquals("https://example.com/author", dataEmbed.getAuthor().getUrl());
-        Assertions.assertEquals("https://example.com/author_icon", dataEmbed.getAuthor().getIconUrl());
-        Assertions.assertEquals("Footer Text", dataEmbed.getFooter().getText());
-        Assertions.assertEquals("https://example.com/footer_icon", dataEmbed.getFooter().getIconUrl());
-        Assertions.assertEquals("https://example.com/image", dataEmbed.getImage().getUrl());
-        Assertions.assertEquals("https://example.com/thumbnail", dataEmbed.getThumbnail().getUrl());
-        Assertions.assertEquals(3, dataEmbed.getFields().size());
-        Assertions.assertEquals("Field 1", dataEmbed.getFields().get(0).getName());
-        Assertions.assertEquals("Field 1 Text", dataEmbed.getFields().get(0).getValue());
-        Assertions.assertTrue(dataEmbed.getFields().get(0).isInline());
-        Assertions.assertEquals("Field 2", dataEmbed.getFields().get(1).getName());
-        Assertions.assertEquals("Field 2 Text", dataEmbed.getFields().get(1).getValue());
-        Assertions.assertFalse(dataEmbed.getFields().get(1).isInline());
-        Assertions.assertEquals("Field 3", dataEmbed.getFields().get(2).getName());
-        Assertions.assertEquals("Field 3 Text", dataEmbed.getFields().get(2).getValue());
-        Assertions.assertTrue(dataEmbed.getFields().get(2).isInline());
+        assertEquals("Description Text", dataEmbed.getDescription());
+        assertEquals("Title Text", dataEmbed.getTitle());
+        assertEquals("https://example.com/title", dataEmbed.getUrl());
+        assertEquals("Author Text", dataEmbed.getAuthor().getName());
+        assertEquals("https://example.com/author", dataEmbed.getAuthor().getUrl());
+        assertEquals("https://example.com/author_icon", dataEmbed.getAuthor().getIconUrl());
+        assertEquals("Footer Text", dataEmbed.getFooter().getText());
+        assertEquals("https://example.com/footer_icon", dataEmbed.getFooter().getIconUrl());
+        assertEquals("https://example.com/image", dataEmbed.getImage().getUrl());
+        assertEquals("https://example.com/thumbnail", dataEmbed.getThumbnail().getUrl());
+        assertEquals(3, dataEmbed.getFields().size());
+        assertEquals("Field 1", dataEmbed.getFields().get(0).getName());
+        assertEquals("Field 1 Text", dataEmbed.getFields().get(0).getValue());
+        assertTrue(dataEmbed.getFields().get(0).isInline());
+        assertEquals("Field 2", dataEmbed.getFields().get(1).getName());
+        assertEquals("Field 2 Text", dataEmbed.getFields().get(1).getValue());
+        assertFalse(dataEmbed.getFields().get(1).isInline());
+        assertEquals("Field 3", dataEmbed.getFields().get(2).getName());
+        assertEquals("Field 3 Text", dataEmbed.getFields().get(2).getValue());
+        assertTrue(dataEmbed.getFields().get(2).isInline());
     }
 }

--- a/src/test/java/net/dv8tion/jda/entities/MessageSerializationTest.java
+++ b/src/test/java/net/dv8tion/jda/entities/MessageSerializationTest.java
@@ -25,21 +25,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class MessageSerializationTest
 {
-
-    private static MessageEmbed getTestEmbed()
-    {
-        return new EmbedBuilder()
-        .setDescription("Description Text")
-        .setTitle("Title Text", "https://example.com/title")
-        .setAuthor("Author Text", "https://example.com/author", "https://example.com/author_icon")
-        .setFooter("Footer Text", "https://example.com/footer_icon")
-        .setImage("https://example.com/image")
-        .setThumbnail("https://example.com/thumbnail")
-        .addField("Field 1", "Field 1 Text", true)
-        .addField("Field 2", "Field 2 Text", false)
-        .addField("Field 3", "Field 3 Text", true).build();
-    }
-
     @Test
     void testEmbedSerialization()
     {
@@ -81,5 +66,19 @@ public class MessageSerializationTest
         assertEquals("Field 3", dataEmbed.getFields().get(2).getName());
         assertEquals("Field 3 Text", dataEmbed.getFields().get(2).getValue());
         assertTrue(dataEmbed.getFields().get(2).isInline());
+    }
+
+    private MessageEmbed getTestEmbed()
+    {
+        return new EmbedBuilder()
+                .setDescription("Description Text")
+                .setTitle("Title Text", "https://example.com/title")
+                .setAuthor("Author Text", "https://example.com/author", "https://example.com/author_icon")
+                .setFooter("Footer Text", "https://example.com/footer_icon")
+                .setImage("https://example.com/image")
+                .setThumbnail("https://example.com/thumbnail")
+                .addField("Field 1", "Field 1 Text", true)
+                .addField("Field 2", "Field 2 Text", false)
+                .addField("Field 3", "Field 3 Text", true).build();
     }
 }

--- a/src/test/java/net/dv8tion/jda/entities/MessageSerializationTest.java
+++ b/src/test/java/net/dv8tion/jda/entities/MessageSerializationTest.java
@@ -25,21 +25,25 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class MessageSerializationTest
 {
+
+    private static MessageEmbed getTestEmbed()
+    {
+        return new EmbedBuilder()
+        .setDescription("Description Text")
+        .setTitle("Title Text", "https://example.com/title")
+        .setAuthor("Author Text", "https://example.com/author", "https://example.com/author_icon")
+        .setFooter("Footer Text", "https://example.com/footer_icon")
+        .setImage("https://example.com/image")
+        .setThumbnail("https://example.com/thumbnail")
+        .addField("Field 1", "Field 1 Text", true)
+        .addField("Field 2", "Field 2 Text", false)
+        .addField("Field 3", "Field 3 Text", true).build();
+    }
+
     @Test
     void testEmbedSerialization()
     {
-        EmbedBuilder builder = new EmbedBuilder();
-        builder.setDescription("Description Text");
-        builder.setTitle("Title Text", "https://example.com/title");
-        builder.setAuthor("Author Text", "https://example.com/author", "https://example.com/author_icon");
-        builder.setFooter("Footer Text", "https://example.com/footer_icon");
-        builder.setImage("https://example.com/image");
-        builder.setThumbnail("https://example.com/thumbnail");
-        builder.addField("Field 1", "Field 1 Text", true);
-        builder.addField("Field 2", "Field 2 Text", false);
-        builder.addField("Field 3", "Field 3 Text", true);
-
-        MessageEmbed embed = builder.build();
+        MessageEmbed embed = getTestEmbed();
 
         MessageEmbed dataEmbed = EmbedBuilder.fromData(embed.toData()).build();
 

--- a/src/test/java/net/dv8tion/jda/interactions/SelectMenuTests.java
+++ b/src/test/java/net/dv8tion/jda/interactions/SelectMenuTests.java
@@ -21,10 +21,11 @@ import net.dv8tion.jda.api.interactions.components.selections.EntitySelectMenu.B
 import net.dv8tion.jda.api.interactions.components.selections.EntitySelectMenu.DefaultValue;
 import net.dv8tion.jda.api.interactions.components.selections.EntitySelectMenu.SelectTarget;
 import net.dv8tion.jda.api.utils.data.DataObject;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SelectMenuTests
 {
@@ -37,9 +38,9 @@ public class SelectMenuTests
         EntitySelectMenu menu = builder.build();
         DataObject value = menu.toData().getArray("default_values").getObject(0);
 
-        Assertions.assertEquals(Arrays.asList(DefaultValue.role("1234")), menu.getDefaultValues());
-        Assertions.assertEquals("role", value.getString("type"));
-        Assertions.assertEquals("1234", value.getString("id"));
+        assertEquals(Arrays.asList(DefaultValue.role("1234")), menu.getDefaultValues());
+        assertEquals("role", value.getString("type"));
+        assertEquals("1234", value.getString("id"));
 
         builder = EntitySelectMenu.create("customid", SelectTarget.USER);
         builder.setDefaultValues(DefaultValue.user("1234"));
@@ -47,9 +48,9 @@ public class SelectMenuTests
         menu = builder.build();
         value = menu.toData().getArray("default_values").getObject(0);
 
-        Assertions.assertEquals(Arrays.asList(DefaultValue.user("1234")), menu.getDefaultValues());
-        Assertions.assertEquals("user", value.getString("type"));
-        Assertions.assertEquals("1234", value.getString("id"));
+        assertEquals(Arrays.asList(DefaultValue.user("1234")), menu.getDefaultValues());
+        assertEquals("user", value.getString("type"));
+        assertEquals("1234", value.getString("id"));
 
         builder = EntitySelectMenu.create("customid", SelectTarget.CHANNEL);
         builder.setDefaultValues(DefaultValue.channel("1234"));
@@ -57,39 +58,39 @@ public class SelectMenuTests
         menu = builder.build();
         value = menu.toData().getArray("default_values").getObject(0);
 
-        Assertions.assertEquals(Arrays.asList(DefaultValue.channel("1234")), menu.getDefaultValues());
-        Assertions.assertEquals("channel", value.getString("type"));
-        Assertions.assertEquals("1234", value.getString("id"));
+        assertEquals(Arrays.asList(DefaultValue.channel("1234")), menu.getDefaultValues());
+        assertEquals("channel", value.getString("type"));
+        assertEquals("1234", value.getString("id"));
     }
 
     @Test
     public void testEntitySelectDefaultValueInvalid()
     {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             Builder builder = EntitySelectMenu.create("customid", SelectTarget.ROLE);
             builder.setDefaultValues(DefaultValue.user("1234"));
         });
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             Builder builder = EntitySelectMenu.create("customid", SelectTarget.ROLE);
             builder.setDefaultValues(DefaultValue.channel("1234"));
         });
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             Builder builder = EntitySelectMenu.create("customid", SelectTarget.ROLE, SelectTarget.USER);
             builder.setDefaultValues(DefaultValue.channel("1234"));
         });
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             Builder builder = EntitySelectMenu.create("customid", SelectTarget.USER);
             builder.setDefaultValues(DefaultValue.channel("1234"));
         });
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             Builder builder = EntitySelectMenu.create("customid", SelectTarget.USER);
             builder.setDefaultValues(DefaultValue.role("1234"));
         });
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             Builder builder = EntitySelectMenu.create("customid", SelectTarget.CHANNEL);
             builder.setDefaultValues(DefaultValue.user("1234"));
         });
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             Builder builder = EntitySelectMenu.create("customid", SelectTarget.CHANNEL);
             builder.setDefaultValues(DefaultValue.role("1234"));
         });


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: Unit Test Cases <!-- Unit Test Cases -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

I have noticed an overwhelming amount of `Assertions.assertEquals()`, `Assertions.assertTrue()` or other similar static method calls from the `Assertions` class. I also noticed that some test classes have static imports for `Assertions`, and some don't. I decided to clean up the code by adding static imports for `Assertions` for the classes that did not import them already.

Another minor change I made within the code cleanup was that I extracted out a huge builder chain into a separate private method in `MessageSerializationTest`, to ensure code tidiness.  