### PR TITLE
Add `DeferrableInteractionCallbackAction`

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/interactions/DeferrableInteractionCallbackAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/interactions/DeferrableInteractionCallbackAction.java
@@ -17,17 +17,19 @@
 package net.dv8tion.jda.api.requests.restaction.interactions;
 
 import net.dv8tion.jda.api.interactions.InteractionHook;
-import net.dv8tion.jda.api.requests.FluentRestAction;
-import net.dv8tion.jda.api.utils.messages.MessageEditRequest;
 
 import javax.annotation.Nonnull;
 
 /**
- * A {@link InteractionCallbackAction} which can be used to edit the message for an interaction.
+ * A callback action which comes from a deferrable {@link net.dv8tion.jda.api.interactions.Interaction Interaction}.
  */
-public interface MessageEditCallbackAction extends DeferrableInteractionCallbackAction<InteractionHook>, MessageEditRequest<MessageEditCallbackAction>, FluentRestAction<InteractionHook, MessageEditCallbackAction>
+public interface DeferrableInteractionCallbackAction<T> extends InteractionCallbackAction<T>
 {
+    /**
+     * The {@link InteractionHook} of this deferrable action.
+     *
+     * @return The interaction hook
+     */
     @Nonnull
-    @Override
-    MessageEditCallbackAction closeResources();
+    InteractionHook getHook();
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/interactions/ReplyCallbackAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/interactions/ReplyCallbackAction.java
@@ -27,7 +27,7 @@ import javax.annotation.Nonnull;
  * A {@link InteractionCallbackAction} which can be used to send a message reply for an interaction.
  * <br>You can use {@link #setEphemeral(boolean)} to hide this message from other users.
  */
-public interface ReplyCallbackAction extends InteractionCallbackAction<InteractionHook>, MessageCreateRequest<ReplyCallbackAction>, FluentRestAction<InteractionHook, ReplyCallbackAction>
+public interface ReplyCallbackAction extends DeferrableInteractionCallbackAction<InteractionHook>, MessageCreateRequest<ReplyCallbackAction>, FluentRestAction<InteractionHook, ReplyCallbackAction>
 {
     @Nonnull
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/DeferrableCallbackActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/DeferrableCallbackActionImpl.java
@@ -19,9 +19,12 @@ package net.dv8tion.jda.internal.requests.restaction.interactions;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.requests.Request;
 import net.dv8tion.jda.api.requests.Response;
+import net.dv8tion.jda.api.requests.restaction.interactions.DeferrableInteractionCallbackAction;
 import net.dv8tion.jda.internal.interactions.InteractionHookImpl;
 
-public abstract class DeferrableCallbackActionImpl extends InteractionCallbackImpl<InteractionHook>
+import javax.annotation.Nonnull;
+
+public abstract class DeferrableCallbackActionImpl extends InteractionCallbackImpl<InteractionHook> implements DeferrableInteractionCallbackAction<InteractionHook>
 {
     protected final InteractionHookImpl hook;
 
@@ -29,6 +32,13 @@ public abstract class DeferrableCallbackActionImpl extends InteractionCallbackIm
     {
         super(hook.getInteraction());
         this.hook = hook;
+    }
+
+    @Nonnull
+    @Override
+    public InteractionHook getHook()
+    {
+        return hook;
     }
 
     //Here we intercept the responses and forward this information to our followup hook


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR adds `DeferrableInteractionCallbackAction`, which is extended by `ReplyCallbackAction` and `MessageEditCallbackAction`, allowing to retrieve the `InteractionHook` when replying/editing a message with an interaction.

My use case is to create extensions such as:
```kt
fun <R> DeferrableInteractionCallbackAction<R>.deleteAfter(duration: Duration): RestAction<R> =
    delay(duration).onSuccess { hook.deleteOriginal() }
```
