### PR TITLE
Fix skipping in thread pagination

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/ThreadChannelPaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/ThreadChannelPaginationAction.java
@@ -78,4 +78,14 @@ public interface ThreadChannelPaginationAction extends PaginationAction<ThreadCh
     {
         return getChannel().getGuild();
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <b>Note:</b> When paginating over public and not-joined private threads,
+     * this skips based on {@link ThreadChannel#getTimeArchiveInfoLastModified() the archive timestamp}.
+     */
+    @Nonnull
+    @Override
+    ThreadChannelPaginationAction skipTo(long id);
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
@@ -14,6 +14,7 @@ import net.dv8tion.jda.api.utils.TimeUtil;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
+import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
@@ -100,7 +101,7 @@ public class ThreadChannelPaginationActionImpl extends PaginationActionImpl<Thre
 
                 try
                 {
-                    ThreadChannel thread = builder.createThreadChannel(threadObj, getGuild().getIdLong());
+                    ThreadChannel thread = builder.createThreadChannel((GuildImpl) getGuild(), threadObj, getGuild().getIdLong(), false);
                     list.add(thread);
 
                     if (this.useCache)

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.requests.Request;
 import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.api.requests.Route;
 import net.dv8tion.jda.api.requests.restaction.pagination.ThreadChannelPaginationAction;
+import net.dv8tion.jda.api.utils.TimeUtil;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
@@ -59,19 +60,16 @@ public class ThreadChannelPaginationActionImpl extends PaginationActionImpl<Thre
         if (useID)
             return Long.toUnsignedString(lastId);
 
-        if (order == PaginationOrder.FORWARD && lastId == 0)
-        {
-            // first second of 2015 aka discords epoch, hard coding something older makes no sense to me
-            return "2015-01-01T00:00:00.000";
-        }
-
-        // this should be redundant, due to calling this with PaginationAction#getLast() as last param,
-        // but let's have this here.
-        if (last == null)
+        if (last != null)
+            // If threads were retrieved
+            // OffsetDateTime#toString() is defined to be ISO8601, needs no helper method.
+            return last.getTimeArchiveInfoLastModified().toString();
+        else if (lastId != 0)
+            // If the user skipped ahead
+            return TimeUtil.getTimeCreated(lastId).toString();
+        else
+            // If we just started paginating
             return OffsetDateTime.now(ZoneOffset.UTC).toString();
-
-        // OffsetDateTime#toString() is defined to be ISO8601, needs no helper method.
-        return last.getTimeArchiveInfoLastModified().toString();
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Attempts to fix thread pagination when using `skipTo`, also stops archived threads from being cached, since I assume they would never get removed