### PR TITLE
Fix `CommandInteractionPayload#getCommandString` in autocomplete interactions

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/CommandInteractionPayload.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/CommandInteractionPayload.java
@@ -149,6 +149,26 @@ public interface CommandInteractionPayload extends Interaction
         for (OptionMapping o : getOptions())
         {
             builder.append(" ").append(o.getName()).append(": ");
+            // Discord doesn't send the resolved entities on autocomplete interactions
+            if (this instanceof CommandAutoCompleteInteraction)
+            {
+                switch (o.getType())
+                {
+                case CHANNEL:
+                    builder.append("<#").append(o.getAsLong()).append(">");
+                    continue;
+                case USER:
+                    builder.append("<@").append(o.getAsLong()).append(">");
+                    continue;
+                case ROLE:
+                    builder.append("<@&").append(o.getAsLong()).append(">");
+                    continue;
+                case MENTIONABLE:
+                    builder.append(o.getAsLong());
+                    continue;
+                }
+            }
+
             switch (o.getType())
             {
             case CHANNEL:

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/CommandInteractionPayload.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/CommandInteractionPayload.java
@@ -155,14 +155,8 @@ public interface CommandInteractionPayload extends Interaction
                 switch (o.getType())
                 {
                 case CHANNEL:
-                    builder.append("<#").append(o.getAsLong()).append(">");
-                    continue;
                 case USER:
-                    builder.append("<@").append(o.getAsLong()).append(">");
-                    continue;
                 case ROLE:
-                    builder.append("<@&").append(o.getAsLong()).append(">");
-                    continue;
                 case MENTIONABLE:
                     builder.append(o.getAsLong());
                     continue;


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

When printing a command string, in an autocomplete interaction, an `IllegalStateException` could occur when an entity is in that command, as Discord does not send resolved entities there