### PR TITLE
Adds support for user's avatar decorations

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Member.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Member.java
@@ -293,6 +293,9 @@ public interface Member extends IMentionable, IPermissionHolder, UserSnowflake
         return avatarUrl == null ? null : new ImageProxy(avatarUrl);
     }
 
+    @Nullable
+    User.AvatarDecoration getAvatarDecoration();
+
     /**
      * The URL for the member's effective avatar image.
      * If they do not have a per guild avatar set, this will return the URL of

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -89,9 +89,7 @@ public interface User extends UserSnowflake
     String DEFAULT_AVATAR_URL = "https://cdn.discordapp.com/embed/avatars/%s.png";
     /** Template for {@link Profile#getBannerUrl()} */
     String BANNER_URL = "https://cdn.discordapp.com/banners/%s/%s.%s";
-    /**
-     * Template for {@link AvatarDecoration#getDecorationAvatarUrl()}
-     */
+    /** Template for {@link AvatarDecoration#getDecorationAvatarUrl()} */
     String DECORATION_AVATAR_URL = "https://cdn.discordapp.com/avatar-decoration-presets/%s.png";
 
     /** Used to keep consistency between color values used in the API */

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.entities.UserSnowflakeImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EntityString;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -526,6 +527,15 @@ public interface User extends UserSnowflake
         public ImageProxy getDecorationAvatar()
         {
             return new ImageProxy(getDecorationAvatarUrl());
+        }
+
+        @Override
+        public String toString()
+        {
+            return new EntityString(this)
+                    .addMetadata("decorationAvatarId", decorationAvatarId)
+                    .addMetadata("skuId", skuId)
+                    .toString();
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -89,6 +89,10 @@ public interface User extends UserSnowflake
     String DEFAULT_AVATAR_URL = "https://cdn.discordapp.com/embed/avatars/%s.png";
     /** Template for {@link Profile#getBannerUrl()} */
     String BANNER_URL = "https://cdn.discordapp.com/banners/%s/%s.%s";
+    /**
+     * Template for {@link AvatarDecoration#getDecorationAvatarUrl()}
+     */
+    String DECORATION_AVATAR_URL = "https://cdn.discordapp.com/avatar-decoration-presets/%s.png";
 
     /** Used to keep consistency between color values used in the API */
     int DEFAULT_ACCENT_COLOR_RAW = 0x1FFFFFFF; // java.awt.Color fills the MSB with FF, we just use 1F to provide better consistency
@@ -362,6 +366,14 @@ public interface User extends UserSnowflake
     int getFlagsRaw();
 
     /**
+     * Returns the possibly-null {@link AvatarDecoration} of this user. If the user has not set a decoration avatar, this will return null.
+     *
+     * @return The possibly-null avatar decoration of this user
+     */
+    @Nullable
+    AvatarDecoration getAvatarDecoration();
+
+    /**
      * Represents the information contained in a {@link User User}'s profile.
      *
      * @since 4.3.0
@@ -453,6 +465,53 @@ public interface User extends UserSnowflake
                     .addMetadata("accentColor", accentColor)
                     .toString();
         }
+    }
+
+    /**
+     * Represents the information contained in a {@link User User}'s profile decoration.
+     */
+    class AvatarDecoration {
+
+        private final String decorationAvatarId;
+        private final String skuId;
+
+        public AvatarDecoration(String decorationAvatarId, String skuId) {
+            this.decorationAvatarId = decorationAvatarId;
+            this.skuId = skuId;
+        }
+
+        /**
+         * The never-null SKU id of the {@link User User} decoration avatar.
+         *
+         * @return The never-null SKU id of the {@link User User} decoration avatar.
+         */
+        @Nonnull
+        public String getSkuId() {
+            return skuId;
+        }
+
+        /**
+         * The never-null avatar ID for this user's decoration avatar image.
+         *
+         * @return The never-null avatar ID for this user's decoration avatar image.
+         */
+        @Nonnull
+        public String getDecorationAvatarId() {
+            return decorationAvatarId;
+        }
+
+        /**
+         * The URL for the user's decoration avatar image.
+         *
+         * @return The never-null String containing the {@link User User} decoration avatar url.
+         *
+         * @see User#DECORATION_AVATAR_URL
+         */
+        @Nullable
+        public String getDecorationAvatarUrl() {
+            return String.format(DECORATION_AVATAR_URL, decorationAvatarId);
+        }
+
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -468,14 +468,16 @@ public interface User extends UserSnowflake
     }
 
     /**
-     * Represents the decoration avatar of a {@link User User}.
+     * Represents the avatar decoration of a {@link User User}.
      */
-    class AvatarDecoration {
+    class AvatarDecoration
+    {
 
         private final String decorationAvatarId;
         private final String skuId;
 
-        public AvatarDecoration(String decorationAvatarId, String skuId) {
+        public AvatarDecoration(String decorationAvatarId, String skuId)
+        {
             this.decorationAvatarId = decorationAvatarId;
             this.skuId = skuId;
         }
@@ -486,7 +488,8 @@ public interface User extends UserSnowflake
          * @return The never-null SKU id of the {@link User User} decoration avatar.
          */
         @Nonnull
-        public String getSkuId() {
+        public String getSkuId()
+        {
             return skuId;
         }
 
@@ -496,7 +499,8 @@ public interface User extends UserSnowflake
          * @return The never-null avatar ID for this user's decoration avatar image.
          */
         @Nonnull
-        public String getDecorationAvatarId() {
+        public String getDecorationAvatarId()
+        {
             return decorationAvatarId;
         }
 
@@ -508,7 +512,8 @@ public interface User extends UserSnowflake
          * @see User#DECORATION_AVATAR_URL
          */
         @Nullable
-        public String getDecorationAvatarUrl() {
+        public String getDecorationAvatarUrl()
+        {
             return String.format(DECORATION_AVATAR_URL, decorationAvatarId);
         }
 

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -509,12 +509,24 @@ public interface User extends UserSnowflake
          *
          * @see User#DECORATION_AVATAR_URL
          */
-        @Nullable
+        @Nonnull
         public String getDecorationAvatarUrl()
         {
             return String.format(DECORATION_AVATAR_URL, decorationAvatarId);
         }
 
+        /**
+         * Returns an {@link ImageProxy} for this user's decoration avatar.
+         *
+         * @return Never-null {@link ImageProxy} of this user's decoration avatar
+         *
+         * @see    #getDecorationAvatarUrl()
+         */
+        @Nonnull
+        public ImageProxy getDecorationAvatar()
+        {
+            return new ImageProxy(getDecorationAvatarUrl());
+        }
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -512,7 +512,7 @@ public interface User extends UserSnowflake
         @Nonnull
         public String getDecorationAvatarUrl()
         {
-            return String.format(DECORATION_AVATAR_URL, decorationAvatarId);
+            return Helpers.format(DECORATION_AVATAR_URL, decorationAvatarId);
         }
 
         /**

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -468,7 +468,7 @@ public interface User extends UserSnowflake
     }
 
     /**
-     * Represents the information contained in a {@link User User}'s profile decoration.
+     * Represents the decoration avatar of a {@link User User}.
      */
     class AvatarDecoration {
 

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateAvatarDecorationEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateAvatarDecorationEvent.java
@@ -1,0 +1,58 @@
+package net.dv8tion.jda.api.events.guild.member.update;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.User;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} updated their {@link net.dv8tion.jda.api.entities.Guild Guild} {@link User.AvatarDecoration avatar decoration}.
+ *
+ * <p>Can be used to retrieve members who change their per guild avatar decoration, the triggering guild, the old avatar decoration and the new avatar decoration.
+ *
+ * <p>Identifier: {@code avatar_decoration}
+ *
+ * <p><b>Requirements</b><br>
+ *
+ * <p>This event requires the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent to be enabled.
+ * <br>{@link net.dv8tion.jda.api.JDABuilder#createDefault(String) createDefault(String)} and
+ * {@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disable this by default!
+ *
+ * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
+ * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
+ * member was updated and gives us the updated member object. In order to fire a specific event like this we
+ * need to have the old member cached to compare against.
+ */
+public class GuildMemberUpdateAvatarDecorationEvent extends GenericGuildMemberUpdateEvent<User.AvatarDecoration> {
+
+    public static final String IDENTIFIER = "avatar_decoration";
+
+    public GuildMemberUpdateAvatarDecorationEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, @Nullable User.AvatarDecoration next)
+    {
+        super(api, responseNumber, member, member.getAvatarDecoration(), next, IDENTIFIER);
+    }
+
+    /**
+     * The old avatar decoration
+     *
+     * @return The old avatar decoration
+     */
+    @Nullable
+    public User.AvatarDecoration getOldAvatarDecoration()
+    {
+        return getOldValue();
+    }
+
+    /**
+     * The new avatar decoration
+     *
+     * @return The new avatar decoration
+     */
+    @Nullable
+    public User.AvatarDecoration getNewAvatarDecoration()
+    {
+        return getNewValue();
+    }
+
+}

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateAvatarDecorationEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateAvatarDecorationEvent.java
@@ -1,0 +1,55 @@
+package net.dv8tion.jda.api.events.user.update;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.User;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Indicates that the {@link net.dv8tion.jda.api.entities.User.AvatarDecoration AvatarDecoration} of a {@link net.dv8tion.jda.api.entities.User User} changed.
+ *
+ * <p>Can be used to retrieve the User who changed their avatar and their previous Avatar Decoration object.
+ *
+ * <p>Identifier: {@code avatar_decoration}
+ *
+ * <p><b>Requirements</b><br>
+ *
+ * <p>This event requires the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent to be enabled.
+ * <br>{@link net.dv8tion.jda.api.JDABuilder#createDefault(String) createDefault(String)} and
+ * {@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disable this by default!
+ *
+ * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
+ * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
+ * member was updated and gives us the updated member object. In order to fire a specific event like this we
+ * need to have the old member cached to compare against.
+ */
+public class UserUpdateAvatarDecorationEvent extends GenericUserUpdateEvent<User.AvatarDecoration>
+{
+    public static final String IDENTIFIER = "avatar_decoration";
+
+    public UserUpdateAvatarDecorationEvent(@NotNull JDA api, long responseNumber, @NotNull User user, @Nullable User.AvatarDecoration oldAvatarDecoration)
+    {
+        super(api, responseNumber, user, oldAvatarDecoration, user.getAvatarDecoration(), IDENTIFIER);
+    }
+
+    /**
+     * The old avatar decoration
+     * @return The old avatar decoration
+     */
+    @Nullable
+    public User.AvatarDecoration getOldAvatarDecoration()
+    {
+        return getOldValue();
+    }
+
+    /**
+     * The new avatar decoration
+     * @return The new avatar decoration
+     */
+    @Nullable
+    public User.AvatarDecoration getNewAvatarDecoration()
+    {
+        return getNewValue();
+    }
+
+}

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -313,6 +313,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onGuildMemberUpdate(@Nonnull GuildMemberUpdateEvent event) {}
     public void onGuildMemberUpdateNickname(@Nonnull GuildMemberUpdateNicknameEvent event) {}
     public void onGuildMemberUpdateAvatar(@Nonnull GuildMemberUpdateAvatarEvent event) {}
+    public void onGuildMemberUpdateAvatarDecoration(@Nonnull GuildMemberUpdateAvatarDecorationEvent event) {}
     public void onGuildMemberUpdateBoostTime(@Nonnull GuildMemberUpdateBoostTimeEvent event) {}
     public void onGuildMemberUpdatePending(@Nonnull GuildMemberUpdatePendingEvent event) {}
     public void onGuildMemberUpdateFlags(@Nonnull GuildMemberUpdateFlagsEvent event) {}

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -164,6 +164,7 @@ public abstract class ListenerAdapter implements EventListener
     @ForRemoval
     public void onUserUpdateDiscriminator(@Nonnull UserUpdateDiscriminatorEvent event) {}
     public void onUserUpdateAvatar(@Nonnull UserUpdateAvatarEvent event) {}
+    public void onUserUpdateAvatarDecoration(@Nonnull UserUpdateAvatarDecorationEvent event) {}
     public void onUserUpdateOnlineStatus(@Nonnull UserUpdateOnlineStatusEvent event) {}
     public void onUserUpdateActivityOrder(@Nonnull UserUpdateActivityOrderEvent event) {}
     public void onUserUpdateFlags(@Nonnull UserUpdateFlagsEvent event) {}

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -486,6 +486,10 @@ public class EntityBuilder
         short newDiscriminator = Short.parseShort(user.getString("discriminator", "0"));
         String oldAvatar = userObj.getAvatarId();
         String newAvatar = user.getString("avatar", null);
+        User.AvatarDecoration oldAvatarDecoration = userObj.getAvatarDecoration();
+        User.AvatarDecoration newAvatarDecoration = user.optObject("avatar_decoration_data")
+                .map(o -> new User.AvatarDecoration(o.getString("asset"), o.getString("sku_id")))
+                .orElse(null);
         int oldFlags = userObj.getFlagsRaw();
         int newFlags = user.getInt("public_flags", 0);
 
@@ -526,6 +530,15 @@ public class EntityBuilder
                 new UserUpdateAvatarEvent(
                     jda, responseNumber,
                     userObj, oldAvatar));
+        }
+
+        if (!Objects.equals(oldAvatarDecoration, newAvatarDecoration))
+        {
+            userObj.setAvatarDecoration(newAvatarDecoration);
+            jda.handleEvent(
+                new UserUpdateAvatarDecorationEvent(
+                    jda, responseNumber,
+                    userObj, oldAvatarDecoration));
         }
 
         if (oldFlags != newFlags)

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -633,6 +633,11 @@ public class EntityBuilder
             if (!memberJson.isNull("flags"))
                 member.setFlags(memberJson.getInt("flags"));
 
+            User.AvatarDecoration avatarDecoration = memberJson.optObject("avatar_decoration_data")
+                    .map(o -> new User.AvatarDecoration(o.getString("asset"), o.getString("sku_id")))
+                    .orElse(null);
+            member.setAvatarDecoration(avatarDecoration);
+
             long boostTimestamp = memberJson.isNull("premium_since")
                 ? 0
                 : Helpers.toTimestamp(memberJson.getString("premium_since"));
@@ -759,6 +764,22 @@ public class EntityBuilder
                     new GuildMemberUpdateBoostTimeEvent(
                         getJDA(), responseNumber,
                         member, oldTime));
+            }
+        }
+        if (content.hasKey("avatar_decoration_data"))
+        {
+            DataObject avatarDecorationData = content.getObject("avatar_decoration_data");
+            User.AvatarDecoration oldAvatarDecoration = member.getAvatarDecoration();
+            User.AvatarDecoration newAvatarDecoration = new User.AvatarDecoration(
+                avatarDecorationData.getString("asset"),
+                avatarDecorationData.getString("sku_id"));
+            if (!Objects.equals(oldAvatarDecoration, newAvatarDecoration))
+            {
+                member.setAvatarDecoration(newAvatarDecoration);
+                getJDA().handleEvent(
+                    new GuildMemberUpdateAvatarDecorationEvent(
+                        getJDA(), responseNumber,
+                        member, oldAvatarDecoration));
             }
         }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -450,9 +450,7 @@ public class EntityBuilder
             ? new User.Profile(id, user.getString("banner", null), user.getInt("accent_color", User.DEFAULT_ACCENT_COLOR_RAW))
             : null;
 
-        User.AvatarDecoration avatarDecoration = user.isNull("avatar_decoration_data")
-                ? null
-                : new User.AvatarDecoration(user.getObject("avatar_decoration_data").getString("asset"), user.getObject("avatar_decoration_data").getString("sku_id"));
+        User.AvatarDecoration avatarDecoration = user.optObject("avatar_decoration_data").map(o -> new User.AvatarDecoration(o.getString("asset"), o.getString("sku_id"))).orElse(null);
 
         if (newUser)
         {

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -450,6 +450,10 @@ public class EntityBuilder
             ? new User.Profile(id, user.getString("banner", null), user.getInt("accent_color", User.DEFAULT_ACCENT_COLOR_RAW))
             : null;
 
+        User.AvatarDecoration avatarDecoration = user.isNull("avatar_decoration_data")
+                ? null
+                : new User.AvatarDecoration(user.getObject("avatar_decoration_data").getString("asset"), user.getObject("avatar_decoration_data").getString("sku_id"));
+
         if (newUser)
         {
             // Initial creation
@@ -457,6 +461,7 @@ public class EntityBuilder
                    .setGlobalName(user.getString("global_name", null))
                    .setDiscriminator(Short.parseShort(user.getString("discriminator", "0")))
                    .setAvatarId(user.getString("avatar", null))
+                   .setAvatarDecoration(avatarDecoration)
                    .setBot(user.getBoolean("bot"))
                    .setSystem(user.getBoolean("system"))
                    .setFlags(user.getInt("public_flags", 0))

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -450,7 +450,9 @@ public class EntityBuilder
             ? new User.Profile(id, user.getString("banner", null), user.getInt("accent_color", User.DEFAULT_ACCENT_COLOR_RAW))
             : null;
 
-        User.AvatarDecoration avatarDecoration = user.optObject("avatar_decoration_data").map(o -> new User.AvatarDecoration(o.getString("asset"), o.getString("sku_id"))).orElse(null);
+        User.AvatarDecoration avatarDecoration = user.optObject("avatar_decoration_data")
+                .map(o -> new User.AvatarDecoration(o.getString("asset"), o.getString("sku_id")))
+                .orElse(null);
 
         if (newUser)
         {

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -53,6 +53,7 @@ public class MemberImpl implements Member
     private User user;
     private String nickname;
     private String avatarId;
+    private User.AvatarDecoration avatarDecoration;
     private long joinDate, boostDate, timeOutEnd;
     private boolean pending = false;
     private int flags;
@@ -188,6 +189,13 @@ public class MemberImpl implements Member
     public String getAvatarId()
     {
         return avatarId;
+    }
+
+    @Nullable
+    @Override
+    public User.AvatarDecoration getAvatarDecoration()
+    {
+        return avatarDecoration;
     }
 
     @Nonnull
@@ -440,6 +448,12 @@ public class MemberImpl implements Member
     public MemberImpl setFlags(int flags)
     {
         this.flags = flags;
+        return this;
+    }
+
+    public MemberImpl setAvatarDecoration(User.AvatarDecoration avatarDecoration)
+    {
+        this.avatarDecoration = avatarDecoration;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -45,6 +45,7 @@ public class UserImpl extends UserSnowflakeImpl implements User
     protected String name;
     protected String globalName;
     protected String avatarId;
+    protected AvatarDecoration avatarDecoration;
     protected Profile profile;
     protected long privateChannelId = 0L;
     protected boolean bot;
@@ -191,6 +192,13 @@ public class UserImpl extends UserSnowflakeImpl implements User
         return flags;
     }
 
+    @Nullable
+    @Override
+    public User.AvatarDecoration getAvatarDecoration()
+    {
+        return avatarDecoration;
+    }
+
     @Override
     public String toString()
     {
@@ -222,6 +230,12 @@ public class UserImpl extends UserSnowflakeImpl implements User
     public UserImpl setAvatarId(String avatarId)
     {
         this.avatarId = avatarId;
+        return this;
+    }
+
+    public UserImpl setAvatarDecoration(AvatarDecoration avatarDecoration)
+    {
+        this.avatarDecoration = avatarDecoration;
         return this;
     }
 


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds support for the user's decoration avatar. Discord docs are outdated about the user's object, check [this PR](https://github.com/discord/discord-api-docs/pull/6464) for the "updated" endpoints.

> It's my first PR there, hope I did not break anything 😓