### PR TITLE
Also use _trace from resumed event

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -985,6 +985,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 case "RESUMED":
                     reconnectTimeoutS = 2;
                     sentAuthInfo = true;
+                    traceMetadata = content.opt("_trace").map(String::valueOf).orElse(traceMetadata);
                     if (!processingReady)
                     {
                         initiating = false;


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Updates the trace of the websocket client when a RESUMED event is received
