### PR TITLE
Add more static analyzer annotations

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -16,7 +16,6 @@
 
 package net.dv8tion.jda.api;
 
-import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.annotations.Incubating;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.Channel;
@@ -50,6 +49,7 @@ import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EntityString;
 import net.dv8tion.jda.internal.utils.Helpers;
 import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -933,6 +933,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @return Immutable list of all created AudioManager instances
      */
     @Nonnull
+    @Unmodifiable
     default List<AudioManager> getAudioManagers()
     {
         return getAudioManagerCache().asList();
@@ -966,6 +967,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @return Immutable list of all {@link net.dv8tion.jda.api.entities.User Users} that are visible to JDA.
      */
     @Nonnull
+    @Unmodifiable
     default List<User> getUsers()
     {
         return getUserCache().asList();
@@ -1031,14 +1033,9 @@ public interface JDA extends IGuildChannelContainer<Channel>
      *         If the provided tag is null or not in the described format
      *
      * @return The {@link net.dv8tion.jda.api.entities.User} for the discord tag or null if no user has the provided tag
-     *
-     * @deprecated This will become obsolete in the future.
-     *             Discriminators are being phased out and replaced by globally unique usernames.
-     *             For more information, see <a href="https://support.discord.com/hc/en-us/articles/12620128861463" target="_blank">New Usernames &amp; Display Names</a>.
      */
     @Nullable
-    @Deprecated
-    @ForRemoval
+    @Incubating
     default User getUserByTag(@Nonnull String tag)
     {
         Checks.notNull(tag, "Tag");
@@ -1070,14 +1067,9 @@ public interface JDA extends IGuildChannelContainer<Channel>
      *         If the provided arguments are null or not in the described format
      *
      * @return The {@link net.dv8tion.jda.api.entities.User} for the discord tag or null if no user has the provided tag
-     *
-     * @deprecated This will become obsolete in the future.
-     *             Discriminators are being phased out and replaced by globally unique usernames.
-     *             For more information, see <a href="https://support.discord.com/hc/en-us/articles/12620128861463" target="_blank">New Usernames &amp; Display Names</a>.
      */
     @Nullable
-    @Deprecated
-    @ForRemoval
+    @Incubating
     default User getUserByTag(@Nonnull String username, @Nonnull String discriminator)
     {
         Checks.notNull(username, "Username");
@@ -1112,6 +1104,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      */
     @Nonnull
     @Incubating
+    @Unmodifiable
     default List<User> getUsersByName(@Nonnull String name, boolean ignoreCase)
     {
         return getUserCache().getElementsByName(name, ignoreCase);
@@ -1128,6 +1121,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @see    Guild#isMember(UserSnowflake)
      */
     @Nonnull
+    @Unmodifiable
     List<Guild> getMutualGuilds(@Nonnull User... users);
 
     /**
@@ -1139,6 +1133,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @return Immutable list of all {@link Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.User Users} in them.
      */
     @Nonnull
+    @Unmodifiable
     List<Guild> getMutualGuilds(@Nonnull Collection<User> users);
 
     /**
@@ -1229,6 +1224,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @return Possibly-empty immutable list of all the {@link Guild Guilds} that this account is connected to.
      */
     @Nonnull
+    @Unmodifiable
     default List<Guild> getGuilds()
     {
         return getGuildCache().asList();
@@ -1279,6 +1275,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @return Possibly-empty immutable list of all the {@link Guild Guilds} that all have the same name as the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<Guild> getGuildsByName(@Nonnull String name, boolean ignoreCase)
     {
         return getGuildCache().getElementsByName(name, ignoreCase);
@@ -1330,6 +1327,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @return Immutable List of all visible Roles
      */
     @Nonnull
+    @Unmodifiable
     default List<Role> getRoles()
     {
         return getRoleCache().asList();
@@ -1383,10 +1381,12 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @return Immutable List of all Roles matching the parameters provided.
      */
     @Nonnull
+    @Unmodifiable
     default List<Role> getRolesByName(@Nonnull String name, boolean ignoreCase)
     {
         return getRoleCache().getElementsByName(name, ignoreCase);
     }
+
     /**
      * {@link SnowflakeCacheView} of
      * all cached {@link ScheduledEvent ScheduledEvents} visible to this JDA session.
@@ -1412,6 +1412,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @return Possibly-empty immutable list of all known {@link ScheduledEvent ScheduledEvents}.
      */
     @Nonnull
+    @Unmodifiable
     default List<ScheduledEvent> getScheduledEvents()
     {
         return getScheduledEventCache().asList();
@@ -1474,6 +1475,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      *         same name as the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<ScheduledEvent> getScheduledEventsByName(@Nonnull String name, boolean ignoreCase)
     {
         return getScheduledEventCache().getElementsByName(name, ignoreCase);
@@ -1499,6 +1501,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @return Possibly-empty list of all {@link PrivateChannel PrivateChannels}.
      */
     @Nonnull
+    @Unmodifiable
     default List<PrivateChannel> getPrivateChannels()
     {
         return getPrivateChannelCache().asList();
@@ -1634,6 +1637,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @return An immutable list of Custom Emojis (which may or may not be available to usage).
      */
     @Nonnull
+    @Unmodifiable
     default List<RichCustomEmoji> getEmojis()
     {
         return getEmojiCache().asList();
@@ -1696,6 +1700,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      *         name as the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<RichCustomEmoji> getEmojisByName(@Nonnull String name, boolean ignoreCase)
     {
         return getEmojiCache().getElementsByName(name, ignoreCase);
@@ -1734,7 +1739,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      */
     @Nonnull
     @CheckReturnValue
-    RestAction<List<StickerPack>> retrieveNitroStickerPacks();
+    RestAction<@Unmodifiable List<StickerPack>> retrieveNitroStickerPacks();
 
     /**
      * The EventManager used by this JDA instance.

--- a/src/main/java/net/dv8tion/jda/api/audit/AuditLogEntry.java
+++ b/src/main/java/net/dv8tion/jda/api/audit/AuditLogEntry.java
@@ -27,6 +27,7 @@ import net.dv8tion.jda.internal.entities.UserImpl;
 import net.dv8tion.jda.internal.entities.WebhookImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EntityString;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -240,6 +241,7 @@ public class AuditLogEntry implements ISnowflake
      * @return Possibly-empty, never-null immutable list of {@link AuditLogChange AuditLogChanges}
      */
     @Nonnull
+    @Unmodifiable
     public List<AuditLogChange> getChangesForKeys(@Nonnull AuditLogKey... keys)
     {
         Checks.notNull(keys, "Keys");
@@ -329,6 +331,7 @@ public class AuditLogEntry implements ISnowflake
      * @return Unmodifiable list of representative values
      */
     @Nonnull
+    @Unmodifiable
     public List<Object> getOptions(@Nonnull AuditLogOption... options)
     {
         Checks.notNull(options, "Options");

--- a/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.utils.ImageProxy;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -313,6 +314,7 @@ public interface ApplicationInfo extends ISnowflake
      * @return Immutable list containing the tags of this bot's application
      */
     @Nonnull
+    @Unmodifiable
     List<String> getTags();
 
     /**
@@ -323,6 +325,7 @@ public interface ApplicationInfo extends ISnowflake
      * @return Immutable list containing the OAuth2 redirect URIs of this bot's application
      */
     @Nonnull
+    @Unmodifiable
     List<String> getRedirectUris();
 
     /**
@@ -366,6 +369,7 @@ public interface ApplicationInfo extends ISnowflake
      * @return Immutable list of scopes the default authorization URL is set up with.
      */
     @Nonnull
+    @Unmodifiable
     List<String> getScopes();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/ApplicationTeam.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ApplicationTeam.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.api.entities;
 import net.dv8tion.jda.api.utils.ImageProxy;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -107,6 +108,7 @@ public interface ApplicationTeam extends ISnowflake
      * @return Immutable list of team members
      */
     @Nonnull
+    @Unmodifiable
     List<TeamMember> getMembers();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -68,6 +68,7 @@ import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EntityString;
 import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.concurrent.task.GatewayTask;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -415,7 +416,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      */
     @Nonnull
     @CheckReturnValue
-    RestAction<List<AutoModRule>> retrieveAutoModRules();
+    RestAction<@Unmodifiable List<AutoModRule>> retrieveAutoModRules();
 
     /**
      * Retrieves the {@link AutoModRule} for the provided id.
@@ -692,6 +693,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @see <a target="_blank" href="https://discord.com/developers/docs/resources/guild#guild-object-guild-features">List of Features</a>
      */
     @Nonnull
+    @Unmodifiable
     Set<String> getFeatures();
 
     /**
@@ -907,6 +909,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return Immutable list of members who boost this guild
      */
     @Nonnull
+    @Unmodifiable
     List<Member> getBoosters();
 
     /**
@@ -1282,6 +1285,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @see    #loadMembers()
      */
     @Nonnull
+    @Unmodifiable
     default List<Member> getMembers()
     {
         return getMemberCache().asList();
@@ -1311,6 +1315,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      */
     @Nonnull
     @Incubating
+    @Unmodifiable
     default List<Member> getMembersByName(@Nonnull String name, boolean ignoreCase)
     {
         return getMemberCache().getElementsByUsername(name, ignoreCase);
@@ -1334,6 +1339,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @see    #retrieveMembersByPrefix(String, int)
      */
     @Nonnull
+    @Unmodifiable
     default List<Member> getMembersByNickname(@Nullable String nickname, boolean ignoreCase)
     {
         return getMemberCache().getElementsByNickname(nickname, ignoreCase);
@@ -1360,6 +1366,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @see    #retrieveMembersByPrefix(String, int)
      */
     @Nonnull
+    @Unmodifiable
     default List<Member> getMembersByEffectiveName(@Nonnull String name, boolean ignoreCase)
     {
         return getMemberCache().getElementsByName(name, ignoreCase);
@@ -1384,6 +1391,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @see    #findMembersWithRoles(Role...)
      */
     @Nonnull
+    @Unmodifiable
     default List<Member> getMembersWithRoles(@Nonnull Role... roles)
     {
         Checks.notNull(roles, "Roles");
@@ -1409,6 +1417,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @see    #findMembersWithRoles(Collection)
      */
     @Nonnull
+    @Unmodifiable
     default List<Member> getMembersWithRoles(@Nonnull Collection<Role> roles)
     {
         Checks.noneNull(roles, "Roles");
@@ -1463,6 +1472,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return Possibly-empty immutable list of all ScheduledEvent names that match the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<ScheduledEvent> getScheduledEventsByName(@Nonnull String name, boolean ignoreCase)
     {
         return getScheduledEventCache().getElementsByName(name, ignoreCase);
@@ -1526,6 +1536,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return Possibly-empty immutable List of {@link ScheduledEvent ScheduledEvents}.
      */
     @Nonnull
+    @Unmodifiable
     default List<ScheduledEvent> getScheduledEvents()
     {
         return getScheduledEventCache().asList();
@@ -1599,6 +1610,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @see    #getChannels(boolean)
      */
     @Nonnull
+    @Unmodifiable
     default List<GuildChannel> getChannels()
     {
         return getChannels(true);
@@ -1628,6 +1640,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @see    #getChannels()
      */
     @Nonnull
+    @Unmodifiable
     List<GuildChannel> getChannels(boolean includeHidden);
 
     /**
@@ -1680,6 +1693,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return An immutable List of {@link Role Roles}.
      */
     @Nonnull
+    @Unmodifiable
     default List<Role> getRoles()
     {
         return getRoleCache().asList();
@@ -1698,6 +1712,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return Possibly-empty immutable list of all Role names that match the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<Role> getRolesByName(@Nonnull String name, boolean ignoreCase)
     {
         return getRoleCache().getElementsByName(name, ignoreCase);
@@ -1893,6 +1908,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @see    #retrieveEmojis()
      */
     @Nonnull
+    @Unmodifiable
     default List<RichCustomEmoji> getEmojis()
     {
         return getEmojiCache().asList();
@@ -1915,6 +1931,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return Possibly-empty immutable list of all Emojis that match the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<RichCustomEmoji> getEmojisByName(@Nonnull String name, boolean ignoreCase)
     {
         return getEmojiCache().getElementsByName(name, ignoreCase);
@@ -1995,6 +2012,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @see    #retrieveStickers()
      */
     @Nonnull
+    @Unmodifiable
     default List<GuildSticker> getStickers()
     {
         return getStickerCache().asList();
@@ -2015,6 +2033,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return Possibly-empty immutable list of all Stickers that match the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<GuildSticker> getStickersByName(@Nonnull String name, boolean ignoreCase)
     {
         return getStickerCache().getElementsByName(name, ignoreCase);
@@ -2044,7 +2063,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      */
     @Nonnull
     @CheckReturnValue
-    RestAction<List<RichCustomEmoji>> retrieveEmojis();
+    RestAction<@Unmodifiable List<RichCustomEmoji>> retrieveEmojis();
 
     /**
      * Retrieves a custom emoji together with its respective creator.
@@ -2144,7 +2163,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      */
     @Nonnull
     @CheckReturnValue
-    RestAction<List<GuildSticker>> retrieveStickers();
+    RestAction<@Unmodifiable List<GuildSticker>> retrieveStickers();
 
     /**
      * Attempts to retrieve a {@link GuildSticker} object for this guild based on the provided snowflake reference.
@@ -2480,7 +2499,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      */
     @Nonnull
     @CheckReturnValue
-    RestAction<List<Invite>> retrieveInvites();
+    RestAction<@Unmodifiable List<Invite>> retrieveInvites();
 
     /**
      * Retrieves all {@link net.dv8tion.jda.api.entities.templates.Template Templates} for this guild.
@@ -2495,7 +2514,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      */
     @Nonnull
     @CheckReturnValue
-    RestAction<List<Template>> retrieveTemplates();
+    RestAction<@Unmodifiable List<Template>> retrieveTemplates();
 
     /**
      * Used to create a new {@link net.dv8tion.jda.api.entities.templates.Template Template} for this Guild.
@@ -2543,7 +2562,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      */
     @Nonnull
     @CheckReturnValue
-    RestAction<List<Webhook>> retrieveWebhooks();
+    RestAction<@Unmodifiable List<Webhook>> retrieveWebhooks();
 
     /**
      * Retrieves the {@link GuildWelcomeScreen welcome screen} for this Guild.
@@ -3247,7 +3266,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
 
     @Nonnull
     @CheckReturnValue
-    RestAction<List<ThreadChannel>> retrieveActiveThreads();
+    RestAction<@Unmodifiable List<ThreadChannel>> retrieveActiveThreads();
 
     /**
      * Retrieves a {@link ScheduledEvent} by its ID.

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -3264,6 +3264,11 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
     @CheckReturnValue
     Task<List<Member>> retrieveMembersByPrefix(@Nonnull String prefix, int limit);
 
+    /**
+     * Retrieves the active threads in this guild.
+     *
+     * @return {@link RestAction} - List of {@link ThreadChannel}
+     */
     @Nonnull
     @CheckReturnValue
     RestAction<@Unmodifiable List<ThreadChannel>> retrieveActiveThreads();

--- a/src/main/java/net/dv8tion/jda/api/entities/Member.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Member.java
@@ -33,6 +33,7 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -183,6 +184,7 @@ public interface Member extends IMentionable, IPermissionHolder, UserSnowflake
      * @return Immutable list of {@link Activity Activities} for the user
      */
     @Nonnull
+    @Unmodifiable
     List<Activity> getActivities();
 
     /**
@@ -339,6 +341,7 @@ public interface Member extends IMentionable, IPermissionHolder, UserSnowflake
      * @see    Guild#modifyMemberRoles(Member, Collection, Collection)
      */
     @Nonnull
+    @Unmodifiable
     List<Role> getRoles();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Mentions.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Mentions.java
@@ -22,6 +22,7 @@ import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.entities.emoji.CustomEmoji;
 import net.dv8tion.jda.api.interactions.commands.SlashCommandReference;
 import org.apache.commons.collections4.Bag;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -58,6 +59,7 @@ public interface Mentions
      * @return Immutable list of mentioned users
      */
     @Nonnull
+    @Unmodifiable
     List<User> getUsers();
 
     /**
@@ -102,6 +104,7 @@ public interface Mentions
      * @return Immutable list of mentioned GuildChannels
      */
     @Nonnull
+    @Unmodifiable
     List<GuildChannel> getChannels();
 
     /**
@@ -161,6 +164,7 @@ public interface Mentions
      * @return Immutable list of mentioned GuildChannels that are of type {@code clazz}.
      */
     @Nonnull
+    @Unmodifiable
     <T extends GuildChannel> List<T> getChannels(@Nonnull Class<T> clazz);
 
     /**
@@ -210,6 +214,7 @@ public interface Mentions
      * @return immutable list of mentioned Roles
      */
     @Nonnull
+    @Unmodifiable
     List<Role> getRoles();
 
     /**
@@ -254,6 +259,7 @@ public interface Mentions
      * @return An immutable list of the Custom Emojis used (example match {@literal <:jda:230988580904763393>})
      */
     @Nonnull
+    @Unmodifiable
     List<CustomEmoji> getCustomEmojis();
 
     /**
@@ -337,6 +343,7 @@ public interface Mentions
      * @return Immutable list of mentioned slash commands, or an empty list
      */
     @Nonnull
+    @Unmodifiable
     List<SlashCommandReference> getSlashCommands();
 
     /**
@@ -387,6 +394,7 @@ public interface Mentions
      * @return Immutable list of filtered {@link net.dv8tion.jda.api.entities.IMentionable IMentionable} instances
      */
     @Nonnull
+    @Unmodifiable
     List<IMentionable> getMentions(@Nonnull Message.MentionType... types);
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -69,6 +69,7 @@ import net.dv8tion.jda.internal.utils.IOUtil;
 import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -456,6 +457,7 @@ public interface Message extends ISnowflake, Formattable
      * @return Immutable list of invite codes
      */
     @Nonnull
+    @Unmodifiable
     List<String> getInvites();
 
     /**
@@ -658,6 +660,7 @@ public interface Message extends ISnowflake, Formattable
      * @return Immutable list of {@link net.dv8tion.jda.api.entities.Message.Attachment Attachments}.
      */
     @Nonnull
+    @Unmodifiable
     List<Attachment> getAttachments();
 
     /**
@@ -668,6 +671,7 @@ public interface Message extends ISnowflake, Formattable
      * @return Immutable list of all given MessageEmbeds.
      */
     @Nonnull
+    @Unmodifiable
     List<MessageEmbed> getEmbeds();
 
     /**
@@ -683,6 +687,7 @@ public interface Message extends ISnowflake, Formattable
      * @see    #getButtonById(String)
      */
     @Nonnull
+    @Unmodifiable
     List<LayoutComponent> getComponents();
 
     /**
@@ -734,6 +739,7 @@ public interface Message extends ISnowflake, Formattable
      * @see    #getButtonById(String)
      */
     @Nonnull
+    @Unmodifiable
     default List<ActionRow> getActionRows()
     {
         return getComponents()
@@ -751,6 +757,7 @@ public interface Message extends ISnowflake, Formattable
      * @return Immutable {@link List} of {@link Button Buttons}
      */
     @Nonnull
+    @Unmodifiable
     default List<Button> getButtons()
     {
         return getComponents().stream()
@@ -797,6 +804,7 @@ public interface Message extends ISnowflake, Formattable
      * @return Immutable {@link List} of {@link Button Buttons} with the specified label
      */
     @Nonnull
+    @Unmodifiable
     default List<Button> getButtonsByLabel(@Nonnull String label, boolean ignoreCase)
     {
         Checks.notNull(label, "Label");
@@ -818,6 +826,7 @@ public interface Message extends ISnowflake, Formattable
      * @see    MessageReaction
      */
     @Nonnull
+    @Unmodifiable
     List<MessageReaction> getReactions();
 
     /**
@@ -827,6 +836,7 @@ public interface Message extends ISnowflake, Formattable
      * @return Immutable list of all StickerItems in this message.
      */
     @Nonnull
+    @Unmodifiable
     List<StickerItem> getStickers();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.api.utils.data.SerializableData;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -301,6 +302,7 @@ public class MessageEmbed implements SerializableData
      *         containing field information.
      */
     @Nonnull
+    @Unmodifiable
     public List<Field> getFields()
     {
         return fields;

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
@@ -36,6 +36,7 @@ import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import org.apache.commons.collections4.map.ListOrderedMap;
+import org.jetbrains.annotations.Unmodifiable;
 import org.slf4j.Logger;
 
 import javax.annotation.CheckReturnValue;
@@ -182,7 +183,7 @@ public class MessageHistory
      */
     @Nonnull
     @CheckReturnValue
-    public RestAction<List<Message>> retrievePast(int amount)
+    public RestAction<@Unmodifiable List<Message>> retrievePast(int amount)
     {
         if (amount > 100 || amount < 1)
             throw new IllegalArgumentException("Message retrieval limit is between 1 and 100 messages. No more, no less. Limit provided: " + amount);
@@ -260,7 +261,7 @@ public class MessageHistory
      */
     @Nonnull
     @CheckReturnValue
-    public RestAction<List<Message>> retrieveFuture(int amount)
+    public RestAction<@Unmodifiable List<Message>> retrieveFuture(int amount)
     {
         if (amount > 100 || amount < 1)
             throw new IllegalArgumentException("Message retrieval limit is between 1 and 100 messages. No more, no less. Limit provided: " + amount);
@@ -309,6 +310,7 @@ public class MessageHistory
      * @return An immutable List of Messages, sorted newest to oldest.
      */
     @Nonnull
+    @Unmodifiable
     public List<Message> getRetrievedHistory()
     {
         int size = size();

--- a/src/main/java/net/dv8tion/jda/api/entities/StageInstance.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/StageInstance.java
@@ -22,6 +22,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.StageChannel;
 import net.dv8tion.jda.api.managers.StageInstanceManager;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -79,6 +80,7 @@ public interface StageInstance extends ISnowflake
      * @return Immutable {@link List} of {@link Member Members} which can speak in this stage instance
      */
     @Nonnull
+    @Unmodifiable
     default List<Member> getSpeakers()
     {
         return getChannel().getMembers()
@@ -100,6 +102,7 @@ public interface StageInstance extends ISnowflake
      * @return Immutable {@link List} of {@link Member Members} which cannot speak in this stage instance
      */
     @Nonnull
+    @Unmodifiable
     default List<Member> getAudience()
     {
         return getChannel().getMembers()

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.entities.UserSnowflakeImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EntityString;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -321,6 +322,7 @@ public interface User extends UserSnowflake
      * @return Immutable list of all {@link net.dv8tion.jda.api.entities.Guild Guilds} that this user is a member of.
      */
     @Nonnull
+    @Unmodifiable
     List<Guild> getMutualGuilds();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IGuildChannelContainer.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IGuildChannelContainer.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.cache.ChannelCacheView;
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -300,6 +301,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return Possibly-empty immutable list of all StageChannel names that match the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<StageChannel> getStageChannelsByName(@Nonnull String name, boolean ignoreCase)
     {
         return getStageChannelCache().getElementsByName(name, ignoreCase);
@@ -371,6 +373,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return An immutable List of {@link StageChannel StageChannels}.
      */
     @Nonnull
+    @Unmodifiable
     default List<StageChannel> getStageChannels()
     {
         return getStageChannelCache().asList();
@@ -419,6 +422,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return Possibly-empty immutable list of all ThreadChannel names that match the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<ThreadChannel> getThreadChannelsByName(@Nonnull String name, boolean ignoreCase)
     {
         return getThreadChannelCache().getElementsByName(name, ignoreCase);
@@ -495,6 +499,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return An immutable List of {@link ThreadChannel ThreadChannels}.
      */
     @Nonnull
+    @Unmodifiable
     default List<ThreadChannel> getThreadChannels()
     {
         return getThreadChannelCache().asList();
@@ -543,6 +548,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return Immutable list of all categories matching the provided name
      */
     @Nonnull
+    @Unmodifiable
     default List<Category> getCategoriesByName(@Nonnull String name, boolean ignoreCase)
     {
         return getCategoryCache().getElementsByName(name, ignoreCase);
@@ -614,6 +620,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return An immutable list of all {@link Category Categories} in this Guild.
      */
     @Nonnull
+    @Unmodifiable
     default List<Category> getCategories()
     {
         return getCategoryCache().asList();
@@ -659,6 +666,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return Possibly-empty immutable list of all TextChannels names that match the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<TextChannel> getTextChannelsByName(@Nonnull String name, boolean ignoreCase)
     {
         return getTextChannelCache().getElementsByName(name, ignoreCase);
@@ -730,6 +738,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return An immutable List of all {@link TextChannel TextChannels} in this Guild.
      */
     @Nonnull
+    @Unmodifiable
     default List<TextChannel> getTextChannels()
     {
         return getTextChannelCache().asList();
@@ -775,6 +784,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return Possibly-empty immutable list of all NewsChannels names that match the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<NewsChannel> getNewsChannelsByName(@Nonnull String name, boolean ignoreCase)
     {
         return getNewsChannelCache().getElementsByName(name, ignoreCase);
@@ -846,6 +856,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return An immutable List of all {@link NewsChannel NewsChannels} in this Guild.
      */
     @Nonnull
+    @Unmodifiable
     default List<NewsChannel> getNewsChannels()
     {
         return getNewsChannelCache().asList();
@@ -891,6 +902,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return Possibly-empty immutable list of all VoiceChannel names that match the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<VoiceChannel> getVoiceChannelsByName(@Nonnull String name, boolean ignoreCase)
     {
         return getVoiceChannelCache().getElementsByName(name, ignoreCase);
@@ -962,6 +974,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return An immutable List of {@link VoiceChannel VoiceChannels}.
      */
     @Nonnull
+    @Unmodifiable
     default List<VoiceChannel> getVoiceChannels()
     {
         return getVoiceChannelCache().asList();
@@ -1006,6 +1019,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return Possibly-empty immutable list of all ForumChannel names that match the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<ForumChannel> getForumChannelsByName(@Nonnull String name, boolean ignoreCase)
     {
         return getForumChannelCache().getElementsByName(name, ignoreCase);
@@ -1076,6 +1090,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return An immutable List of {@link ForumChannel}.
      */
     @Nonnull
+    @Unmodifiable
     default List<ForumChannel> getForumChannels()
     {
         return getForumChannelCache().asList();
@@ -1120,6 +1135,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return Possibly-empty immutable list of all ForumChannel names that match the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<MediaChannel> getMediaChannelsByName(@Nonnull String name, boolean ignoreCase)
     {
         return getMediaChannelCache().getElementsByName(name, ignoreCase);
@@ -1190,6 +1206,7 @@ public interface IGuildChannelContainer<C extends Channel>
      * @return An immutable List of {@link MediaChannel}.
      */
     @Nonnull
+    @Unmodifiable
     default List<MediaChannel> getMediaChannels()
     {
         return getMediaChannelCache().asList();

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IMemberContainer.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IMemberContainer.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.Category;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -53,5 +54,6 @@ public interface IMemberContainer extends GuildChannel
      * @return An immutable List of {@link net.dv8tion.jda.api.entities.Member Members} that are in this GuildChannel.
      */
     @Nonnull
+    @Unmodifiable
     List<Member> getMembers();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IPermissionContainer.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IPermissionContainer.java
@@ -22,6 +22,7 @@ import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.managers.channel.attribute.IPermissionContainerManager;
 import net.dv8tion.jda.api.requests.restaction.PermissionOverrideAction;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -73,6 +74,7 @@ public interface IPermissionContainer extends GuildChannel
      *         for this {@link GuildChannel GuildChannel}.
      */
     @Nonnull
+    @Unmodifiable
     List<PermissionOverride> getPermissionOverrides();
 
     /**
@@ -86,6 +88,7 @@ public interface IPermissionContainer extends GuildChannel
      *         for this {@link GuildChannel GuildChannel}.
      */
     @Nonnull
+    @Unmodifiable
     default List<PermissionOverride> getMemberPermissionOverrides()
     {
         return getPermissionOverrides().stream()
@@ -102,6 +105,7 @@ public interface IPermissionContainer extends GuildChannel
      *         for this {@link GuildChannel GuildChannel}.
      */
     @Nonnull
+    @Unmodifiable
     default List<PermissionOverride> getRolePermissionOverrides()
     {
         return getPermissionOverrides().stream()

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IPostContainer.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IPostContainer.java
@@ -30,6 +30,7 @@ import net.dv8tion.jda.api.managers.channel.attribute.IPostContainerManager;
 import net.dv8tion.jda.api.requests.restaction.ForumPostAction;
 import net.dv8tion.jda.api.utils.cache.SortedSnowflakeCacheView;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -86,6 +87,7 @@ public interface IPostContainer extends IThreadContainer
      * @return Immutable {@link List} of {@link ForumTag}
      */
     @Nonnull
+    @Unmodifiable
     default List<ForumTag> getAvailableTags()
     {
         return getAvailableTagCache().asList();
@@ -111,6 +113,7 @@ public interface IPostContainer extends IThreadContainer
      * @return Immutable {@link List} of {@link ForumTag} with the given name
      */
     @Nonnull
+    @Unmodifiable
     default List<ForumTag> getAvailableTagsByName(@Nonnull String name, boolean ignoreCase)
     {
         return getAvailableTagCache().getElementsByName(name, ignoreCase);

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IThreadContainer.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IThreadContainer.java
@@ -27,6 +27,7 @@ import net.dv8tion.jda.api.requests.restaction.pagination.ThreadChannelPaginatio
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.api.utils.messages.MessageCreateData;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -56,6 +57,7 @@ public interface IThreadContainer extends GuildChannel, IPermissionContainer
      * @return Immutable list of all ThreadChannel children.
      */
     @Nonnull
+    @Unmodifiable
     default List<ThreadChannel> getThreadChannels()
     {
         return getGuild().getThreadChannelCache().applyStream(stream ->

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IWebhookContainer.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IWebhookContainer.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.WebhookAction;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -54,7 +55,7 @@ public interface IWebhookContainer extends GuildChannel
      */
     @Nonnull
     @CheckReturnValue
-    RestAction<List<Webhook>> retrieveWebhooks();
+    RestAction<@Unmodifiable List<Webhook>> retrieveWebhooks();
 
     /**
      * Creates a new {@link net.dv8tion.jda.api.entities.Webhook Webhook}.

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/Category.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/Category.java
@@ -29,6 +29,7 @@ import net.dv8tion.jda.api.requests.restaction.order.CategoryOrderAction;
 import net.dv8tion.jda.api.requests.restaction.order.ChannelOrderAction;
 import net.dv8tion.jda.api.requests.restaction.order.OrderAction;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -57,6 +58,7 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
      * @return Immutable list of all child channels
      */
     @Nonnull
+    @Unmodifiable
     default List<GuildChannel> getChannels()
     {
         return getGuild()
@@ -76,6 +78,7 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
      * @return Immutable list of all child TextChannels
      */
     @Nonnull
+    @Unmodifiable
     default List<TextChannel> getTextChannels()
     {
         return getGuild().getTextChannelCache().applyStream(stream ->
@@ -92,6 +95,7 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
      * @return Immutable list of all child NewsChannels
      */
     @Nonnull
+    @Unmodifiable
     default List<NewsChannel> getNewsChannels()
     {
         return getGuild().getNewsChannelCache().applyStream(stream ->
@@ -107,6 +111,7 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
      * @return Immutable list of all child ForumChannels
      */
     @Nonnull
+    @Unmodifiable
     default List<ForumChannel> getForumChannels()
     {
         return getGuild().getForumChannelCache().applyStream(stream ->
@@ -122,6 +127,7 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
      * @return Immutable list of all child ForumChannels
      */
     @Nonnull
+    @Unmodifiable
     default List<MediaChannel> getMediaChannels()
     {
         return getGuild().getMediaChannelCache().applyStream(stream ->
@@ -138,6 +144,7 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
      * @return Immutable list of all child VoiceChannels
      */
     @Nonnull
+    @Unmodifiable
     default List<VoiceChannel> getVoiceChannels()
     {
         return getGuild().getVoiceChannelCache().applyStream(stream ->
@@ -154,6 +161,7 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
      * @return Immutable list of all child StageChannel
      */
     @Nonnull
+    @Unmodifiable
     default List<StageChannel> getStageChannels()
     {
         return getGuild().getStageChannelCache().applyStream(stream ->
@@ -443,6 +451,7 @@ public interface Category extends GuildChannel, ICopyableChannel, IPositionableC
 
     @Nonnull
     @Override
+    @Unmodifiable
     default List<Member> getMembers()
     {
         return getChannels().stream()

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/ThreadChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/ThreadChannel.java
@@ -33,6 +33,7 @@ import net.dv8tion.jda.api.requests.restaction.CacheRestAction;
 import net.dv8tion.jda.api.requests.restaction.pagination.ThreadMemberPaginationAction;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -184,6 +185,7 @@ public interface ThreadChannel extends GuildMessageChannel, IMemberContainer, IS
      * @return Immutable {@link List} of {@link net.dv8tion.jda.api.entities.channel.forums.ForumTag ForumTags} applied to this post
      */
     @Nonnull
+    @Unmodifiable
     List<ForumTag> getAppliedTags();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/middleman/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/middleman/MessageChannel.java
@@ -54,6 +54,7 @@ import net.dv8tion.jda.internal.requests.restaction.pagination.MessagePagination
 import net.dv8tion.jda.internal.requests.restaction.pagination.PollVotersPaginationActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.pagination.ReactionPaginationActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -2342,7 +2343,7 @@ public interface MessageChannel extends Channel, Formattable
      */
     @Nonnull
     @CheckReturnValue
-    default RestAction<List<Message>> retrievePinnedMessages()
+    default RestAction<@Unmodifiable List<Message>> retrievePinnedMessages()
     {
         JDAImpl jda = (JDAImpl) getJDA();
         Route.CompiledRoute route = Route.Messages.GET_PINNED_MESSAGES.compile(getId());

--- a/src/main/java/net/dv8tion/jda/api/entities/emoji/RichCustomEmoji.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/emoji/RichCustomEmoji.java
@@ -27,6 +27,7 @@ import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.CacheRestAction;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -66,6 +67,7 @@ public interface RichCustomEmoji extends CustomEmoji
      * @return An immutable list of the roles this emoji is active for (all roles if empty)
      */
     @Nonnull
+    @Unmodifiable
     List<Role> getRoles();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/messages/MessagePoll.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/messages/MessagePoll.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.entities.emoji.EmojiUnion;
 import net.dv8tion.jda.api.utils.messages.MessagePollBuilder;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -70,6 +71,7 @@ public interface MessagePoll
      * @return Immutable {@link List} of {@link Answer}
      */
     @Nonnull
+    @Unmodifiable
     List<Answer> getAnswers();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/sticker/StickerPack.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/sticker/StickerPack.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.api.entities.sticker;
 
 import net.dv8tion.jda.api.entities.ISnowflake;
 import net.dv8tion.jda.api.utils.ImageProxy;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -40,6 +41,7 @@ public interface StickerPack extends ISnowflake
      * @return Immutable List of {@link StandardSticker StandardStickers}
      */
     @Nonnull
+    @Unmodifiable
     List<StandardSticker> getStickers();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/templates/TemplateChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/templates/TemplateChannel.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.api.entities.templates;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.ISnowflake;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -229,6 +230,7 @@ public class TemplateChannel implements ISnowflake
      *         for this {@link net.dv8tion.jda.api.entities.templates.TemplateChannel TemplateChannel}.
      */
     @Nonnull
+    @Unmodifiable
     public List<TemplateChannel.PermissionOverride> getPermissionOverrides()
     {
         return this.permissionOverrides;

--- a/src/main/java/net/dv8tion/jda/api/entities/templates/TemplateGuild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/templates/TemplateGuild.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.entities.Guild.VerificationLevel;
 import net.dv8tion.jda.api.entities.ISnowflake;
 import net.dv8tion.jda.api.interactions.DiscordLocale;
 import net.dv8tion.jda.api.utils.ImageProxy;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -226,6 +227,7 @@ public class TemplateGuild implements ISnowflake
      * @return An immutable List of {@link net.dv8tion.jda.api.entities.templates.TemplateRole Roles}.
      */
     @Nonnull
+    @Unmodifiable
     public List<TemplateRole> getRoles()
     {
         return this.roles;
@@ -237,6 +239,7 @@ public class TemplateGuild implements ISnowflake
      * @return An immutable List of {@link net.dv8tion.jda.api.entities.templates.TemplateChannel Channels}.
      */
     @Nonnull
+    @Unmodifiable
     public List<TemplateChannel> getChannels()
     {
         return this.channels;

--- a/src/main/java/net/dv8tion/jda/api/hooks/AnnotatedEventManager.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/AnnotatedEventManager.java
@@ -19,6 +19,7 @@ import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.utils.ClassWalker;
 import net.dv8tion.jda.internal.utils.JDALogger;
+import org.jetbrains.annotations.Unmodifiable;
 import org.slf4j.Logger;
 
 import javax.annotation.Nonnull;
@@ -91,6 +92,7 @@ public class AnnotatedEventManager implements IEventManager
 
     @Nonnull
     @Override
+    @Unmodifiable
     public List<Object> getRegisteredListeners()
     {
         return Collections.unmodifiableList(new ArrayList<>(listeners));

--- a/src/main/java/net/dv8tion/jda/api/hooks/InterfacedEventManager.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/InterfacedEventManager.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.api.hooks;
 import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.utils.JDALogger;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -81,6 +82,7 @@ public class InterfacedEventManager implements IEventManager
 
     @Nonnull
     @Override
+    @Unmodifiable
     public List<Object> getRegisteredListeners()
     {
         return Collections.unmodifiableList(new ArrayList<>(listeners));

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/Command.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/Command.java
@@ -34,6 +34,7 @@ import net.dv8tion.jda.internal.interactions.command.CommandImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EntityString;
 import net.dv8tion.jda.internal.utils.localization.LocalizationUtils;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -151,6 +152,7 @@ public interface Command extends ISnowflake, ICommandReference
      * @return Immutable list of command options
      */
     @Nonnull
+    @Unmodifiable
     List<Option> getOptions();
 
     /**
@@ -159,6 +161,7 @@ public interface Command extends ISnowflake, ICommandReference
      * @return Immutable list of subcommands
      */
     @Nonnull
+    @Unmodifiable
     List<Subcommand> getSubcommands();
 
     /**
@@ -167,6 +170,7 @@ public interface Command extends ISnowflake, ICommandReference
      * @return Immutable list of subcommand groups
      */
     @Nonnull
+    @Unmodifiable
     List<SubcommandGroup> getSubcommandGroups();
 
     /**
@@ -739,6 +743,7 @@ public interface Command extends ISnowflake, ICommandReference
          * @return Immutable {@link Set} of {@link ChannelType}
          */
         @Nonnull
+        @Unmodifiable
         public Set<ChannelType> getChannelTypes()
         {
             return channelTypes;
@@ -803,6 +808,7 @@ public interface Command extends ISnowflake, ICommandReference
          * @return Immutable {@link List} of {@link Choice}
          */
         @Nonnull
+        @Unmodifiable
         public List<Choice> getChoices()
         {
             return choices;
@@ -932,6 +938,7 @@ public interface Command extends ISnowflake, ICommandReference
          * @return Immutable list of Options
          */
         @Nonnull
+        @Unmodifiable
         public List<Option> getOptions()
         {
             return options;
@@ -1052,6 +1059,7 @@ public interface Command extends ISnowflake, ICommandReference
          * @return Immutable {@link List} of {@link Subcommand}
          */
         @Nonnull
+        @Unmodifiable
         public List<Subcommand> getSubcommands()
         {
             return subcommands;

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/PrivilegeConfig.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/PrivilegeConfig.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.SelfUser;
 import net.dv8tion.jda.api.interactions.commands.privileges.IntegrationPrivilege;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -78,6 +79,7 @@ public class PrivilegeConfig
      * @return Immutable List containing all IntegrationPrivileges that have been applied to this application in this guild.
      */
     @Nullable
+    @Unmodifiable
     public List<IntegrationPrivilege> getApplicationPrivileges()
     {
         return getCommandPrivileges(getJDA().getSelfUser().getApplicationId());
@@ -99,6 +101,7 @@ public class PrivilegeConfig
      * @return Immutable List containing all IntegrationPrivileges that have been applied to the command with the given id in this guild.
      */
     @Nullable
+    @Unmodifiable
     public List<IntegrationPrivilege> getCommandPrivileges(@Nonnull String id)
     {
         Checks.notNull(id, "Id");
@@ -121,6 +124,7 @@ public class PrivilegeConfig
      * @return Immutable List containing all IntegrationPrivileges that have been applied to the command in this guild.
      */
     @Nullable
+    @Unmodifiable
     public List<IntegrationPrivilege> getCommandPrivileges(@Nonnull Command command)
     {
         Checks.notNull(command, "Command");

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.api.utils.data.DataType;
 import net.dv8tion.jda.api.utils.data.SerializableData;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.localization.LocalizationUtils;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -348,6 +349,7 @@ public class OptionData implements SerializableData
      * @see #addChoice(String, String)
      */
     @Nonnull
+    @Unmodifiable
     public List<Command.Choice> getChoices()
     {
         if (choices == null || choices.isEmpty())

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SlashCommandData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SlashCommandData.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.interactions.CommandDataImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.localization.LocalizationUtils;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
@@ -249,6 +250,7 @@ public interface SlashCommandData extends CommandData
      * @return Immutable list of {@link SubcommandData}
      */
     @Nonnull
+    @Unmodifiable
     List<SubcommandData> getSubcommands();
 
     /**
@@ -257,6 +259,7 @@ public interface SlashCommandData extends CommandData
      * @return Immutable list of {@link SubcommandGroupData}
      */
     @Nonnull
+    @Unmodifiable
     List<SubcommandGroupData> getSubcommandGroups();
 
     /**
@@ -265,6 +268,7 @@ public interface SlashCommandData extends CommandData
      * @return Immutable list of {@link OptionData}
      */
     @Nonnull
+    @Unmodifiable
     List<OptionData> getOptions();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SubcommandData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SubcommandData.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.api.utils.data.SerializableData;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.localization.LocalizationUtils;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import java.util.*;
@@ -421,6 +422,7 @@ public class SubcommandData implements SerializableData
      * @return Immutable list of {@link OptionData}
      */
     @Nonnull
+    @Unmodifiable
     public List<OptionData> getOptions()
     {
         return Collections.unmodifiableList(options);

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SubcommandGroupData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SubcommandGroupData.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.api.utils.data.SerializableData;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.localization.LocalizationUtils;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import java.util.*;
@@ -303,6 +304,7 @@ public class SubcommandGroupData implements SerializableData
      * @return Immutable list of {@link SubcommandData}
      */
     @Nonnull
+    @Unmodifiable
     public List<SubcommandData> getSubcommands()
     {
         return Collections.unmodifiableList(subcommands);

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/LayoutComponent.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/LayoutComponent.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.utils.data.SerializableData;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -70,6 +71,7 @@ public interface LayoutComponent extends SerializableData, Iterable<ItemComponen
      * @return Immutable {@link List} copy of {@link ActionComponent ActionComponents} in this layout
      */
     @Nonnull
+    @Unmodifiable
     default List<ActionComponent> getActionComponents()
     {
         return getComponents().stream()
@@ -84,6 +86,7 @@ public interface LayoutComponent extends SerializableData, Iterable<ItemComponen
      * @return Immutable {@link List} of {@link Button Buttons}
      */
     @Nonnull
+    @Unmodifiable
     default List<Button> getButtons()
     {
         return getComponents().stream()

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/EntitySelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/EntitySelectMenu.java
@@ -31,6 +31,7 @@ import net.dv8tion.jda.internal.interactions.component.EntitySelectMenuImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EntityString;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -123,6 +124,7 @@ public interface EntitySelectMenu extends SelectMenu
      * @return Immutable list of {@link DefaultValue default values}
      */
     @Nonnull
+    @Unmodifiable
     List<DefaultValue> getDefaultValues();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/StringSelectInteraction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/StringSelectInteraction.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.api.interactions.components.selections;
 
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -36,6 +37,7 @@ public interface StringSelectInteraction extends SelectMenuInteraction<String, S
      * @return {@link List} of {@link SelectOption#getValue()}
      */
     @Nonnull
+    @Unmodifiable
     List<String> getValues();
 
     /**
@@ -45,6 +47,7 @@ public interface StringSelectInteraction extends SelectMenuInteraction<String, S
      * @return Immutable {@link List} of the selected options
      */
     @Nonnull
+    @Unmodifiable
     default List<SelectOption> getSelectedOptions()
     {
         StringSelectMenu menu = getComponent();

--- a/src/main/java/net/dv8tion/jda/api/interactions/modals/Modal.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/modals/Modal.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.api.utils.data.SerializableData;
 import net.dv8tion.jda.internal.interactions.modal.ModalImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -380,6 +381,7 @@ public interface Modal extends SerializableData
         @ForRemoval
         @Deprecated
         @ReplaceWith("getComponents()")
+        @Unmodifiable
         public List<ActionRow> getActionRows()
         {
             return components.stream()

--- a/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalInteraction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalInteraction.java
@@ -22,6 +22,7 @@ import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 import net.dv8tion.jda.api.interactions.callbacks.IMessageEditCallback;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -55,6 +56,7 @@ public interface ModalInteraction extends IReplyCallback, IMessageEditCallback
      * @see    #getValue(String)
      */
     @Nonnull
+    @Unmodifiable
     List<ModalMapping> getValues();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/managers/GuildWelcomeScreenManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/GuildWelcomeScreenManager.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.api.managers;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildWelcomeScreen;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -141,6 +142,7 @@ public interface GuildWelcomeScreenManager extends Manager<GuildWelcomeScreenMan
      * @return An immutable list of the welcome channels to be set by the manager
      */
     @Nonnull
+    @Unmodifiable
     List<GuildWelcomeScreen.Channel> getWelcomeChannels();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.operator.*;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.ContextRunnable;
+import org.jetbrains.annotations.Blocking;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -625,6 +626,7 @@ public interface RestAction<T>
      *
      * @return The response value
      */
+    @Blocking
     default T complete()
     {
         try
@@ -658,6 +660,7 @@ public interface RestAction<T>
      *
      * @return The response value
      */
+    @Blocking
     T complete(boolean shouldQueue) throws RateLimitedException;
 
     /**
@@ -1350,6 +1353,7 @@ public interface RestAction<T>
      *
      * @return The response value
      */
+    @Blocking
     default T completeAfter(long delay, @Nonnull TimeUnit unit)
     {
         Checks.notNull(unit, "TimeUnit");

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/order/OrderAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/order/OrderAction.java
@@ -17,6 +17,7 @@
 package net.dv8tion.jda.api.requests.restaction.order;
 
 import net.dv8tion.jda.api.requests.RestAction;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -72,6 +73,7 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      * @return Immutable List representing the current order
      */
     @Nonnull
+    @Unmodifiable
     List<T> getCurrentOrder();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.Procedure;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -82,7 +83,7 @@ import java.util.stream.StreamSupport;
  *
  * @since  3.1
  */
-public interface PaginationAction<T, M extends PaginationAction<T, M>> extends RestAction<List<T>>, Iterable<T>
+public interface PaginationAction<T, M extends PaginationAction<T, M>> extends RestAction<@Unmodifiable List<T>>, Iterable<T>
 {
     /**
      * Skips past the specified ID for successive requests.
@@ -234,6 +235,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      * @return Immutable {@link java.util.List List} containing all currently cached entities for this PaginationAction
      */
     @Nonnull
+    @Unmodifiable
     List<T> getCached();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.Procedure;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Blocking;
 import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
@@ -655,9 +656,11 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *         The {@link net.dv8tion.jda.api.utils.Procedure Procedure}
      *         which should return {@code true} to continue iterating
      */
+    @Blocking
     void forEachRemaining(@Nonnull final Procedure<? super T> action);
 
     @Override
+    @Blocking
     default Spliterator<T> spliterator()
     {
         return Spliterators.spliteratorUnknownSize(iterator(), Spliterator.IMMUTABLE);
@@ -669,6 +672,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      * @return a sequential {@code Stream} over the elements in this PaginationAction
      */
     @Nonnull
+    @Blocking
     default Stream<T> stream()
     {
         return StreamSupport.stream(spliterator(), false);
@@ -681,6 +685,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      * @return a sequential {@code Stream} over the elements in this PaginationAction
      */
     @Nonnull
+    @Blocking
     default Stream<T> parallelStream()
     {
         return StreamSupport.stream(spliterator(), true);
@@ -694,6 +699,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      */
     @Nonnull
     @Override
+    @Blocking
     PaginationIterator<T> iterator();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -41,6 +41,7 @@ import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.cache.UnifiedChannelCacheView;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -313,6 +314,7 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      * @return An immutable list of custom emojis (which may or may not be available to usage).
      */
     @Nonnull
+    @Unmodifiable
     default List<RichCustomEmoji> getEmojis()
     {
         return this.getEmojiCache().asList();
@@ -335,6 +337,7 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      *         name as the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<RichCustomEmoji> getEmojisByName(@Nonnull final String name, final boolean ignoreCase)
     {
         return this.getEmojiCache().getElementsByName(name, ignoreCase);
@@ -382,6 +385,7 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      * @return Possibly-empty list of all the {@link net.dv8tion.jda.api.entities.Guild Guilds} that all have the same name as the provided name.
      */
     @Nonnull
+    @Unmodifiable
     default List<Guild> getGuildsByName(@Nonnull final String name, final boolean ignoreCase)
     {
         return this.getGuildCache().getElementsByName(name, ignoreCase);
@@ -412,6 +416,7 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      * @return Possibly-empty list of all the {@link net.dv8tion.jda.api.entities.Guild Guilds} that this account is connected to.
      */
     @Nonnull
+    @Unmodifiable
     default List<Guild> getGuilds()
     {
         return this.getGuildCache().asList();
@@ -426,6 +431,7 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      * @return Unmodifiable list of all {@link net.dv8tion.jda.api.entities.Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.User Users} in them.
      */
     @Nonnull
+    @Unmodifiable
     default List<Guild> getMutualGuilds(@Nonnull final Collection<User> users)
     {
         Checks.noneNull(users, "users");
@@ -444,6 +450,7 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      * @return Unmodifiable list of all {@link net.dv8tion.jda.api.entities.Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.User Users} in them.
      */
     @Nonnull
+    @Unmodifiable
     default List<Guild> getMutualGuilds(@Nonnull final User... users)
     {
         Checks.notNull(users, "users");
@@ -599,6 +606,7 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      * @return Possibly-empty list of all {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannels}.
      */
     @Nonnull
+    @Unmodifiable
     default List<PrivateChannel> getPrivateChannels()
     {
         return this.getPrivateChannelCache().asList();
@@ -664,6 +672,7 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      * @return Immutable List of all visible Roles
      */
     @Nonnull
+    @Unmodifiable
     default List<Role> getRoles()
     {
         return this.getRoleCache().asList();
@@ -682,6 +691,7 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      * @return Immutable List of all Roles matching the parameters provided.
      */
     @Nonnull
+    @Unmodifiable
     default List<Role> getRolesByName(@Nonnull final String name, final boolean ignoreCase)
     {
         return this.getRoleCache().getElementsByName(name, ignoreCase);
@@ -869,6 +879,7 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      * @return An immutable list of all managed {@link net.dv8tion.jda.api.JDA JDA} instances.
      */
     @Nonnull
+    @Unmodifiable
     default List<JDA> getShards()
     {
         return this.getShardCache().asList();
@@ -897,6 +908,7 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      * @return All current shard statuses.
      */
     @Nonnull
+    @Unmodifiable
     default Map<JDA, Status> getStatuses()
     {
         return Collections.unmodifiableMap(this.getShardCache().stream()
@@ -962,6 +974,7 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      * @return List of all {@link net.dv8tion.jda.api.entities.User Users} that are visible to JDA.
      */
     @Nonnull
+    @Unmodifiable
     default List<User> getUsers()
     {
         return this.getUserCache().asList();

--- a/src/main/java/net/dv8tion/jda/api/utils/cache/CacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/CacheView.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
 import net.dv8tion.jda.internal.utils.cache.ShardCacheViewImpl;
 import net.dv8tion.jda.internal.utils.cache.SortedSnowflakeCacheViewImpl;
 import net.dv8tion.jda.internal.utils.cache.UnifiedCacheViewImpl;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -70,6 +71,7 @@ public interface CacheView<T> extends Iterable<T>
      * @return Immutable list of cached elements
      */
     @Nonnull
+    @Unmodifiable
     List<T> asList();
 
     /**
@@ -79,6 +81,7 @@ public interface CacheView<T> extends Iterable<T>
      * @return Immutable set of cached elements
      */
     @Nonnull
+    @Unmodifiable
     Set<T> asSet();
 
     /**
@@ -224,6 +227,7 @@ public interface CacheView<T> extends Iterable<T>
      * @return Immutable list of elements with the given name
      */
     @Nonnull
+    @Unmodifiable
     List<T> getElementsByName(@Nonnull String name, boolean ignoreCase);
 
     /**
@@ -240,6 +244,7 @@ public interface CacheView<T> extends Iterable<T>
      * @return Immutable list of elements with the given name
      */
     @Nonnull
+    @Unmodifiable
     default List<T> getElementsByName(@Nonnull String name)
     {
         return getElementsByName(name, false);

--- a/src/main/java/net/dv8tion/jda/api/utils/cache/MemberCacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/MemberCacheView.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.api.utils.cache;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.utils.MiscUtil;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -80,6 +81,7 @@ public interface MemberCacheView extends SnowflakeCacheView<Member>
      * @return Immutable list of members with the given username
      */
     @Nonnull
+    @Unmodifiable
     List<Member> getElementsByUsername(@Nonnull String name, boolean ignoreCase);
 
     /**
@@ -95,6 +97,7 @@ public interface MemberCacheView extends SnowflakeCacheView<Member>
      * @return Immutable list of members with the given username
      */
     @Nonnull
+    @Unmodifiable
     default List<Member> getElementsByUsername(@Nonnull String name)
     {
         return getElementsByUsername(name, false);
@@ -114,6 +117,7 @@ public interface MemberCacheView extends SnowflakeCacheView<Member>
      * @return Immutable list of members with the given nickname
      */
     @Nonnull
+    @Unmodifiable
     List<Member> getElementsByNickname(@Nullable String name, boolean ignoreCase);
 
     /**
@@ -128,6 +132,7 @@ public interface MemberCacheView extends SnowflakeCacheView<Member>
      * @return Immutable list of members with the given nickname
      */
     @Nonnull
+    @Unmodifiable
     default List<Member> getElementsByNickname(@Nullable String name)
     {
         return getElementsByNickname(name, false);
@@ -146,6 +151,7 @@ public interface MemberCacheView extends SnowflakeCacheView<Member>
      * @return Immutable list of members with the given roles
      */
     @Nonnull
+    @Unmodifiable
     List<Member> getElementsWithRoles(@Nonnull Role... roles);
 
     /**
@@ -161,5 +167,6 @@ public interface MemberCacheView extends SnowflakeCacheView<Member>
      * @return Immutable list of members with the given roles
      */
     @Nonnull
+    @Unmodifiable
     List<Member> getElementsWithRoles(@Nonnull Collection<Role> roles);
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/cache/UnifiedMemberCacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/UnifiedMemberCacheView.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.api.utils.cache;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.utils.MiscUtil;
+import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -80,6 +81,7 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      * @return Immutable list of members with the given username
      */
     @Nonnull
+    @Unmodifiable
     List<Member> getElementsByUsername(@Nonnull String name, boolean ignoreCase);
 
     /**
@@ -95,6 +97,7 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      * @return Immutable list of members with the given username
      */
     @Nonnull
+    @Unmodifiable
     default List<Member> getElementsByUsername(@Nonnull String name)
     {
         return getElementsByUsername(name, false);
@@ -114,6 +117,7 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      * @return Immutable list of members with the given nickname
      */
     @Nonnull
+    @Unmodifiable
     List<Member> getElementsByNickname(@Nullable String name, boolean ignoreCase);
 
     /**
@@ -128,6 +132,7 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      * @return Immutable list of members with the given nickname
      */
     @Nonnull
+    @Unmodifiable
     default List<Member> getElementsByNickname(@Nullable String name)
     {
         return getElementsByNickname(name, false);
@@ -146,6 +151,7 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      * @return Immutable list of members with the given roles
      */
     @Nonnull
+    @Unmodifiable
     List<Member> getElementsWithRoles(@Nonnull Role... roles);
 
     /**
@@ -161,5 +167,6 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      * @return Immutable list of members with the given roles
      */
     @Nonnull
+    @Unmodifiable
     List<Member> getElementsWithRoles(@Nonnull Collection<Role> roles);
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/concurrent/Task.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/concurrent/Task.java
@@ -17,6 +17,7 @@
 package net.dv8tion.jda.api.utils.concurrent;
 
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Blocking;
 
 import javax.annotation.Nonnull;
 import java.time.Duration;
@@ -129,6 +130,7 @@ public interface Task<T>
      * @return The result value
      */
     @Nonnull
+    @Blocking
     T get();
 
     /**


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This causes static analyzers (Intellij etc.) to show warnings when using modification methods like `add` on one of these collections.

![image](https://github.com/discord-jda/JDA/assets/18090140/5f7e3e21-6249-4016-b09a-c30560094d8d)

Additional, unrelated changes:

- Removed deprecation of `getUserByTag` since it is still necessary
- Added handling for parsing errors in retrievePinnedMessages
- Added missing docs to Guild#retrieveActiveThreads
