### PR TITLE
Add Android Compatibility by removing UNICODE_CHARACTER_CLASS flag which DOES NOT run on Android

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/utils/Checks.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/Checks.java
@@ -40,8 +40,8 @@ import java.util.stream.Stream;
 
 public class Checks
 {
-    public static final Pattern ALPHANUMERIC_WITH_DASH = Pattern.compile("[\\w-]+", Pattern.UNICODE_CHARACTER_CLASS);
-    public static final Pattern ALPHANUMERIC = Pattern.compile("\\w+", Pattern.UNICODE_CHARACTER_CLASS);
+    public static final Pattern ALPHANUMERIC_WITH_DASH = Pattern.compile("[\\w-]+");
+    public static final Pattern ALPHANUMERIC = Pattern.compile("\\w+");
     public static final Pattern LOWERCASE_ASCII_ALPHANUMERIC = Pattern.compile("[a-z0-9_]+");
 
     @Contract("null -> fail")


### PR DESCRIPTION

[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Android throws `Caused by: java.lang.IllegalArgumentException: UNICODE_CHARACTER_CLASS flag not supported` if you use JDA in Android. This prevents it from being used inside Android.

Why? Well, I want to run my Discord Bot in Android because it's power efficient and has its own UPS. I have succeeded in doing as such