### PR TITLE
Add `JDA#listenOnce`

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -610,6 +610,12 @@ public interface JDA extends IGuildChannelContainer<Channel>
     /**
      * Returns a reusable builder for a one-time event listener.
      *
+     * <p>Note that this method only works if the {@link JDABuilder#setEventManager(IEventManager) event manager}
+     * is either the {@link net.dv8tion.jda.api.hooks.InterfacedEventManager InterfacedEventManager}
+     * or {@link net.dv8tion.jda.api.hooks.AnnotatedEventManager AnnotatedEventManager}.
+     * <br>Other implementations can support it as long as they call
+     * {@link net.dv8tion.jda.api.hooks.EventListener#onEvent(GenericEvent) EventListener.onEvent(GenericEvent)}.
+     *
      * <p><b>Example:</b>
      *
      * <p>Listening to a message from a channel and a user, after using a slash command:
@@ -634,10 +640,10 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @param  eventType
      *         Type of the event to listen to
      *
-     * @return The one-time event listener builder
-     *
      * @throws IllegalArgumentException
      *         If the provided event type is {@code null}
+     *
+     * @return The one-time event listener builder
      */
     @Nonnull
     @CheckReturnValue

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -631,8 +631,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      *         .timeout(timeout, () -> {
      *             event.getHook().editOriginal("Timeout!").queue();
      *         })
-     *         .submit()
-     *         .onSuccess(messageEvent -> {
+     *         .subscribe(messageEvent -> {
      *             event.getHook().editOriginal("You sent: " + messageEvent.getMessage().getContentRaw()).queue();
      *         });
      * }</pre>

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.emoji.RichCustomEmoji;
 import net.dv8tion.jda.api.entities.sticker.*;
+import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.api.hooks.IEventManager;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
@@ -39,6 +40,7 @@ import net.dv8tion.jda.api.requests.restaction.*;
 import net.dv8tion.jda.api.requests.restaction.pagination.EntitlementPaginationAction;
 import net.dv8tion.jda.api.sharding.ShardManager;
 import net.dv8tion.jda.api.utils.MiscUtil;
+import net.dv8tion.jda.api.utils.Once;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
@@ -604,6 +606,37 @@ public interface JDA extends IGuildChannelContainer<Channel>
      */
     @Nonnull
     List<Object> getRegisteredListeners();
+
+    /**
+     * Returns a reusable builder for a one-time event listener.
+     *
+     * <p><b>Example:</b>
+     *
+     * <p>Listening to a message from a channel and a user, after using a slash command:
+     * <pre>{@code
+     * jda.listenOnce(MessageReceivedEvent.class)
+     *     .filter(messageEvent -> messageEvent.getChannel().getIdLong() == event.getChannel().getIdLong())
+     *     .filter(messageEvent -> messageEvent.getAuthor().getIdLong() == event.getUser().getIdLong())
+     *     .timeout(Duration.ofSeconds(5), () -> {
+     *         event.getHook().sendMessage("Timeout!").queue();
+     *     })
+     *     .submit()
+     *     .onSuccess(messageEvent -> {
+     *         event.getHook().sendMessage("You sent: " + messageEvent.getMessage().getContentRaw()).queue();
+     *     });
+     * }</pre>
+     *
+     * @param  eventType
+     *         Type of the event to listen to
+     *
+     * @return The one-time event listener builder
+     *
+     * @throws IllegalArgumentException
+     *         If the provided event type is {@code null}
+     */
+    @Nonnull
+    @CheckReturnValue
+    <E extends GenericEvent> Once.Builder<E> listenOnce(@Nonnull Class<E> eventType);
 
     /**
      * Retrieves the list of global commands.

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -614,16 +614,21 @@ public interface JDA extends IGuildChannelContainer<Channel>
      *
      * <p>Listening to a message from a channel and a user, after using a slash command:
      * <pre>{@code
-     * jda.listenOnce(MessageReceivedEvent.class)
-     *     .filter(messageEvent -> messageEvent.getChannel().getIdLong() == event.getChannel().getIdLong())
-     *     .filter(messageEvent -> messageEvent.getAuthor().getIdLong() == event.getUser().getIdLong())
-     *     .timeout(Duration.ofSeconds(5), () -> {
-     *         event.getHook().sendMessage("Timeout!").queue();
-     *     })
-     *     .submit()
-     *     .onSuccess(messageEvent -> {
-     *         event.getHook().sendMessage("You sent: " + messageEvent.getMessage().getContentRaw()).queue();
-     *     });
+     * final Duration timeout = Duration.ofSeconds(5);
+     * event.reply("Reply in " + TimeFormat.RELATIVE.after(timeout) + " if you can!")
+     *         .setEphemeral(true)
+     *         .queue();
+     *
+     * event.getJDA().listenOnce(MessageReceivedEvent.class)
+     *         .filter(messageEvent -> messageEvent.getChannel().getIdLong() == event.getChannel().getIdLong())
+     *         .filter(messageEvent -> messageEvent.getAuthor().getIdLong() == event.getUser().getIdLong())
+     *         .timeout(timeout, () -> {
+     *             event.getHook().editOriginal("Timeout!").queue();
+     *         })
+     *         .submit()
+     *         .onSuccess(messageEvent -> {
+     *             event.getHook().editOriginal("You sent: " + messageEvent.getMessage().getContentRaw()).queue();
+     *         });
      * }</pre>
      *
      * @param  eventType

--- a/src/main/java/net/dv8tion/jda/api/utils/Once.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Once.java
@@ -3,6 +3,7 @@ package net.dv8tion.jda.api.utils;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.api.hooks.EventListener;
+import net.dv8tion.jda.api.hooks.SubscribeEvent;
 import net.dv8tion.jda.api.utils.concurrent.Task;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.concurrent.task.GatewayTask;
@@ -89,6 +90,7 @@ public class Once<E extends GenericEvent> implements EventListener
     }
 
     @Override
+    @SubscribeEvent
     public void onEvent(@Nonnull GenericEvent event)
     {
         if (!eventType.isInstance(event))

--- a/src/main/java/net/dv8tion/jda/api/utils/Once.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Once.java
@@ -1,0 +1,212 @@
+package net.dv8tion.jda.api.utils;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.hooks.EventListener;
+import net.dv8tion.jda.api.utils.concurrent.Task;
+import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.concurrent.task.GatewayTask;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * Helper class to listen to an event, once.
+ *
+ * @param <E> Type of the event listened to
+ *
+ * @see   JDA#listenOnce(Class)
+ */
+public class Once<E extends GenericEvent> implements EventListener
+{
+    private final JDA jda;
+    private final Class<E> eventType;
+    private final List<Predicate<? super E>> filters;
+    private final CompletableFuture<E> future;
+    private final GatewayTask<E> task;
+    private final ScheduledFuture<?> timeoutFuture;
+    private final Runnable timeoutCallback;
+
+    private Once(@Nonnull Once.Builder<E> builder)
+    {
+        this.jda = builder.jda;
+        this.eventType = builder.eventType;
+        this.filters = new ArrayList<>(builder.filters);
+        this.timeoutCallback = builder.timeoutCallback;
+
+        this.future = new CompletableFuture<>();
+        this.task = createTask(future);
+        this.timeoutFuture = scheduleTimeout(builder.timeout, future);
+    }
+
+    @Nonnull
+    private GatewayTask<E> createTask(@Nonnull CompletableFuture<E> future)
+    {
+        final GatewayTask<E> task = new GatewayTask<>(future, () ->
+        {
+            // On cancellation, throw cancellation exception and cancel timeout
+            jda.removeEventListener(this);
+            future.completeExceptionally(new CancellationException());
+            if (timeoutFuture != null)
+                timeoutFuture.cancel(false);
+        });
+        task.onSetTimeout(e ->
+        {
+            throw new UnsupportedOperationException("You must set the timeout on Once.Builder#timeout");
+        });
+        return task;
+    }
+
+    @Nullable
+    private ScheduledFuture<?> scheduleTimeout(@Nullable Duration timeout, @Nonnull CompletableFuture<E> future)
+    {
+        if (timeout == null) return null;
+
+        return jda.getGatewayPool().schedule(() ->
+        {
+            // On timeout, throw timeout exception and run timeout callback
+            jda.removeEventListener(this);
+            future.completeExceptionally(new TimeoutException());
+            if (timeoutCallback != null)
+            {
+                try
+                {
+                    timeoutCallback.run();
+                }
+                catch (Throwable e)
+                {
+                    future.completeExceptionally(e);
+                }
+            }
+        }, timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void onEvent(@Nonnull GenericEvent event)
+    {
+        if (!eventType.isInstance(event))
+            return;
+        final E casted = eventType.cast(event);
+        if (filters.stream().allMatch(p -> p.test(casted)))
+        {
+            if (timeoutFuture != null)
+                timeoutFuture.cancel(false);
+            event.getJDA().removeEventListener(this);
+            future.complete(casted);
+        }
+    }
+
+    /**
+     * Builds a one-time event listener, can be reused.
+     *
+     * @param <E> Type of the event listened to
+     */
+    public static class Builder<E extends GenericEvent>
+    {
+        private final JDA jda;
+        private final Class<E> eventType;
+        private final List<Predicate<? super E>> filters = new ArrayList<>();
+
+        private Duration timeout;
+        private Runnable timeoutCallback;
+
+        /**
+         * Creates a builder for a one-time event listener
+         *
+         * @param jda
+         *        The JDA instance
+         * @param eventType
+         *        The event type to listen for
+         */
+        public Builder(@Nonnull JDA jda, @Nonnull Class<E> eventType)
+        {
+            Checks.notNull(jda, "JDA");
+            Checks.notNull(eventType, "Event type");
+            this.jda = jda;
+            this.eventType = eventType;
+        }
+
+        /**
+         * Adds an event filter, all filters need to return {@code true} for the event to be consumed.
+         *
+         * @param  filter
+         *         The filter to add, returns {@code true} if the event can be consumed
+         *
+         * @return This instance for chaining convenience
+         */
+        @Nonnull
+        public Builder<E> filter(@Nonnull Predicate<? super E> filter)
+        {
+            Checks.notNull(filter, "Filter");
+            filters.add(filter);
+            return this;
+        }
+
+        /**
+         * Sets the timeout duration, after which the event is no longer listener for.
+         *
+         * @param  timeout
+         *         The duration after which the event is no longer listener for
+         *
+         * @return This instance for chaining convenience
+         */
+        @Nonnull
+        public Builder<E> timeout(@Nonnull Duration timeout)
+        {
+            return timeout(timeout, null);
+        }
+
+        /**
+         * Sets the timeout duration, after which the event is no longer listener for,
+         * and the callback is run.
+         *
+         * @param  timeout
+         *         The duration after which the event is no longer listener for
+         * @param  timeoutCallback
+         *         The callback run after the duration
+         *
+         * @return This instance for chaining convenience
+         */
+        @Nonnull
+        public Builder<E> timeout(@Nonnull Duration timeout, @Nullable Runnable timeoutCallback)
+        {
+            Checks.notNull(timeout, "Timeout");
+            this.timeout = timeout;
+            this.timeoutCallback = timeoutCallback;
+            return this;
+        }
+
+        /**
+         * Starts listening for the event, once.
+         *
+         * <p>The task will be completed after all {@link #filter(Predicate) filters} return {@code true}.
+         *
+         * <p>Exceptions thrown in {@link Task#get() blocking} and {@link Task#onSuccess(Consumer) async} contexts includes:
+         * <ul>
+         *     <li>{@link CancellationException} - When {@link Task#cancel()} is called</li>
+         *     <li>{@link TimeoutException} - When the listener has expired</li>
+         *     <li>Any exception thrown by the {@link #timeout(Duration, Runnable) timeout callback}</li>
+         * </ul>
+         *
+         * @return {@link Task} returning an event satisfying all preconditions
+         *
+         * @see Task#onSuccess(Consumer)
+         * @see Task#get()
+         */
+        @Nonnull
+        @CheckReturnValue
+        public Task<E> submit()
+        {
+            final Once<E> once = new Once<>(this);
+            jda.addEventListener(once);
+            return once.task;
+        }
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/utils/Once.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Once.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.dv8tion.jda.api.utils;
 
 import net.dv8tion.jda.api.JDA;

--- a/src/main/java/net/dv8tion/jda/api/utils/Once.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Once.java
@@ -232,6 +232,9 @@ public class Once<E extends GenericEvent> implements EventListener
          *     <li>Any exception thrown by the {@link #timeout(Duration, Runnable) timeout callback}</li>
          * </ul>
          *
+         * @throws IllegalArgumentException
+         *         If the callback is null
+         *
          * @return {@link Task} returning an event satisfying all preconditions
          *
          * @see Task#onSuccess(Consumer)
@@ -239,11 +242,11 @@ public class Once<E extends GenericEvent> implements EventListener
          */
         @Nonnull
         @CheckReturnValue
-        public Task<E> submit()
+        public Task<E> subscribe(@Nonnull Consumer<E> callback)
         {
             final Once<E> once = new Once<>(this);
             jda.addEventListener(once);
-            return once.task;
+            return once.task.onSuccess(callback);
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/Once.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Once.java
@@ -126,6 +126,9 @@ public class Once<E extends GenericEvent> implements EventListener
          *        The JDA instance
          * @param eventType
          *        The event type to listen for
+         *
+         * @throws IllegalArgumentException
+         *         If any of the parameters is null
          */
         public Builder(@Nonnull JDA jda, @Nonnull Class<E> eventType)
         {
@@ -140,6 +143,9 @@ public class Once<E extends GenericEvent> implements EventListener
          *
          * @param  filter
          *         The filter to add, returns {@code true} if the event can be consumed
+         *
+         * @throws IllegalArgumentException
+         *         If the filter is null
          *
          * @return This instance for chaining convenience
          */
@@ -157,6 +163,9 @@ public class Once<E extends GenericEvent> implements EventListener
          * @param  timeout
          *         The duration after which the event is no longer listener for
          *
+         * @throws IllegalArgumentException
+         *         If the timeout is null
+         *
          * @return This instance for chaining convenience
          */
         @Nonnull
@@ -173,6 +182,9 @@ public class Once<E extends GenericEvent> implements EventListener
          *         The duration after which the event is no longer listener for
          * @param  timeoutCallback
          *         The callback run after the duration
+         *
+         * @throws IllegalArgumentException
+         *         If the timeout is null
          *
          * @return This instance for chaining convenience
          */

--- a/src/main/java/net/dv8tion/jda/api/utils/Once.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Once.java
@@ -6,7 +6,9 @@ import net.dv8tion.jda.api.hooks.EventListener;
 import net.dv8tion.jda.api.hooks.SubscribeEvent;
 import net.dv8tion.jda.api.utils.concurrent.Task;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.JDALogger;
 import net.dv8tion.jda.internal.utils.concurrent.task.GatewayTask;
+import org.slf4j.Logger;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -27,6 +29,8 @@ import java.util.function.Predicate;
  */
 public class Once<E extends GenericEvent> implements EventListener
 {
+    private static final Logger LOG = JDALogger.getLog(Once.class);
+
     private final JDA jda;
     private final Class<E> eventType;
     private final List<Predicate<? super E>> filters;
@@ -84,7 +88,7 @@ public class Once<E extends GenericEvent> implements EventListener
                 }
                 catch (Throwable e)
                 {
-                    future.completeExceptionally(e);
+                    LOG.error("An error occurred while running the timeout callback", e);
                 }
             }
         }, timeout.toMillis(), TimeUnit.MILLISECONDS);

--- a/src/main/java/net/dv8tion/jda/api/utils/Once.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Once.java
@@ -79,7 +79,9 @@ public class Once<E extends GenericEvent> implements EventListener
         {
             // On timeout, throw timeout exception and run timeout callback
             jda.removeEventListener(this);
-            future.completeExceptionally(new TimeoutException());
+            if (!future.completeExceptionally(new TimeoutException()))
+                // Return if the future was already completed
+                return;
             if (timeoutCallback != null)
             {
                 try

--- a/src/main/java/net/dv8tion/jda/api/utils/Once.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Once.java
@@ -43,12 +43,12 @@ public class Once<E extends GenericEvent> implements EventListener
         this.timeoutCallback = builder.timeoutCallback;
 
         this.future = new CompletableFuture<>();
-        this.task = createTask(future);
-        this.timeoutFuture = scheduleTimeout(builder.timeout, builder.timeoutPool, future);
+        this.task = createTask();
+        this.timeoutFuture = scheduleTimeout(builder.timeout, builder.timeoutPool);
     }
 
     @Nonnull
-    private GatewayTask<E> createTask(@Nonnull CompletableFuture<E> future)
+    private GatewayTask<E> createTask()
     {
         final GatewayTask<E> task = new GatewayTask<>(future, () ->
         {
@@ -66,7 +66,7 @@ public class Once<E extends GenericEvent> implements EventListener
     }
 
     @Nullable
-    private ScheduledFuture<?> scheduleTimeout(@Nullable Duration timeout, @Nullable ScheduledExecutorService timeoutPool, @Nonnull CompletableFuture<E> future)
+    private ScheduledFuture<?> scheduleTimeout(@Nullable Duration timeout, @Nullable ScheduledExecutorService timeoutPool)
     {
         if (timeout == null) return null;
         if (timeoutPool == null) timeoutPool = jda.getGatewayPool();

--- a/src/main/java/net/dv8tion/jda/api/utils/Once.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Once.java
@@ -55,16 +55,16 @@ public class Once<E extends GenericEvent> implements EventListener
     private final ScheduledFuture<?> timeoutFuture;
     private final Runnable timeoutCallback;
 
-    private Once(@Nonnull Once.Builder<E> builder)
+    protected Once(JDA jda, Class<E> eventType, List<Predicate<? super E>> filters, Runnable timeoutCallback, Duration timeout, ScheduledExecutorService timeoutPool)
     {
-        this.jda = builder.jda;
-        this.eventType = builder.eventType;
-        this.filters = new ArrayList<>(builder.filters);
-        this.timeoutCallback = builder.timeoutCallback;
+        this.jda = jda;
+        this.eventType = eventType;
+        this.filters = new ArrayList<>(filters);
+        this.timeoutCallback = timeoutCallback;
 
         this.future = new CompletableFuture<>();
         this.task = createTask();
-        this.timeoutFuture = scheduleTimeout(builder.timeout, builder.timeoutPool);
+        this.timeoutFuture = scheduleTimeout(timeout, timeoutPool);
     }
 
     @Nonnull
@@ -279,7 +279,7 @@ public class Once<E extends GenericEvent> implements EventListener
         @CheckReturnValue
         public Task<E> subscribe(@Nonnull Consumer<E> callback)
         {
-            final Once<E> once = new Once<>(this);
+            final Once<E> once = new Once<>(jda, eventType, filters, timeoutCallback, timeout, timeoutPool);
             jda.addEventListener(once);
             return once.task.onSuccess(callback);
         }

--- a/src/main/java/net/dv8tion/jda/api/utils/Once.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Once.java
@@ -91,6 +91,8 @@ public class Once<E extends GenericEvent> implements EventListener
                 catch (Throwable e)
                 {
                     LOG.error("An error occurred while running the timeout callback", e);
+                    if (e instanceof Error)
+                        throw (Error) e;
                 }
             }
         }, timeout.toMillis(), TimeUnit.MILLISECONDS);
@@ -117,6 +119,8 @@ public class Once<E extends GenericEvent> implements EventListener
         {
             if (future.completeExceptionally(e))
                 event.getJDA().removeEventListener(this);
+            if (e instanceof Error)
+                throw (Error) e;
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/api/utils/Once.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Once.java
@@ -80,7 +80,6 @@ public class Once<E extends GenericEvent> implements EventListener
             // On timeout, throw timeout exception and run timeout callback
             jda.removeEventListener(this);
             if (!future.completeExceptionally(new TimeoutException()))
-                // Return if the future was already completed
                 return;
             if (timeoutCallback != null)
             {

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -1011,6 +1011,13 @@ public class JDAImpl implements JDA
 
     @Nonnull
     @Override
+    public <E extends GenericEvent> Once.Builder<E> listenOnce(@Nonnull Class<E> eventType)
+    {
+        return new Once.Builder<>(this, eventType);
+    }
+
+    @Nonnull
+    @Override
     public RestAction<List<Command>> retrieveCommands(boolean withLocalizations)
     {
         Route.CompiledRoute route = Route.Interactions.GET_COMMANDS


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds an helper method to listen for an event, once.

#### Example: Listening to a message from a channel and a user, after using a slash command:
     
```java
final Duration timeout = Duration.ofSeconds(5);
event.reply("Reply in " + TimeFormat.RELATIVE.after(timeout) + " if you can!")
       .setEphemeral(true)
       .queue();

event.getJDA().listenOnce(MessageReceivedEvent.class)
        .filter(messageEvent -> messageEvent.getChannel().getIdLong() == event.getChannel().getIdLong())
        .filter(messageEvent -> messageEvent.getAuthor().getIdLong() == event.getUser().getIdLong())
        .timeout(timeout, () -> {
            event.getHook().editOriginal("Timeout!").queue();
        })
        .submit()
        .onSuccess(messageEvent -> {
            event.getHook().editOriginal("You sent: " + messageEvent.getMessage().getContentRaw()).queue();
        });
```