### PR TITLE
Add abstract `createCopy` method in `SelectMenu`

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/EntitySelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/EntitySelectMenu.java
@@ -135,6 +135,7 @@ public interface EntitySelectMenu extends SelectMenu
      */
     @Nonnull
     @CheckReturnValue
+    @Override
     default Builder createCopy()
     {
         //noinspection ConstantConditions

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectMenu.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.api.interactions.components.selections;
 import net.dv8tion.jda.api.interactions.components.ActionComponent;
 import net.dv8tion.jda.internal.utils.Checks;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -77,6 +78,10 @@ public interface SelectMenu extends ActionComponent
      * @return The max values
      */
     int getMaxValues();
+
+    @Nonnull
+    @CheckReturnValue
+    Builder<? extends SelectMenu, ? extends Builder<?, ?>> createCopy();
 
     /**
      * A preconfigured builder for the creation of select menus.

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectMenu.java
@@ -79,6 +79,12 @@ public interface SelectMenu extends ActionComponent
      */
     int getMaxValues();
 
+    /**
+     * Creates a new preconfigured {@link SelectMenu.Builder} with the same settings used for this select menu.
+     * <br>This can be useful to create an updated version of this menu without needing to rebuild it from scratch.
+     *
+     * @return The {@link SelectMenu.Builder} used to create the select menu
+     */
     @Nonnull
     @CheckReturnValue
     Builder<? extends SelectMenu, ? extends Builder<?, ?>> createCopy();

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/StringSelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/StringSelectMenu.java
@@ -100,6 +100,7 @@ public interface StringSelectMenu extends SelectMenu
      */
     @Nonnull
     @CheckReturnValue
+    @Override
     default Builder createCopy()
     {
         //noinspection ConstantConditions


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ 

Closes Issue: NaN

## Description

Adds an abstract `createCopy` method in the `SelectMenu` interface. This allows to create a copy of a SelectMenu without knowing the actual type
