### PR TITLE
Document `GuildVoiceState#getChannel()` requires the member cache

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
@@ -121,6 +121,10 @@ public interface GuildVoiceState extends ISnowflake
      * Returns the current {@link AudioChannelUnion} that the {@link Member} is in.
      * If the {@link Member} is currently not connected to a {@link AudioChannel}, this returns null.
      *
+     * <p><b>Note:</b> This will return {@code null} if the member is not cached!
+     * You can use {@link net.dv8tion.jda.api.utils.MemberCachePolicy#VOICE MemberCachePolicy.VOICE}
+     * to cache members in voice channels.
+     *
      * @return The AudioChannelUnion that the Member is connected to, or null.
      */
     @Nullable


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This is required as the voice state is not sent with, for example, interactions.
