### PR TITLE
Fix deserialization of interaction components

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/interactions/component/TextInputImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/component/TextInputImpl.java
@@ -41,7 +41,7 @@ public class TextInputImpl implements TextInput
                 object.getString("custom_id"),
                 TextInputStyle.fromKey(object.getInt("style", -1)),
                 object.getString("label", null),
-                object.getInt("min_Length", -1),
+                object.getInt("min_length", -1),
                 object.getInt("max_length", -1),
                 object.getBoolean("required", true),
                 object.getString("value", null),

--- a/src/main/java/net/dv8tion/jda/internal/interactions/modal/ModalImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/modal/ModalImpl.java
@@ -37,7 +37,7 @@ public class ModalImpl implements Modal
 
     public ModalImpl(DataObject object)
     {
-        this.id = object.getString("id");
+        this.id = object.getString("custom_id");
         this.title = object.getString("title");
         this.components = object.optArray("components").orElseGet(DataArray::empty)
                     .stream(DataArray::getObject)


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

## Description

It fixes the deserialization of some interaction components. Actually, I identified two classes that are deserializing in a wrong way.

**ModalImpl**: isn't using custom_id if available. When converting to data, it saves the id as custom_id

**TextInputImpl**: serializes minimum length as min_length but actually uses min_**L**ength 