### PR TITLE
Fix parsing error for AutoModResponse

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/automod/AutoModResponseImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/automod/AutoModResponseImpl.java
@@ -66,10 +66,11 @@ public class AutoModResponseImpl implements AutoModResponse
 
     public AutoModResponseImpl(Guild guild, DataObject json)
     {
+        DataObject metadata = json.getObject("metadata");
         this.type = AutoModResponse.Type.fromKey(json.getInt("type", -1));
-        this.channel = guild.getChannelById(GuildMessageChannel.class, json.getUnsignedLong("channel_id", 0L));
-        this.customMessage = json.getString("custom_message", null);
-        this.timeoutDuration = json.getUnsignedLong("duration_seconds", 0L);
+        this.channel = guild.getChannelById(GuildMessageChannel.class, metadata.getUnsignedLong("channel_id", 0L));
+        this.customMessage = metadata.getString("custom_message", null);
+        this.timeoutDuration = metadata.getUnsignedLong("duration_seconds", 0L);
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/automod/AutoModResponseImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/automod/AutoModResponseImpl.java
@@ -66,7 +66,7 @@ public class AutoModResponseImpl implements AutoModResponse
 
     public AutoModResponseImpl(Guild guild, DataObject json)
     {
-        DataObject metadata = json.getObject("metadata");
+        DataObject metadata = json.optObject("metadata").orElseGet(DataObject::empty);
         this.type = AutoModResponse.Type.fromKey(json.getInt("type", -1));
         this.channel = guild.getChannelById(GuildMessageChannel.class, metadata.getUnsignedLong("channel_id", 0L));
         this.customMessage = metadata.getString("custom_message", null);


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

## Issue
While rewriting a bot from Discord.js to Discord JDA, it was discovered that `AutoModResponseImpl` always returns 0 and null for `customMessage`, `timeoutDuration` and `channel`, respectively, despite these values being set.

## Cause
Upon investigation, it was found that these values are being accessed incorrectly. They are actually nested within a sub-object called `metadata`.

## Solution
This pull request addresses the issue by correctly accessing the `custom_message`, `duration_seconds` and `channel_id` values from the `metadata` object in `AutoModResponseImpl`.

## Changes
- Updated `AutoModResponseImpl` to access `custom_message`, `duration_seconds` and `channel_id` from the `metadata` object.
- Ensured that the correct values are now being returned when these properties are accessed.

Please review and let me know if any further changes or information are needed.
