### PR TITLE
Add `Guild#retrieveMemberVoiceState`

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2667,7 +2667,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
     default CacheRestAction<GuildVoiceState> retrieveMemberVoiceState(UserSnowflake user)
     {
         Checks.notNull(user, "User");
-        return retrieveMemberVoiceStateById(user.getId());
+        return retrieveMemberVoiceStateById(user.getIdLong());
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2587,13 +2587,6 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
     /**
      * Load the member's voice state for the specified user.
      *
-     * <br>If the member is already loaded it will be retrieved from {@link #getMemberById(long)} and
-     * the voice state is immediately provided by {@link Member#getVoiceState()}.
-     * The cache consistency directly relies on the enabled {@link GatewayIntent GatewayIntents} as {@link GatewayIntent#GUILD_MEMBERS GatewayIntent.GUILD_MEMBERS}
-     * and {@link GatewayIntent#GUILD_VOICE_STATES GatewayIntent.GUILD_VOICE_STATES} are required to keep the cache updated with the latest information.
-     * You can use {@link CacheRestAction#useCache(boolean) useCache(false)} to always
-     * make a new request, which is the default behavior if the required intents are disabled.
-     *
      * <p>Possible {@link net.dv8tion.jda.api.exceptions.ErrorResponseException ErrorResponseExceptions} include:
      * <ul>
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_VOICE_STATE}
@@ -2606,16 +2599,10 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return {@link RestAction} - Type: {@link GuildVoiceState}
      */
     @Nonnull
-    CacheRestAction<GuildVoiceState> retrieveMemberVoiceStateById(long id);
+    RestAction<GuildVoiceState> retrieveMemberVoiceStateById(long id);
 
     /**
      * Load the member's voice state for the specified user.
-     * <br>If the member is already loaded it will be retrieved from {@link #getMemberById(long)} and
-     * the voice state is immediately provided by {@link Member#getVoiceState()}.
-     * The cache consistency directly relies on the enabled {@link GatewayIntent GatewayIntents} as {@link GatewayIntent#GUILD_MEMBERS GatewayIntent.GUILD_MEMBERS}
-     * and {@link GatewayIntent#GUILD_VOICE_STATES GatewayIntent.GUILD_VOICE_STATES} are required to keep the cache updated with the latest information.
-     * You can use {@link CacheRestAction#useCache(boolean) useCache(false)} to always
-     * make a new request, which is the default behavior if the required intents are disabled.
      *
      * <p>Possible {@link net.dv8tion.jda.api.exceptions.ErrorResponseException ErrorResponseExceptions} include:
      * <ul>
@@ -2634,19 +2621,13 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return {@link RestAction} - Type: {@link GuildVoiceState}
      */
     @Nonnull
-    default CacheRestAction<GuildVoiceState> retrieveMemberVoiceStateById(@Nonnull String id)
+    default RestAction<GuildVoiceState> retrieveMemberVoiceStateById(@Nonnull String id)
     {
         return retrieveMemberVoiceStateById(MiscUtil.parseSnowflake(id));
     }
 
     /**
      * Load the member's voice state for the specified {@link UserSnowflake}.
-     * <br>If the member is already loaded it will be retrieved from {@link #getMemberById(long)} and
-     * the voice state is immediately provided by {@link Member#getVoiceState()}.
-     * The cache consistency directly relies on the enabled {@link GatewayIntent GatewayIntents} as {@link GatewayIntent#GUILD_MEMBERS GatewayIntent.GUILD_MEMBERS}
-     * and {@link GatewayIntent#GUILD_VOICE_STATES GatewayIntent.GUILD_VOICE_STATES} are required to keep the cache updated with the latest information.
-     * You can use {@link CacheRestAction#useCache(boolean) useCache(false)} to always
-     * make a new request, which is the default behavior if the required intents are disabled.
      *
      * <p>Possible {@link net.dv8tion.jda.api.exceptions.ErrorResponseException ErrorResponseExceptions} include:
      * <ul>
@@ -2664,7 +2645,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return {@link RestAction} - Type: {@link GuildVoiceState}
      */
     @Nonnull
-    default CacheRestAction<GuildVoiceState> retrieveMemberVoiceState(@Nonnull UserSnowflake user)
+    default RestAction<GuildVoiceState> retrieveMemberVoiceState(@Nonnull UserSnowflake user)
     {
         Checks.notNull(user, "User");
         return retrieveMemberVoiceStateById(user.getIdLong());

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2664,7 +2664,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return {@link RestAction} - Type: {@link GuildVoiceState}
      */
     @Nonnull
-    default CacheRestAction<GuildVoiceState> retrieveMemberVoiceState(UserSnowflake user)
+    default CacheRestAction<GuildVoiceState> retrieveMemberVoiceState(@Nonnull UserSnowflake user)
     {
         Checks.notNull(user, "User");
         return retrieveMemberVoiceStateById(user.getIdLong());

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2599,6 +2599,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return {@link RestAction} - Type: {@link GuildVoiceState}
      */
     @Nonnull
+    @CheckReturnValue
     RestAction<GuildVoiceState> retrieveMemberVoiceStateById(long id);
 
     /**
@@ -2621,6 +2622,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return {@link RestAction} - Type: {@link GuildVoiceState}
      */
     @Nonnull
+    @CheckReturnValue
     default RestAction<GuildVoiceState> retrieveMemberVoiceStateById(@Nonnull String id)
     {
         return retrieveMemberVoiceStateById(MiscUtil.parseSnowflake(id));
@@ -2645,6 +2647,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
      * @return {@link RestAction} - Type: {@link GuildVoiceState}
      */
     @Nonnull
+    @CheckReturnValue
     default RestAction<GuildVoiceState> retrieveMemberVoiceState(@Nonnull UserSnowflake user)
     {
         Checks.notNull(user, "User");

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2585,6 +2585,91 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
     List<GuildVoiceState> getVoiceStates();
 
     /**
+     * Load the member's voice state for the specified user.
+     * <br>If the member is already loaded it will be retrieved from {@link #getMemberById(long)} and
+     * the voice state is immediately provided by {@link Member#getVoiceState()}.
+     * The cache consistency directly relies on the enabled {@link GatewayIntent GatewayIntents} as {@link GatewayIntent#GUILD_MEMBERS GatewayIntent.GUILD_MEMBERS}
+     * and {@link GatewayIntent#GUILD_VOICE_STATES GatewayIntent.GUILD_VOICE_STATES} are required to keep the cache updated with the latest information.
+     * You can use {@link CacheRestAction#useCache(boolean) useCache(false)} to always
+     * make a new request, which is the default behavior if the required intents are disabled.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.exceptions.ErrorResponseException ErrorResponseExceptions} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_VOICE_STATE}
+     *     <br>The specified user does not exist, is not a member of this guild or is not connected to a voice channel</li>
+     * </ul>
+     *
+     * @param  id
+     *         The user id to load the voice state from
+     *
+     * @return {@link RestAction} - Type: {@link GuildVoiceState}
+     */
+    @Nonnull
+    CacheRestAction<GuildVoiceState> retrieveMemberVoiceStateById(long id);
+
+    /**
+     * Load the member's voice state for the specified user.
+     * <br>If the member is already loaded it will be retrieved from {@link #getMemberById(long)} and
+     * the voice state is immediately provided by {@link Member#getVoiceState()}.
+     * The cache consistency directly relies on the enabled {@link GatewayIntent GatewayIntents} as {@link GatewayIntent#GUILD_MEMBERS GatewayIntent.GUILD_MEMBERS}
+     * and {@link GatewayIntent#GUILD_VOICE_STATES GatewayIntent.GUILD_VOICE_STATES} are required to keep the cache updated with the latest information.
+     * You can use {@link CacheRestAction#useCache(boolean) useCache(false)} to always
+     * make a new request, which is the default behavior if the required intents are disabled.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.exceptions.ErrorResponseException ErrorResponseExceptions} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_VOICE_STATE}
+     *     <br>The specified user does not exist, is not a member of this guild or is not connected to a voice channel</li>
+     * </ul>
+     *
+     * @param  id
+     *         The user id to load the voice state from
+     *
+     * @throws IllegalArgumentException
+     *         If the provided id is empty or null
+     * @throws NumberFormatException
+     *         If the provided id is not a snowflake
+     *
+     * @return {@link RestAction} - Type: {@link GuildVoiceState}
+     */
+    @Nonnull
+    default CacheRestAction<GuildVoiceState> retrieveMemberVoiceStateById(@Nonnull String id)
+    {
+        return retrieveMemberVoiceStateById(MiscUtil.parseSnowflake(id));
+    }
+
+    /**
+     * Load the member's voice state for the specified {@link UserSnowflake}.
+     * <br>If the member is already loaded it will be retrieved from {@link #getMemberById(long)} and
+     * the voice state is immediately provided by {@link Member#getVoiceState()}.
+     * The cache consistency directly relies on the enabled {@link GatewayIntent GatewayIntents} as {@link GatewayIntent#GUILD_MEMBERS GatewayIntent.GUILD_MEMBERS}
+     * and {@link GatewayIntent#GUILD_VOICE_STATES GatewayIntent.GUILD_VOICE_STATES} are required to keep the cache updated with the latest information.
+     * You can use {@link CacheRestAction#useCache(boolean) useCache(false)} to always
+     * make a new request, which is the default behavior if the required intents are disabled.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.exceptions.ErrorResponseException ErrorResponseExceptions} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_VOICE_STATE}
+     *     <br>The specified user does not exist, is not a member of this guild or is not connected to a voice channel</li>
+     * </ul>
+     *
+     * @param  user
+     *         The {@link UserSnowflake} for the member's voice state to retrieve.
+     *         This can be a member or user instance or {@link User#fromId(long)}.
+     *
+     * @throws IllegalArgumentException
+     *         If provided with null
+     *
+     * @return {@link RestAction} - Type: {@link GuildVoiceState}
+     */
+    @Nonnull
+    default CacheRestAction<GuildVoiceState> retrieveMemberVoiceState(UserSnowflake user)
+    {
+        Checks.notNull(user, "User");
+        return retrieveMemberVoiceStateById(user.getId());
+    }
+
+    /**
      * Returns the verification-Level of this Guild. Verification level is one of the factors that determines if a Member
      * can send messages in a Guild.
      * <br>For a short description of the different values, see {@link net.dv8tion.jda.api.entities.Guild.VerificationLevel}.

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2586,6 +2586,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake
 
     /**
      * Load the member's voice state for the specified user.
+     *
      * <br>If the member is already loaded it will be retrieved from {@link #getMemberById(long)} and
      * the voice state is immediately provided by {@link Member#getVoiceState()}.
      * The cache consistency directly relies on the enabled {@link GatewayIntent GatewayIntents} as {@link GatewayIntent#GUILD_MEMBERS GatewayIntent.GUILD_MEMBERS}

--- a/src/main/java/net/dv8tion/jda/api/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/Route.java
@@ -122,6 +122,7 @@ public class Route
         public static final Route GET_GUILD_EMOJIS =   new Route(GET,    "guilds/{guild_id}/emojis");
         public static final Route GET_AUDIT_LOGS =     new Route(GET,    "guilds/{guild_id}/audit-logs");
         public static final Route GET_VOICE_REGIONS =  new Route(GET,    "guilds/{guild_id}/regions");
+        public static final Route GET_VOICE_STATE =    new Route(GET,    "guilds/{guild_id}/voice-states/{user_id}");
         public static final Route UPDATE_VOICE_STATE = new Route(PATCH,  "guilds/{guild_id}/voice-states/{user_id}");
 
         public static final Route GET_INTEGRATIONS =   new Route(GET,    "guilds/{guild_id}/integrations");

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -679,7 +679,10 @@ public class EntityBuilder
         final long channelId = newVoiceStateJson.getLong("channel_id");
         AudioChannel audioChannel = (AudioChannel) guild.getGuildChannelById(channelId);
         if (audioChannel != null)
-            ((AudioChannelMixin<?>) audioChannel).getConnectedMembersMap().put(member.getIdLong(), member);
+        {
+            if (member.getVoiceState() != null)
+                ((AudioChannelMixin<?>) audioChannel).getConnectedMembersMap().put(member.getIdLong(), member);
+        }
         else
             LOG.error("Received a GuildVoiceState with a channel ID for a non-existent channel! ChannelId: {} GuildId: {} UserId: {}",
                     channelId, guild.getId(), member.getId());

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -616,13 +616,13 @@ public class EntityBuilder
                 member.setFlags(memberJson.getInt("flags"));
 
             long boostTimestamp = memberJson.isNull("premium_since")
-                    ? 0
-                    : Helpers.toTimestamp(memberJson.getString("premium_since"));
+                ? 0
+                : Helpers.toTimestamp(memberJson.getString("premium_since"));
             member.setBoostDate(boostTimestamp);
 
             long timeOutTimestamp = memberJson.isNull("communication_disabled_until")
-                    ? 0
-                    : Helpers.toTimestamp(memberJson.getString("communication_disabled_until"));
+                ? 0
+                : Helpers.toTimestamp(memberJson.getString("communication_disabled_until"));
             member.setTimeOutEnd(timeOutTimestamp);
 
             if (!memberJson.isNull("pending"))

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -616,13 +616,13 @@ public class EntityBuilder
                 member.setFlags(memberJson.getInt("flags"));
 
             long boostTimestamp = memberJson.isNull("premium_since")
-                ? 0
-                : Helpers.toTimestamp(memberJson.getString("premium_since"));
+                    ? 0
+                    : Helpers.toTimestamp(memberJson.getString("premium_since"));
             member.setBoostDate(boostTimestamp);
 
             long timeOutTimestamp = memberJson.isNull("communication_disabled_until")
-                ? 0
-                : Helpers.toTimestamp(memberJson.getString("communication_disabled_until"));
+                    ? 0
+                    : Helpers.toTimestamp(memberJson.getString("communication_disabled_until"));
             member.setTimeOutEnd(timeOutTimestamp);
 
             if (!memberJson.isNull("pending"))
@@ -658,39 +658,47 @@ public class EntityBuilder
 
         // Load voice state and presence if necessary
         if (voiceStateJson != null && member.getVoiceState() != null)
-            createVoiceState(guild, voiceStateJson, user, member);
+            createGuildVoiceState(member, voiceStateJson);
         if (presence != null)
             createPresence(member, presence);
         return member;
     }
 
-    private void createVoiceState(GuildImpl guild, DataObject voiceStateJson, User user, MemberImpl member)
-    {
+    public GuildVoiceState createGuildVoiceState(MemberImpl member, DataObject voiceStateJson) {
         GuildVoiceStateImpl voiceState = (GuildVoiceStateImpl) member.getVoiceState();
+        if (voiceState == null)
+            voiceState = new GuildVoiceStateImpl(member);
+        updateGuildVoiceState(voiceState, voiceStateJson, member);
+        return voiceState;
+    }
 
-        final long channelId = voiceStateJson.getLong("channel_id");
+    private void updateGuildVoiceState(GuildVoiceStateImpl oldVoiceState, DataObject newVoiceStateJson, MemberImpl member)
+    {
+        Guild guild = member.getGuild();
+
+        final long channelId = newVoiceStateJson.getLong("channel_id");
         AudioChannel audioChannel = (AudioChannel) guild.getGuildChannelById(channelId);
         if (audioChannel != null)
             ((AudioChannelMixin<?>) audioChannel).getConnectedMembersMap().put(member.getIdLong(), member);
         else
             LOG.error("Received a GuildVoiceState with a channel ID for a non-existent channel! ChannelId: {} GuildId: {} UserId: {}",
-                      channelId, guild.getId(), user.getId());
+                    channelId, guild.getId(), member.getId());
 
-        String requestToSpeak = voiceStateJson.getString("request_to_speak_timestamp", null);
+        String requestToSpeak = newVoiceStateJson.getString("request_to_speak_timestamp", null);
         OffsetDateTime timestamp = null;
         if (requestToSpeak != null)
             timestamp = OffsetDateTime.parse(requestToSpeak);
 
         // VoiceState is considered volatile so we don't expect anything to actually exist
-        voiceState.setSelfMuted(voiceStateJson.getBoolean("self_mute"))
-                  .setSelfDeafened(voiceStateJson.getBoolean("self_deaf"))
-                  .setGuildMuted(voiceStateJson.getBoolean("mute"))
-                  .setGuildDeafened(voiceStateJson.getBoolean("deaf"))
-                  .setSuppressed(voiceStateJson.getBoolean("suppress"))
-                  .setSessionId(voiceStateJson.getString("session_id"))
-                  .setStream(voiceStateJson.getBoolean("self_stream"))
-                  .setRequestToSpeak(timestamp)
-                  .setConnectedChannel(audioChannel);
+        oldVoiceState.setSelfMuted(newVoiceStateJson.getBoolean("self_mute"))
+                .setSelfDeafened(newVoiceStateJson.getBoolean("self_deaf"))
+                .setGuildMuted(newVoiceStateJson.getBoolean("mute"))
+                .setGuildDeafened(newVoiceStateJson.getBoolean("deaf"))
+                .setSuppressed(newVoiceStateJson.getBoolean("suppress"))
+                .setSessionId(newVoiceStateJson.getString("session_id"))
+                .setStream(newVoiceStateJson.getBoolean("self_stream"))
+                .setRequestToSpeak(timestamp)
+                .setConnectedChannel(audioChannel);
     }
 
     public void updateMember(GuildImpl guild, MemberImpl member, DataObject content, List<Role> newRoles)

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1155,6 +1155,7 @@ public class GuildImpl implements Guild
 
     @Nonnull
     @Override
+    @CheckReturnValue
     public RestAction<GuildVoiceState> retrieveMemberVoiceStateById(long id)
     {
         JDAImpl jda = getJDA();

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1155,28 +1155,18 @@ public class GuildImpl implements Guild
 
     @Nonnull
     @Override
-    public CacheRestAction<GuildVoiceState> retrieveMemberVoiceStateById(long id)
+    public RestAction<GuildVoiceState> retrieveMemberVoiceStateById(long id)
     {
         JDAImpl jda = getJDA();
-        return new DeferredRestAction<>(jda, GuildVoiceState.class,
-                () ->
-                {
-                    MemberImpl member = (MemberImpl) getMemberById(id);
-                    return member == null ? null : member.getVoiceState();
-                },
-                () ->
-                {
-                    Route.CompiledRoute route = Route.Guilds.GET_VOICE_STATE.compile(getId(), Long.toUnsignedString(id));
-                    return new RestActionImpl<>(jda, route, (response, request) ->
-                    {
-                        EntityBuilder entityBuilder = jda.getEntityBuilder();
-                        DataObject voiceStateData = response.getObject();
-                        //Creates voice state if VOICE_STATE cache flag is set
-                        MemberImpl member = entityBuilder.createMember(this, voiceStateData.getObject("member"), voiceStateData, null);
-                        entityBuilder.updateMemberCache(member);
-                        return entityBuilder.createGuildVoiceState(member, voiceStateData);
-                    });
-                }).useCache(jda.isIntent(GatewayIntent.GUILD_MEMBERS) && jda.isIntent(GatewayIntent.GUILD_VOICE_STATES));
+        Route.CompiledRoute route = Route.Guilds.GET_VOICE_STATE.compile(getId(), Long.toUnsignedString(id));
+        return new RestActionImpl<>(jda, route, (response, request) ->
+        {
+            EntityBuilder entityBuilder = jda.getEntityBuilder();
+            DataObject voiceStateData = response.getObject();
+            MemberImpl member = entityBuilder.createMember(this, voiceStateData.getObject("member"), voiceStateData, null);
+            entityBuilder.updateMemberCache(member);
+            return entityBuilder.createGuildVoiceState(member, voiceStateData);
+        });
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1164,7 +1164,7 @@ public class GuildImpl implements Guild
         {
             EntityBuilder entityBuilder = jda.getEntityBuilder();
             DataObject voiceStateData = response.getObject();
-            MemberImpl member = entityBuilder.createMember(this, voiceStateData.getObject("member"), voiceStateData, null);
+            MemberImpl member = entityBuilder.createMember(this, voiceStateData.getObject("member"), null, null);
             entityBuilder.updateMemberCache(member);
             return entityBuilder.createGuildVoiceState(member, voiceStateData);
         });


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Discord recently added an API endpoint to get a user's voice state in a guild (https://discord.com/developers/docs/resources/voice).
Adds `Guild#retrieveMemberVoiceState`, `Guild#retrieveMemberVoiceStateById(long)` and `Guild#retrieveMemberVoiceStateById(String)` that send a request and create a new `GuildVoiceState` if not already cached.

Also makes changes to `EntityBuilder` to allow the creation of voice states from JSON and `Route` for the new endpoint.