### PR TITLE
Remove `@CheckReturnValue` from Once.Builder.subscribe

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/Once.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Once.java
@@ -26,7 +26,6 @@ import net.dv8tion.jda.internal.utils.JDALogger;
 import net.dv8tion.jda.internal.utils.concurrent.task.GatewayTask;
 import org.slf4j.Logger;
 
-import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.Duration;
@@ -276,7 +275,6 @@ public class Once<E extends GenericEvent> implements EventListener
          * @see Task#get()
          */
         @Nonnull
-        @CheckReturnValue
         public Task<E> subscribe(@Nonnull Consumer<E> callback)
         {
             final Once<E> once = new Once<>(jda, eventType, filters, timeoutCallback, timeout, timeoutPool);


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Users are not required to use the return value
