### PR TITLE
Add `ScheduledEvent::getJumpUrl`

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/ScheduledEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ScheduledEvent.java
@@ -37,6 +37,12 @@ import java.time.OffsetDateTime;
  */
 public interface ScheduledEvent extends ISnowflake, Comparable<ScheduledEvent>
 {
+
+    /**
+     * Template for {@link #getJumpUrl()}. Args: .../guild_id/event_id
+     */
+    String JUMP_URL = "https://discord.com/events/%s/%s";
+
     /**
      * The maximum allowed length for an event's name.
      */
@@ -200,6 +206,14 @@ public interface ScheduledEvent extends ISnowflake, Comparable<ScheduledEvent>
      */
     @Nonnull
     String getLocation();
+
+    /**
+     * Returns the jump-to URL of the event. Clicking this URL in the Discord client will open the event.
+     *
+     * @return A String representing the jump-to URL of the event.
+     */
+    @Nonnull
+    String getJumpUrl();
 
     /**
      * Deletes this Scheduled Event.

--- a/src/main/java/net/dv8tion/jda/internal/entities/ScheduledEventImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ScheduledEventImpl.java
@@ -17,6 +17,7 @@ package net.dv8tion.jda.internal.entities;
 
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.ScheduledEvent;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.unions.GuildChannelUnion;
@@ -29,6 +30,8 @@ import net.dv8tion.jda.internal.managers.ScheduledEventManagerImpl;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.pagination.ScheduledEventMembersPaginationActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -131,6 +134,12 @@ public class ScheduledEventImpl implements ScheduledEvent
     public String getLocation()
     {
         return location;
+    }
+
+    @NotNull
+    @Override
+    public String getJumpUrl(){
+        return Helpers.format(ScheduledEvent.JUMP_URL, getGuild().getId(), getId());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/ScheduledEventImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ScheduledEventImpl.java
@@ -17,7 +17,6 @@ package net.dv8tion.jda.internal.entities;
 
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.ScheduledEvent;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.unions.GuildChannelUnion;

--- a/src/test/java/net/dv8tion/jda/test/entities/scheduledevent/ScheduledEventTest.java
+++ b/src/test/java/net/dv8tion/jda/test/entities/scheduledevent/ScheduledEventTest.java
@@ -1,0 +1,29 @@
+package net.dv8tion.jda.test.entities.scheduledevent;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.ScheduledEvent;
+import net.dv8tion.jda.internal.JDAImpl;
+import net.dv8tion.jda.internal.entities.GuildImpl;
+import net.dv8tion.jda.internal.entities.ScheduledEventImpl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ScheduledEventTest{
+
+    @Test
+    void testGetJumpUrl(){
+
+        long guildId = 7777777;
+        long eventId = 333;
+
+        String expected = "https://discord.com/events/" + guildId + "/" + eventId;
+
+        Guild guild = new GuildImpl(new JDAImpl(null), guildId);
+
+        ScheduledEvent scheduledEvent = new ScheduledEventImpl(eventId, guild);
+
+        Assertions.assertEquals(expected, scheduledEvent.getJumpUrl());
+
+    }
+
+}


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette
- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes
- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____

## Description
Added the `getJumpUrl` method to the `ScheduledEvent` interface, and implemented it in `ScheduledEventImpl` class (the only implementation of `ScheduledEvent`).
