### PR TITLE
Fix ScheduledEventManagerImpl::setStatus

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/managers/ScheduledEventManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/ScheduledEventManagerImpl.java
@@ -165,10 +165,11 @@ public class ScheduledEventManagerImpl extends ManagerBase<ScheduledEventManager
     public ScheduledEventManager setStatus(@Nonnull ScheduledEvent.Status newStatus)
     {
         Checks.notNull(newStatus, "Status");
-        switch (newStatus){
+        switch (newStatus)
+        {
             case SCHEDULED:
             case UNKNOWN:
-                throw new IllegalArgumentException("Invalid new status: " + newStatus);
+                throw new IllegalArgumentException("Cannot change scheduled event status to " + newStatus);
         }
 
         //get the current status of the event. multiple-usage
@@ -180,7 +181,7 @@ public class ScheduledEventManagerImpl extends ManagerBase<ScheduledEventManager
                 //event is scheduled -> new status can be only active or cancel
                 Checks.check(
                         newStatus == ScheduledEvent.Status.ACTIVE || newStatus == ScheduledEvent.Status.CANCELED,
-                        "Cannot perform status update! A scheduled event can only be set to active or canceled status."
+                        "Cannot perform status update! A scheduled event with status SCHEDULED can only be set to ACTIVE or CANCELED status."
                 );
                 break;
 
@@ -188,7 +189,7 @@ public class ScheduledEventManagerImpl extends ManagerBase<ScheduledEventManager
                 //event is active -> new status can be only completed
                 Checks.check(
                         newStatus == ScheduledEvent.Status.COMPLETED,
-                        "Cannot perform status updated! An active event can only be set to completed status."
+                        "Cannot perform status updated! A scheduled event with status ACTIVE can only be set to COMPLETED status."
                 );
                 break;
 

--- a/src/main/java/net/dv8tion/jda/internal/managers/ScheduledEventManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/ScheduledEventManagerImpl.java
@@ -165,8 +165,30 @@ public class ScheduledEventManagerImpl extends ManagerBase<ScheduledEventManager
     public ScheduledEventManager setStatus(@Nonnull ScheduledEvent.Status status)
     {
         Checks.notNull(status, "Status");
-        Checks.check(status != ScheduledEvent.Status.UNKNOWN, "Cannot set the event status to an unknown status!");
-        Checks.check(status != ScheduledEvent.Status.SCHEDULED && getScheduledEvent().getStatus() != ScheduledEvent.Status.ACTIVE, "Cannot perform status update!");
+        Checks.check(
+                status != ScheduledEvent.Status.UNKNOWN && status != ScheduledEvent.Status.SCHEDULED,
+                "Cannot set the event status to an unknown or scheduled status!"
+        );
+
+        //get the current status of the event. multiple-usages
+        ScheduledEvent.Status eventStatus = getScheduledEvent().getStatus();
+
+        //event should be different from complete and cancel
+        Checks.check(
+                eventStatus != ScheduledEvent.Status.COMPLETED && eventStatus != ScheduledEvent.Status.CANCELED,
+                "Cannot perform status update! Event is completed or canceled."
+        );
+        //if event is scheduled -> new status can be only active or cancel
+        Checks.check(
+                !(eventStatus == ScheduledEvent.Status.SCHEDULED && status != ScheduledEvent.Status.ACTIVE && status != ScheduledEvent.Status.CANCELED),
+                "Cannot perform status update! A scheduled event can be set only to active or canceled status."
+        );
+        //if event is active -> new status can be only completed
+        Checks.check(
+                !(eventStatus == ScheduledEvent.Status.ACTIVE && status != ScheduledEvent.Status.COMPLETED),
+                "Cannot perform status updated! An active event can be set only completed status."
+        );
+
         this.status = status;
         set |= STATUS;
         return this;


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/
[documentation]: https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-valid-guild-scheduled-event-status-transitions
## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description
The check `status != ScheduledEvent.Status.SCHEDULED && getScheduledEvent().getStatus() != ScheduledEvent.Status.ACTIVE` is not correct.
According to Discord [documentation] you can set ACTIVE to COMPLETED, but if the event was ACTIVE, the `check` was always false and throwing error.

New checks:
 - Current status should be different than COMPLETED or CANCELED
 - If current status is SCHEDULED, the new one can be only ACTIVE or CANCELED
 - If current status is ACTIVE, the new one can be only COMPLETED

I also updated the first check which verifies the new status to not be UNKNOWN.
I added the condition that the new status to not be SCHEDULED too.
