### PR TITLE
Fix handling of passing null to setMessageReference

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageCreateActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageCreateActionImpl.java
@@ -149,8 +149,13 @@ public class MessageCreateActionImpl extends RestActionImpl<Message> implements 
     @Override
     public MessageCreateAction setMessageReference(@Nullable String messageId)
     {
-        if (messageId != null)
-            Checks.isSnowflake(messageId);
+        if (messageId == null)
+        {
+            this.messageReference = null;
+            return this;
+        }
+
+        Checks.isSnowflake(messageId);
         String guildId = null;
         if (channel instanceof GuildChannel)
             guildId = ((GuildChannel) channel).getGuild().getId();

--- a/src/test/java/net/dv8tion/jda/test/restaction/MessageCreateActionTest.java
+++ b/src/test/java/net/dv8tion/jda/test/restaction/MessageCreateActionTest.java
@@ -266,6 +266,21 @@ public class MessageCreateActionTest extends IntegrationTest
             .whenQueueCalled();
     }
 
+    @Test
+    void testSetMessageReferenceNull()
+    {
+        MessageCreateActionImpl action = new MessageCreateActionImpl(channel);
+
+        action.setMessageReference((String) null);
+        action.setContent("test content");
+        action.failOnInvalidReply(true);
+
+        assertThatRequestFrom(action)
+            .hasBodyEqualTo(defaultMessageRequest()
+                .put("content", "test content"))
+            .whenQueueCalled();
+    }
+
     @Nonnull
     protected DataObject normalizeRequestBody(@Nonnull DataObject body)
     {


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This fixes the handling of `setMessageReference((String) null)`. The previous release introduced a bug that caused this code to serialize invalid request bodies.
