### PR TITLE
Fix typo in JDA#isAutoReconnect javadocs

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -1865,7 +1865,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
     void setRequestTimeoutRetry(boolean retryOnTimeout);
 
     /**
-     * USed to determine whether or not autoReconnect is enabled for JDA.
+     * Used to determine whether or not autoReconnect is enabled for JDA.
      *
      * @return True if JDA will attempt to automatically reconnect when a connection-error is encountered.
      */


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fix typo in JDA#isAutoReconnect javadocs that I found when reading JDA's sopurce code... Previously it was `USed` so I fixed it to `Used`, yeah, that's it.
