### PR TITLE
Updating Dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -149,6 +149,9 @@ dependencies {
 
     //Audio crypto libraries
     implementation(libs.tink)
+    implementation(libs.protobuf.java) {
+        because("Overrides transitive dependency from tink to address CVE-2024-7254.")
+    }
 
     //Sets the dependencies for the examples
     configurations["examplesImplementation"].withDependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,8 +23,9 @@ dependencyResolutionManagement {
             library("mockito",               "org.mockito",              "mockito-core"        ).version("5.11.0")
             library("reflections",           "org.reflections",          "reflections"         ).version("0.10.2")
             library("slf4j",                 "org.slf4j",                "slf4j-api"           ).version("2.0.13")
-            library("tink",                  "com.google.crypto.tink",   "tink"                ).version("1.14.1")
+            library("tink",                  "com.google.crypto.tink",   "tink"                ).version("1.15.0")
             library("archunit",              "com.tngtech.archunit",     "archunit"            ).version("1.3.0")
+            library("protobuf-java",         "com.google.protobuf",      "protobuf-java"       ).version("3.25.5")
         }
     }
 }


### PR DESCRIPTION
## Description

Updated tink from 1.14.1 to 1.15.0
Updated protobuf-java from 3.25.3 to 3.25.5 (transitive dependency from tink, vulnerable in the current version of tink)

Addressed CVE:
CVE-2024-7254

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: Dependency Update (Vulnerability)

Closes Issue: NaN
