### PR TITLE
Correctly handle disabled intent in setEnabledIntents

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/JDABuilder.java
@@ -1554,7 +1554,7 @@ public class JDABuilder
     {
         this.intents = GatewayIntent.ALL_INTENTS;
         if (intents != null)
-            this.intents &= ~GatewayIntent.getRaw(intents);
+            this.intents = 1 | (GatewayIntent.ALL_INTENTS & ~GatewayIntent.getRaw(intents));
         return this;
     }
 
@@ -1646,7 +1646,7 @@ public class JDABuilder
         Checks.notNull(intent, "Intents");
         Checks.noneNull(intents, "Intents");
         EnumSet<GatewayIntent> set = EnumSet.of(intent, intents);
-        return setDisabledIntents(EnumSet.complementOf(set));
+        return setEnabledIntents(set);
     }
 
     /**
@@ -1673,11 +1673,9 @@ public class JDABuilder
     public JDABuilder setEnabledIntents(@Nullable Collection<GatewayIntent> intents)
     {
         if (intents == null || intents.isEmpty())
-            setDisabledIntents(EnumSet.allOf(GatewayIntent.class));
-        else if (intents instanceof EnumSet)
-            setDisabledIntents(EnumSet.complementOf((EnumSet<GatewayIntent>) intents));
+            this.intents = 1;
         else
-            setDisabledIntents(EnumSet.complementOf(EnumSet.copyOf(intents)));
+            this.intents = 1 | GatewayIntent.getRaw(intents);
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -2018,7 +2018,7 @@ public class  DefaultShardManagerBuilder
     {
         this.intents = GatewayIntent.ALL_INTENTS;
         if (intents != null)
-            this.intents &= ~GatewayIntent.getRaw(intents);
+            this.intents = 1 | ~GatewayIntent.getRaw(intents);
         return this;
     }
 
@@ -2110,7 +2110,7 @@ public class  DefaultShardManagerBuilder
         Checks.notNull(intent, "Intent");
         Checks.noneNull(intents, "Intent");
         EnumSet<GatewayIntent> set = EnumSet.of(intent, intents);
-        return setDisabledIntents(EnumSet.complementOf(set));
+        return setEnabledIntents(set);
     }
 
     /**
@@ -2137,11 +2137,9 @@ public class  DefaultShardManagerBuilder
     public DefaultShardManagerBuilder setEnabledIntents(@Nullable Collection<GatewayIntent> intents)
     {
         if (intents == null || intents.isEmpty())
-            setDisabledIntents(EnumSet.allOf(GatewayIntent.class));
-        else if (intents instanceof EnumSet)
-            setDisabledIntents(EnumSet.complementOf((EnumSet<GatewayIntent>) intents));
+            this.intents = 1;
         else
-            setDisabledIntents(EnumSet.complementOf(EnumSet.copyOf(intents)));
+            this.intents = 1 | GatewayIntent.getRaw(intents);
         return this;
     }
 

--- a/src/test/java/net/dv8tion/jda/test/JDABuilderTest.java
+++ b/src/test/java/net/dv8tion/jda/test/JDABuilderTest.java
@@ -148,19 +148,40 @@ public class JDABuilderTest
         assertThat(logs).contains("Member chunking is disabled due to missing GUILD_MEMBERS intent.");
     }
 
-    @Test
+    @EnumSource
+    @ParameterizedTest
     @SuppressWarnings("deprecation")
-    void testDeprecatedIntentDoesNotDisableCache()
+    void testDeprecatedIntentDoesNotDisableCache(IntentTestCase testCase)
     {
-        TestJDABuilder builder = new TestJDABuilder(GatewayIntent.GUILD_EMOJIS_AND_STICKERS.getRawValue());
-        builder.applyIntents();
+        TestJDABuilder builder;
+
+        switch (testCase)
+        {
+        case PASSED_TO_FACTORY:
+            builder = new TestJDABuilder(GatewayIntent.GUILD_EMOJIS_AND_STICKERS.getRawValue());
+            builder.applyIntents();
+            break;
+        case PASSED_TO_RELATIVE:
+            builder = new TestJDABuilder(0);
+            builder.applyLight();
+            builder.enableIntents(GatewayIntent.GUILD_EMOJIS_AND_STICKERS);
+            builder.enableCache(CacheFlag.EMOJI, CacheFlag.STICKER);
+            break;
+        case PASSED_TO_SETTER:
+            builder = new TestJDABuilder(0);
+            builder.applyLight();
+            builder.setEnabledIntents(GatewayIntent.GUILD_EMOJIS_AND_STICKERS);
+            builder.enableCache(CacheFlag.EMOJI, CacheFlag.STICKER);
+            break;
+        default:
+            throw new AssertionError("Unexpected test case " + testCase);
+        }
 
         List<String> logs = captureLogging(() ->
             assertThatNoException().isThrownBy(builder::checkIntents)
         );
 
         assertThat(logs)
-            .isNotEmpty()
             .noneMatch(log -> log.contains("CacheFlag." + CacheFlag.EMOJI))
             .noneMatch(log -> log.contains("CacheFlag." + CacheFlag.STICKER));
     }
@@ -214,5 +235,12 @@ public class JDABuilderTest
         {
             super.checkIntents();
         }
+    }
+
+    enum IntentTestCase
+    {
+        PASSED_TO_FACTORY,
+        PASSED_TO_RELATIVE,
+        PASSED_TO_SETTER;
     }
 }

--- a/src/test/java/net/dv8tion/jda/test/JDABuilderTest.java
+++ b/src/test/java/net/dv8tion/jda/test/JDABuilderTest.java
@@ -102,7 +102,6 @@ public class JDABuilderTest
         }
     }
 
-
     @ParameterizedTest
     @EnumSource(CacheFlag.class)
     void testRequiredIntentForCacheFlagEnabled(CacheFlag cacheFlag)
@@ -110,6 +109,14 @@ public class JDABuilderTest
         GatewayIntent requiredIntent = cacheFlag.getRequiredIntent();
         TestJDABuilder builder = new TestJDABuilder(requiredIntent != null ? requiredIntent.getRawValue() : 0);
         builder.applyIntents();
+        builder.enableCache(cacheFlag);
+
+        assertThatNoException().isThrownBy(builder::checkIntents);
+
+        builder = new TestJDABuilder(0);
+        builder.applyIntents();
+        if (requiredIntent != null)
+            builder.setEnabledIntents(requiredIntent);
         builder.enableCache(cacheFlag);
 
         assertThatNoException().isThrownBy(builder::checkIntents);


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

If one of the two overlapping intents is missing, it was disabled due to `complementOf`.
