### PR TITLE
Handle user in EntityBuilder#createApplicationEmoji as optional

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -693,7 +693,7 @@ public class JDAImpl implements JDA
         return new RestActionImpl<>(this, route, body, (response, request) ->
         {
             final DataObject obj = response.getObject();
-            return entityBuilder.createApplicationEmoji(this, obj);
+            return entityBuilder.createApplicationEmoji(this, obj, true);
         });
     }
 
@@ -710,7 +710,7 @@ public class JDAImpl implements JDA
             {
                 try
                 {
-                    list.add(entityBuilder.createApplicationEmoji(this, emojis.getObject(i)));
+                    list.add(entityBuilder.createApplicationEmoji(this, emojis.getObject(i), false));
                 }
                 catch (ParsingException e)
                 {
@@ -729,7 +729,7 @@ public class JDAImpl implements JDA
         Checks.isSnowflake(emojiId);
         Route.CompiledRoute route = Route.Applications.GET_APPLICATION_EMOJI.compile(getSelfUser().getApplicationId(), emojiId);
         return new RestActionImpl<>(this, route,
-                (response, request) -> entityBuilder.createApplicationEmoji(this, response.getObject())
+                (response, request) -> entityBuilder.createApplicationEmoji(this, response.getObject(), false)
         );
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1021,10 +1021,15 @@ public class EntityBuilder
                 .setAvailable(json.getBoolean("available", true));
     }
 
-    public ApplicationEmojiImpl createApplicationEmoji(JDAImpl api, DataObject json)
+    public ApplicationEmojiImpl createApplicationEmoji(JDAImpl api, DataObject json, boolean newlyCreated)
     {
         final long emojiId = json.getUnsignedLong("id");
-        final User user = createUser(json.getObject("user"));
+        final User user = newlyCreated
+                ? api.getSelfUser()
+                : json.optObject("user")
+                    .map(this::createUser)
+                    .orElse(null);
+
         return new ApplicationEmojiImpl(emojiId, api, user)
                 .setAnimated(json.getBoolean("animated"))
                 .setName(json.getString("name"));

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1021,16 +1021,11 @@ public class EntityBuilder
                 .setAvailable(json.getBoolean("available", true));
     }
 
-    public ApplicationEmojiImpl createApplicationEmoji(JDAImpl api, DataObject json, boolean newlyCreated)
+    public ApplicationEmojiImpl createApplicationEmoji(JDAImpl api, DataObject json, User owner)
     {
         final long emojiId = json.getUnsignedLong("id");
-        final User user = newlyCreated
-                ? api.getSelfUser()
-                : json.optObject("user")
-                    .map(this::createUser)
-                    .orElse(null);
 
-        return new ApplicationEmojiImpl(emojiId, api, user)
+        return new ApplicationEmojiImpl(emojiId, api, owner)
                 .setAnimated(json.getBoolean("animated"))
                 .setName(json.getString("name"));
     }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Handle user in `EntityBuilder#createApplicationEmoji` as optional, and use self-user if it was created by `JDA#createApplicationEmoji`
