### PR TITLE
Add common interface for interactions with a custom ID

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/CustomIdInteraction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/CustomIdInteraction.java
@@ -1,0 +1,29 @@
+package net.dv8tion.jda.api.interactions;
+
+import net.dv8tion.jda.api.interactions.components.ComponentInteraction;
+import net.dv8tion.jda.api.interactions.modals.ModalInteraction;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Interactions which have a custom ID, namely {@link ComponentInteraction} and {@link  ModalInteraction}.
+ *
+ * <br>This id does not have to be numerical.
+ *
+ */
+public interface CustomIdInteraction
+{
+    /**
+     * The custom ID provided to the component or modal when it was originally created.
+     * <br>This value should be used to determine what action to take in regard to this interaction.
+     *
+     * <br>This id does not have to be numerical.
+     *
+     * @return The custom ID
+     *
+     * @see ComponentInteraction#getComponentId()
+     * @see ModalInteraction#getModalId()
+     */
+    @Nonnull
+    String getCustomId();
+}

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/ComponentInteraction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/ComponentInteraction.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.api.interactions.components;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.unions.GuildMessageChannelUnion;
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.interactions.CustomIdInteraction;
 import net.dv8tion.jda.api.interactions.callbacks.IMessageEditCallback;
 import net.dv8tion.jda.api.interactions.callbacks.IModalCallback;
 import net.dv8tion.jda.api.interactions.callbacks.IPremiumRequiredReplyCallback;
@@ -32,8 +33,16 @@ import javax.annotation.Nonnull;
  * <p>Instead of {@link #deferReply()} and {@link #reply(String)} you can use {@link #deferEdit()} and {@link #editMessage(String)} with these interactions!
  * <b>You can only acknowledge an interaction once!</b>
  */
-public interface ComponentInteraction extends IReplyCallback, IMessageEditCallback, IModalCallback, IPremiumRequiredReplyCallback
+public interface ComponentInteraction extends IReplyCallback, IMessageEditCallback, IModalCallback, IPremiumRequiredReplyCallback, CustomIdInteraction
 {
+
+    @Override
+    @Nonnull
+    default String getCustomId()
+    {
+        return getComponentId();
+    }
+
     /**
      * The custom component ID provided to the component when it was originally created.
      * <br>This value should be used to determine what action to take in regard to this interaction.

--- a/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalInteraction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalInteraction.java
@@ -19,9 +19,11 @@ package net.dv8tion.jda.api.interactions.modals;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.unions.GuildMessageChannelUnion;
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.interactions.CustomIdInteraction;
 import net.dv8tion.jda.api.interactions.callbacks.IMessageEditCallback;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.Nonnull;
@@ -36,8 +38,16 @@ import java.util.List;
  *
  * @see    net.dv8tion.jda.api.events.interaction.ModalInteractionEvent
  */
-public interface ModalInteraction extends IReplyCallback, IMessageEditCallback
+public interface ModalInteraction extends IReplyCallback, IMessageEditCallback, CustomIdInteraction
 {
+
+    @Override
+    @NotNull
+    default String getCustomId()
+    {
+        return getModalId();
+    }
+
     /**
      * Returns the custom id of the Modal in question
      *


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ 

Closes Issue: N/A

## Description

Creates a common interface, `CustomIdInteraction` for all interactions that support a user provided custom id, namely components and modals. In the [Discord API](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object), the id is always called `custom_id`, only JDA introduces a distinction between `componentId` and `modalId`. 

### Use case:
Assume an interaction framework that listens for  `GenericInteractionCreateEvent`. Using pattern matching in switch we want to determine if we need a new event handler or use an existing one. 

#### Currently this looks like this:
```java
var handler = switch (genericInteractionCreateEvent) {
    case SlashCommandInteractionEvent _, GenericContextInteractionEvent<?> _,
         CommandAutoCompleteInteractionEvent _ ->
            newHandler();
    case GenericComponentInteractionCreateEvent event when handlerExists(event.getComponentId()) ->
            getHandler(event.getComponentId());
    case ModalInteractionEvent event when handlerExists(event.getModalId()) ->
            getHandler(event.getComponentId());
    case GenericComponentInteractionCreateEvent event when shouldCreate(event.getComponentId()) ->
            newHandler();
    case ModalInteractionEvent event when shouldCreate(event.getModalId()) ->
            newHandler();
    default -> throw new UnsupportedOperationException("Unsupported jda event: %s".formatted(genericInteractionCreateEvent));
};
```

#### With common interface:
```java
var handler = switch (genericInteractionCreateEvent) {
    case SlashCommandInteractionEvent _, GenericContextInteractionEvent<?> _,
         CommandAutoCompleteInteractionEvent _ ->
            newHandler();
    case CustomIdInteraction interaction when handlerExists(interaction.getCustomId()) ->
            getHandler(interaction.getCustomId());
    case CustomIdInteraction interaction when shouldCreate(interaction.getCustomId()) ->
            newHandler();
    default -> throw new UnsupportedOperationException("Unsupported jda event: %s".formatted(genericInteractionCreateEvent));
};
```

### Pros
- Alignment with Discord API
- Useful for pattern matching

### Cons
- The current approach leaves us with two methods that do exactly the same thing, which can be confusing
- Alternatively, if we would deprecate the [`getComponentId`](https://docs.jda.wiki/net/dv8tion/jda/api/events/interaction/component/GenericComponentInteractionCreateEvent.html#getComponentId()) and [`getModalId`](https://docs.jda.wiki/net/dv8tion/jda/api/events/interaction/ModalInteractionEvent.html#getModalId()) methods we would break a lot of end user code

---
I'm up for discussions and aware that the use case might not affect some users, since JDA still uses Java 8