### PR TITLE
Fixing Get Poll Answers endpoint limit from 1000 to 100

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PollVotersPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PollVotersPaginationActionImpl.java
@@ -36,7 +36,7 @@ public class PollVotersPaginationActionImpl extends PaginationActionImpl<User, P
 {
     public PollVotersPaginationActionImpl(JDA jda, String channelId, String messageId, long answerId)
     {
-        super(jda, Route.Messages.GET_POLL_ANSWER_VOTERS.compile(channelId, messageId, Long.toString(answerId)), 1, 1000, 1000);
+        super(jda, Route.Messages.GET_POLL_ANSWER_VOTERS.compile(channelId, messageId, Long.toString(answerId)), 1, 100, 100);
         this.order = PaginationOrder.FORWARD;
     }
 

--- a/src/test/java/net/dv8tion/jda/test/entities/message/PollVotersPaginationTest.java
+++ b/src/test/java/net/dv8tion/jda/test/entities/message/PollVotersPaginationTest.java
@@ -35,7 +35,7 @@ public class PollVotersPaginationTest extends IntegrationTest
     {
         assertThatRequestFrom(newAction())
             .hasMethod(Method.GET)
-            .hasCompiledRoute("channels/381886978205155338/polls/1228092239079804968/answers/5?limit=1000&after=0")
+            .hasCompiledRoute("channels/381886978205155338/polls/1228092239079804968/answers/5?limit=100&after=0")
             .whenQueueCalled();
     }
 
@@ -45,7 +45,7 @@ public class PollVotersPaginationTest extends IntegrationTest
         long randomId = random.nextLong();
         assertThatRequestFrom(newAction().skipTo(randomId))
             .hasMethod(Method.GET)
-            .hasQueryParams("limit", "1000", "after", Long.toUnsignedString(randomId))
+            .hasQueryParams("limit", "100", "after", Long.toUnsignedString(randomId))
             .whenQueueCalled();
     }
 


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Corrects the default max and initial limits of the *Get Answer Voters* endpoint handled in `PollVotersPaginationActionImpl.java` from 1000 to 100 as specified in the [docs](https://discord.com/developers/docs/resources/poll#get-answer-voters). Simply updates the values in its constructor.

## Hotfix

Without updating the limit before execution, the request always fails. Because `PollVotersPaginationActionImpl` is a `PaginationAction`, users can temporarily correct it by chaining `.limit(100)` to their request. Example:
```java
pollMessage.retrievePollVoters(answerID).limit(100).queue();
```