### PR TITLE
Add a way to retrieve users that used super reaction

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2115,6 +2115,10 @@ public interface Message extends ISnowflake, Formattable
     /**
      * This obtains the {@link User users} who reacted using the given {@link Emoji}.
      *
+     * <br>By default, this only includes users that reacted with {@link MessageReaction.ReactionType#NORMAL}.
+     * Use {@link #retrieveReactionUsers(Emoji, MessageReaction.ReactionType) retrieveReactionUsers(emoji, ReactionType.SUPER)}
+     * to retrieve the users that used a super reaction instead.
+     *
      * <p>Messages maintain a list of reactions, alongside a list of users who added them.
      *
      * <p>Using this data, we can obtain a {@link ReactionPaginationAction}
@@ -2149,7 +2153,51 @@ public interface Message extends ISnowflake, Formattable
      */
     @Nonnull
     @CheckReturnValue
-    ReactionPaginationAction retrieveReactionUsers(@Nonnull Emoji emoji);
+    default ReactionPaginationAction retrieveReactionUsers(@Nonnull Emoji emoji)
+    {
+        return retrieveReactionUsers(emoji, MessageReaction.ReactionType.NORMAL);
+    }
+
+    /**
+     * This obtains the {@link User users} who reacted using the given {@link Emoji}.
+     *
+     * <p>Messages maintain a list of reactions, alongside a list of users who added them.
+     *
+     * <p>Using this data, we can obtain a {@link ReactionPaginationAction}
+     * of the users who've reacted to this message.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The retrieve request was attempted after the account lost access to the {@link GuildChannel}
+     *         due to {@link Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} being revoked
+     *     <br>Also can happen if the account lost the {@link Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided emoji was deleted, doesn't exist, or is not available to the currently logged-in account in this channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>If the message has already been deleted. This might also be triggered for ephemeral messages.</li>
+     * </ul>
+     *
+     * @param  emoji
+     *         The {@link Emoji} to retrieve users for.
+     * @param  type
+     *         The specific type of reaction
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the MessageChannel this message was sent in was a {@link GuildChannel} and the
+     *         logged in account does not have {@link Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY} in the channel.
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided null is provided.
+     * @throws IllegalStateException
+     *         If this Message is ephemeral
+     *
+     * @return The {@link ReactionPaginationAction} of the users who reacted with the provided emoji
+     */
+    @Nonnull
+    @CheckReturnValue
+    ReactionPaginationAction retrieveReactionUsers(@Nonnull Emoji emoji, @Nonnull MessageReaction.ReactionType type);
 
     /**
      * This obtains the {@link MessageReaction} for the given {@link Emoji} on this message.

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -381,6 +381,9 @@ public class MessageReaction
      * @param  type
      *         The specific type of reaction
      *
+     * @throws java.lang.IllegalArgumentException
+     *         If {@code null} is provided.
+     *
      * @return {@link ReactionPaginationAction ReactionPaginationAction}
      *
      * @see    #retrieveUsers()

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -348,12 +348,45 @@ public class MessageReaction
      * </ul>
      *
      * @return {@link ReactionPaginationAction ReactionPaginationAction}
+     *
+     * @see    #retrieveUsers(ReactionType)
      */
     @Nonnull
     @CheckReturnValue
     public ReactionPaginationAction retrieveUsers()
     {
         return new ReactionPaginationActionImpl(this);
+    }
+
+    /**
+     * Retrieves the {@link net.dv8tion.jda.api.entities.User Users} that
+     * already reacted with this MessageReaction.
+     *
+     * <p>Possible ErrorResponses include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>If the message this reaction was attached to got deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>If the channel this reaction was used in got deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>If we were removed from the channel/guild</li>
+     * </ul>
+     *
+     * @param  type
+     *         The specific type of reaction
+     *
+     * @return {@link ReactionPaginationAction ReactionPaginationAction}
+     *
+     * @see    #retrieveUsers()
+     */
+    @Nonnull
+    @CheckReturnValue
+    public ReactionPaginationAction retrieveUsers(@Nonnull ReactionType type)
+    {
+        Checks.notNull(type, "Type");
+        return new ReactionPaginationActionImpl(this, type);
     }
 
     /**
@@ -511,6 +544,16 @@ public class MessageReaction
      */
     public enum ReactionType
     {
-        NORMAL, SUPER
+        NORMAL(0), SUPER(1);
+
+        private final int value;
+        ReactionType(int type) {
+            this.value = type;
+        }
+
+        public int getValue()
+        {
+            return value;
+        }
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -335,6 +335,10 @@ public class MessageReaction
      * Retrieves the {@link net.dv8tion.jda.api.entities.User Users} that
      * already reacted with this MessageReaction.
      *
+     * <br>By default, this only includes users that reacted with {@link ReactionType#NORMAL}.
+     * Use {@link #retrieveUsers(ReactionType) retrieveUsers(ReactionType.SUPER)}
+     * to retrieve the users that used a super reaction instead.
+     *
      * <p>Possible ErrorResponses include:
      * <ul>
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
@@ -546,14 +550,21 @@ public class MessageReaction
     {
         NORMAL(0), SUPER(1);
 
-        private final int value;
-        ReactionType(int type) {
-            this.value = type;
+        private final int id;
+
+        ReactionType(int id)
+        {
+            this.id = id;
         }
 
-        public int getValue()
+        /**
+         * The id used to represent this type in requests.
+         *
+         * @return The raw id value
+         */
+        public int getId()
         {
-            return value;
+            return id;
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/middleman/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/middleman/MessageChannel.java
@@ -15,10 +15,7 @@
  */
 package net.dv8tion.jda.api.entities.channel.middleman;
 
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.entities.MessageHistory;
+import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
@@ -2044,6 +2041,10 @@ public interface MessageChannel extends Channel, Formattable
     /**
      * This obtains the {@link net.dv8tion.jda.api.entities.User users} who reacted to a message using the given {@link Emoji}.
      *
+     * <br>By default, this only includes users that reacted with {@link MessageReaction.ReactionType#NORMAL}.
+     * Use {@link #retrieveReactionUsersById(String, Emoji, MessageReaction.ReactionType) retrieveReactionUsersById(messageId, emoji, ReactionType.SUPER)}
+     * to retrieve the users that used a super reaction instead.
+     *
      * <p>Messages maintain a list of reactions, alongside a list of users who added them.
      *
      * <p>Using this data, we can obtain a {@link ReactionPaginationAction ReactionPaginationAction}
@@ -2084,14 +2085,15 @@ public interface MessageChannel extends Channel, Formattable
     @CheckReturnValue
     default ReactionPaginationAction retrieveReactionUsersById(@Nonnull String messageId, @Nonnull Emoji emoji)
     {
-        Checks.isSnowflake(messageId, "Message ID");
-        Checks.notNull(emoji, "Emoji");
-
-        return new ReactionPaginationActionImpl(this, messageId, emoji.getAsReactionCode());
+        return retrieveReactionUsersById(messageId, emoji, MessageReaction.ReactionType.NORMAL);
     }
 
     /**
      * This obtains the {@link net.dv8tion.jda.api.entities.User users} who reacted to a message using the given {@link Emoji}.
+     *
+     * <br>By default, this only includes users that reacted with {@link MessageReaction.ReactionType#NORMAL}.
+     * Use {@link #retrieveReactionUsersById(long, Emoji, MessageReaction.ReactionType) retrieveReactionUsersById(messageId, emoji, ReactionType.SUPER)}
+     * to retrieve the users that used a super reaction instead.
      *
      * <p>Messages maintain a list of reactions, alongside a list of users who added them.
      *
@@ -2138,6 +2140,110 @@ public interface MessageChannel extends Channel, Formattable
     default ReactionPaginationAction retrieveReactionUsersById(long messageId, @Nonnull Emoji emoji)
     {
         return retrieveReactionUsersById(Long.toUnsignedString(messageId), emoji);
+    }
+
+    /**
+     * This obtains the {@link net.dv8tion.jda.api.entities.User users} who reacted to a message using the given {@link Emoji}.
+     *
+     * <p>Messages maintain a list of reactions, alongside a list of users who added them.
+     *
+     * <p>Using this data, we can obtain a {@link ReactionPaginationAction ReactionPaginationAction}
+     * of the users who've reacted to the given message.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The retrieve request was attempted after the account lost access to the {@link GuildMessageChannel GuildMessageChannel}
+     *         due to {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} being revoked
+     *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided emoji was deleted, doesn't exist, or is not available to the currently logged-in account in this channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
+     *         the message it referred to has already been deleted.</li>
+     * </ul>
+     *
+     * @param  messageId
+     *         The messageId to retrieve the users from.
+     * @param  emoji
+     *         The {@link Emoji} to retrieve users for.
+     * @param  type
+     *         The specific type of reaction
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link GuildMessageChannel GuildMessageChannel} and the
+     *         logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}.
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If provided {@code messageId} is {@code null} or not a valid snowflake.</li>
+     *             <li>If provided {@code emoji} is {@code null}.</li>
+     *             <li>If provided {@code type} is {@code null}.</li>
+     *         </ul>
+     *
+     * @return The {@link ReactionPaginationAction} of the emoji's users.
+     */
+    @Nonnull
+    @CheckReturnValue
+    default ReactionPaginationAction retrieveReactionUsersById(@Nonnull String messageId, @Nonnull Emoji emoji, @Nonnull MessageReaction.ReactionType type)
+    {
+        Checks.isSnowflake(messageId, "Message ID");
+        Checks.notNull(emoji, "Emoji");
+        Checks.notNull(type, "ReactionType");
+
+        return new ReactionPaginationActionImpl(this, messageId, emoji.getAsReactionCode(), type);
+    }
+
+    /**
+     * This obtains the {@link net.dv8tion.jda.api.entities.User users} who reacted to a message using the given {@link Emoji}.
+     *
+     * <p>Messages maintain a list of reactions, alongside a list of users who added them.
+     *
+     * <p>Using this data, we can obtain a {@link ReactionPaginationAction ReactionPaginationAction}
+     * of the users who've reacted to the given message.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The retrieve request was attempted after the account lost access to the {@link GuildMessageChannel GuildMessageChannel}
+     *         due to {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} being revoked
+     *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided emoji was deleted, doesn't exist, or is not available to the currently logged-in account in this channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
+     *         the message it referred to has already been deleted.</li>
+     * </ul>
+     *
+     * @param  messageId
+     *         The messageId to retrieve the users from.
+     * @param  emoji
+     *         The {@link Emoji} to retrieve users for.
+     * @param  type
+     *         The specific type of reaction
+     *
+     * @throws java.lang.UnsupportedOperationException
+     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link GuildMessageChannel GuildMessageChannel} and the
+     *         logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}.
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If provided {@code messageId} is not a valid snowflake.</li>
+     *             <li>If provided {@code emoji} is {@code null}.</li>
+     *             <li>If provided {@code type} is {@code null}.</li>
+     *         </ul>
+     *
+     * @return The {@link ReactionPaginationAction ReactionPaginationAction} of the emoji's users.
+     */
+    @Nonnull
+    @CheckReturnValue
+    default ReactionPaginationAction retrieveReactionUsersById(long messageId, @Nonnull Emoji emoji, @Nonnull MessageReaction.ReactionType type)
+    {
+        return retrieveReactionUsersById(Long.toUnsignedString(messageId), emoji, type);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -352,15 +352,18 @@ public class ReceivedMessage implements Message
 
     @Nonnull
     @Override
-    public ReactionPaginationAction retrieveReactionUsers(@Nonnull Emoji emoji)
+    public ReactionPaginationAction retrieveReactionUsers(@Nonnull Emoji emoji, @Nonnull MessageReaction.ReactionType type)
     {
         if (isEphemeral())
             throw new IllegalStateException("Cannot retrieve reactions on ephemeral messages.");
 
         if (hasChannel())
-            return getChannel().retrieveReactionUsersById(id, emoji);
+            return getChannel().retrieveReactionUsersById(id, emoji, type);
 
-        return new ReactionPaginationActionImpl(this, emoji.getAsReactionCode());
+        Checks.notNull(type, "ReactionType");
+        Checks.notNull(emoji, "Emoji");
+
+        return new ReactionPaginationActionImpl(this, emoji.getAsReactionCode(), type);
     }
 
     @Nullable

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ReactionPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ReactionPaginationActionImpl.java
@@ -43,7 +43,7 @@ public class ReactionPaginationActionImpl
      * Creates a new PaginationAction instance
      *
      * @param reaction
-     *        The target {@link net.dv8tion.jda.api.entities.MessageReaction MessageReaction}
+     *        The target {@link MessageReaction MessageReaction}
      */
     public ReactionPaginationActionImpl(MessageReaction reaction)
     {
@@ -54,29 +54,34 @@ public class ReactionPaginationActionImpl
      * Creates a new PaginationAction instance
      *
      * @param reaction
-     *        The target {@link net.dv8tion.jda.api.entities.MessageReaction MessageReaction}
+     *        The target {@link MessageReaction MessageReaction}
      * @param type
-     *        Type of {@link net.dv8tion.jda.api.entities.MessageReaction.ReactionType MessageReaction.ReactionType} to retrieve users for
+     *        Type of {@link MessageReaction.ReactionType MessageReaction.ReactionType} to retrieve users for
      */
     public ReactionPaginationActionImpl(MessageReaction reaction, MessageReaction.ReactionType type)
     {
-        super(reaction.getJDA(), Route.Messages.GET_REACTION_USERS.compile(reaction.getChannelId(), reaction.getMessageId(), getCode(reaction)).withQueryParams("type", String.valueOf(type.getValue())), 1, 100, 100);
+        super(reaction.getJDA(), getCompiledRoute(reaction.getChannelId(), reaction.getMessageId(), getCode(reaction), type), 1, 100, 100);
         super.order(PaginationOrder.FORWARD);
         this.reaction = reaction;
     }
 
-    public ReactionPaginationActionImpl(Message message, String code)
+    public ReactionPaginationActionImpl(Message message, String code, MessageReaction.ReactionType type)
     {
-        super(message.getJDA(), Route.Messages.GET_REACTION_USERS.compile(message.getChannelId(), message.getId(), code), 1, 100, 100);
+        super(message.getJDA(), getCompiledRoute(message.getChannelId(), message.getId(), code, type), 1, 100, 100);
         super.order(PaginationOrder.FORWARD);
         this.reaction = null;
     }
 
-    public ReactionPaginationActionImpl(MessageChannel channel, String messageId, String code)
+    public ReactionPaginationActionImpl(MessageChannel channel, String messageId, String code, MessageReaction.ReactionType type)
     {
-        super(channel.getJDA(), Route.Messages.GET_REACTION_USERS.compile(channel.getId(), messageId, code), 1, 100, 100);
+        super(channel.getJDA(), getCompiledRoute(channel.getId(), messageId, code, type), 1, 100, 100);
         super.order(PaginationOrder.FORWARD);
         this.reaction = null;
+    }
+
+    private static Route.CompiledRoute getCompiledRoute(String channelId, String messageId, String code, MessageReaction.ReactionType type)
+    {
+        return Route.Messages.GET_REACTION_USERS.compile(channelId, messageId, code).withQueryParams("type", String.valueOf(type.getId()));
     }
 
     protected static String getCode(MessageReaction reaction)

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ReactionPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ReactionPaginationActionImpl.java
@@ -47,7 +47,20 @@ public class ReactionPaginationActionImpl
      */
     public ReactionPaginationActionImpl(MessageReaction reaction)
     {
-        super(reaction.getJDA(), Route.Messages.GET_REACTION_USERS.compile(reaction.getChannelId(), reaction.getMessageId(), getCode(reaction)), 1, 100, 100);
+        this(reaction, MessageReaction.ReactionType.NORMAL);
+    }
+
+    /**
+     * Creates a new PaginationAction instance
+     *
+     * @param reaction
+     *        The target {@link net.dv8tion.jda.api.entities.MessageReaction MessageReaction}
+     * @param type
+     *        Type of {@link net.dv8tion.jda.api.entities.MessageReaction.ReactionType MessageReaction.ReactionType} to retrieve users for
+     */
+    public ReactionPaginationActionImpl(MessageReaction reaction, MessageReaction.ReactionType type)
+    {
+        super(reaction.getJDA(), Route.Messages.GET_REACTION_USERS.compile(reaction.getChannelId(), reaction.getMessageId(), getCode(reaction)).withQueryParams("type", String.valueOf(type.getValue())), 1, 100, 100);
         super.order(PaginationOrder.FORWARD);
         this.reaction = reaction;
     }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Currently, there is no way to get users that reacted with super reactions even though [Discord API](https://discord.com/developers/docs/resources/message#get-reactions) supports it.

This PR adds a way to get super reaction users via `MessageReaction#retrieveUsers(MessageReaction.ReactionType)`
