### PR TITLE
Fix channel cache lock handling

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1094,11 +1094,15 @@ public class EntityBuilder
     {
         boolean playbackCache = false;
         final long id = json.getLong("id");
-        CategoryImpl channel = (CategoryImpl) getJDA().getCategoryById(id);
+
+        if (guild == null)
+            guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
+        if (guild == null)
+            throw new IllegalStateException("Missing guild for id " + Long.toUnsignedString(guildId));
+
+        CategoryImpl channel = (CategoryImpl) guild.getCategoryById(id);
         if (channel == null)
         {
-            if (guild == null)
-                guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
             ChannelCacheViewImpl<GuildChannel> guildView = guild.getChannelView();
             ChannelCacheViewImpl<Channel> globalView = getJDA().getChannelsView();
             try (
@@ -1131,11 +1135,15 @@ public class EntityBuilder
     {
         boolean playbackCache = false;
         final long id = json.getLong("id");
-        TextChannelImpl channel = (TextChannelImpl) getJDA().getTextChannelById(id);
+
+        if (guildObj == null)
+            guildObj = (GuildImpl) getJDA().getGuildsView().get(guildId);
+        if (guildObj == null)
+            throw new IllegalStateException("Missing guild for id " + Long.toUnsignedString(guildId));
+
+        TextChannelImpl channel = (TextChannelImpl) guildObj.getTextChannelById(id);
         if (channel == null)
         {
-            if (guildObj == null)
-                guildObj = (GuildImpl) getJDA().getGuildsView().get(guildId);
             ChannelCacheViewImpl<GuildChannel> guildView = guildObj.getChannelView();
             ChannelCacheViewImpl<Channel> globalView = getJDA().getChannelsView();
             try (
@@ -1174,11 +1182,15 @@ public class EntityBuilder
     {
         boolean playbackCache = false;
         final long id = json.getLong("id");
-        NewsChannelImpl channel = (NewsChannelImpl) getJDA().getNewsChannelById(id);
+
+        if (guildObj == null)
+            guildObj = (GuildImpl) getJDA().getGuildsView().get(guildId);
+        if (guildObj == null)
+            throw new IllegalStateException("Missing guild for id " + Long.toUnsignedString(guildId));
+
+        NewsChannelImpl channel = (NewsChannelImpl) guildObj.getNewsChannelById(id);
         if (channel == null)
         {
-            if (guildObj == null)
-                guildObj = (GuildImpl) getJDA().getGuildsView().get(guildId);
             ChannelCacheViewImpl<GuildChannel> guildView = guildObj.getChannelView();
             ChannelCacheViewImpl<Channel> globalView = getJDA().getChannelsView();
             try (
@@ -1214,11 +1226,15 @@ public class EntityBuilder
     {
         boolean playbackCache = false;
         final long id = json.getLong("id");
-        VoiceChannelImpl channel = (VoiceChannelImpl) getJDA().getVoiceChannelById(id);
+
+        if (guild == null)
+            guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
+        if (guild == null)
+            throw new IllegalStateException("Missing guild for id " + Long.toUnsignedString(guildId));
+
+        VoiceChannelImpl channel = (VoiceChannelImpl) guild.getVoiceChannelById(id);
         if (channel == null)
         {
-            if (guild == null)
-                guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
             ChannelCacheViewImpl<GuildChannel> guildView = guild.getChannelView();
             ChannelCacheViewImpl<Channel> globalView = getJDA().getChannelsView();
             try (
@@ -1259,11 +1275,15 @@ public class EntityBuilder
     {
         boolean playbackCache = false;
         final long id = json.getLong("id");
-        StageChannelImpl channel = (StageChannelImpl) getJDA().getStageChannelById(id);
+
+        if (guild == null)
+            guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
+        if (guild == null)
+            throw new IllegalStateException("Missing guild for id " + Long.toUnsignedString(guildId));
+
+        StageChannelImpl channel = (StageChannelImpl) guild.getStageChannelById(id);
         if (channel == null)
         {
-            if (guild == null)
-                guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
             ChannelCacheViewImpl<GuildChannel> guildView = guild.getChannelView();
             ChannelCacheViewImpl<Channel> globalView = getJDA().getChannelsView();
             try (
@@ -1313,6 +1333,8 @@ public class EntityBuilder
 
         if (guild == null)
             guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
+        if (guild == null)
+            throw new IllegalStateException("Missing guild for id " + Long.toUnsignedString(guildId));
 
         IThreadContainer parent = guild.getChannelById(IThreadContainer.class, parentId);
         if (parent == null)
@@ -1404,11 +1426,15 @@ public class EntityBuilder
     {
         boolean playbackCache = false;
         final long id = json.getLong("id");
-        ForumChannelImpl channel = (ForumChannelImpl) getJDA().getForumChannelById(id);
+
+        if (guild == null)
+            guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
+        if (guild == null)
+            throw new IllegalStateException("Missing guild for id " + Long.toUnsignedString(guildId));
+
+        ForumChannelImpl channel = (ForumChannelImpl) guild.getForumChannelById(id);
         if (channel == null)
         {
-            if (guild == null)
-                guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
             ChannelCacheViewImpl<GuildChannel> guildView = guild.getChannelView();
             ChannelCacheViewImpl<Channel> globalView = getJDA().getChannelsView();
             try (
@@ -1456,11 +1482,15 @@ public class EntityBuilder
     {
         boolean playbackCache = false;
         final long id = json.getLong("id");
-        MediaChannelImpl channel = (MediaChannelImpl) getJDA().getMediaChannelById(id);
+
+        if (guild == null)
+            guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
+        if (guild == null)
+            throw new IllegalStateException("Missing guild for id " + Long.toUnsignedString(guildId));
+
+        MediaChannelImpl channel = (MediaChannelImpl) guild.getMediaChannelById(id);
         if (channel == null)
         {
-            if (guild == null)
-                guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
             ChannelCacheViewImpl<GuildChannel> guildView = guild.getChannelView();
             ChannelCacheViewImpl<Channel> globalView = getJDA().getChannelsView();
             try (

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/middleman/AbstractGuildChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/middleman/AbstractGuildChannelImpl.java
@@ -16,6 +16,7 @@
 
 package net.dv8tion.jda.internal.entities.channel.middleman;
 
+import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.channel.AbstractChannelImpl;
@@ -38,6 +39,9 @@ public abstract class AbstractGuildChannelImpl<T extends AbstractGuildChannelImp
     @Override
     public GuildImpl getGuild()
     {
+        Guild cachedGuild = getJDA().getGuildById(id);
+        if (cachedGuild instanceof GuildImpl)
+            return this.guild = (GuildImpl) cachedGuild;
         return guild;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/middleman/AbstractGuildChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/middleman/AbstractGuildChannelImpl.java
@@ -27,7 +27,7 @@ import javax.annotation.Nonnull;
 
 public abstract class AbstractGuildChannelImpl<T extends AbstractGuildChannelImpl<T>> extends AbstractChannelImpl<T> implements GuildChannelMixin<T>
 {
-    protected GuildImpl guild;
+    private GuildImpl guild;
 
     public AbstractGuildChannelImpl(long id, GuildImpl guild)
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/middleman/AbstractStandardGuildChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/middleman/AbstractStandardGuildChannelImpl.java
@@ -72,6 +72,6 @@ public abstract class AbstractStandardGuildChannelImpl<T extends AbstractStandar
 
     protected final void onPositionChange()
     {
-        guild.getChannelView().clearCachedLists();
+        getGuild().getChannelView().clearCachedLists();
     }
 }

--- a/src/test/java/net/dv8tion/jda/test/entities/EntityManagerTest.java
+++ b/src/test/java/net/dv8tion/jda/test/entities/EntityManagerTest.java
@@ -33,8 +33,7 @@ import org.mockito.Mock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class EntityManagerTest extends IntegrationTest
 {
@@ -62,6 +61,7 @@ class EntityManagerTest extends IntegrationTest
         entityBuilder.createTextChannel(guild, TestData.CHANNEL_CREATE, Constants.GUILD_ID);
 
         GuildImpl newGuild = mock(GuildImpl.class);
+        when(newGuild.getJDA()).thenReturn(jda);
         when(newGuild.getChannelView()).thenReturn(new SortedChannelCacheViewImpl<>(GuildChannel.class));
         when(newGuild.getTextChannelById(eq(Constants.CHANNEL_ID))).then(
             invocation -> newGuild.getChannelView().getElementById(Constants.CHANNEL_ID)
@@ -72,6 +72,15 @@ class EntityManagerTest extends IntegrationTest
         assertThat(newGuild.getChannelView().getElementById(Constants.CHANNEL_ID)).isNotNull();
         assertThat(createdChannel)
             .isSameAs(newGuild.getChannelView().getElementById(Constants.CHANNEL_ID));
+
+
+        reset(jda);
+
+        when(jda.getGuildById(eq(Constants.GUILD_ID))).thenReturn(newGuild);
+        assertThat(createdChannel.getGuild())
+            .isSameAs(newGuild);
+
+        verify(jda, times(1)).getGuildById(anyLong());
     }
 
     static class TestData

--- a/src/test/java/net/dv8tion/jda/test/entities/EntityManagerTest.java
+++ b/src/test/java/net/dv8tion/jda/test/entities/EntityManagerTest.java
@@ -48,6 +48,7 @@ class EntityManagerTest extends IntegrationTest
         ChannelCacheViewImpl<Channel> globalChannelCache = new ChannelCacheViewImpl<>(Channel.class);
         SortedChannelCacheViewImpl<GuildChannel> guildChannelCache = new SortedChannelCacheViewImpl<>(GuildChannel.class);
 
+        when(guild.getJDA()).thenReturn(jda);
         when(guild.getChannelView()).thenReturn(guildChannelCache);
         when(jda.getChannelsView()).thenReturn(globalChannelCache);
         when(jda.getTextChannelById(eq(Constants.CHANNEL_ID))).then(

--- a/src/test/java/net/dv8tion/jda/test/entities/EntityManagerTest.java
+++ b/src/test/java/net/dv8tion/jda/test/entities/EntityManagerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.test.entities;
+
+import net.dv8tion.jda.api.entities.channel.Channel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+import net.dv8tion.jda.api.utils.data.DataArray;
+import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.entities.EntityBuilder;
+import net.dv8tion.jda.internal.entities.GuildImpl;
+import net.dv8tion.jda.internal.handle.EventCache;
+import net.dv8tion.jda.internal.utils.cache.ChannelCacheViewImpl;
+import net.dv8tion.jda.internal.utils.cache.SortedChannelCacheViewImpl;
+import net.dv8tion.jda.test.Constants;
+import net.dv8tion.jda.test.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EntityManagerTest extends IntegrationTest
+{
+    @Mock
+    private GuildImpl guild;
+
+    @Test
+    void createTextChannelWhileInvalidatingCache()
+    {
+        EntityBuilder entityBuilder = new EntityBuilder(jda);
+
+        ChannelCacheViewImpl<Channel> globalChannelCache = new ChannelCacheViewImpl<>(Channel.class);
+        SortedChannelCacheViewImpl<GuildChannel> guildChannelCache = new SortedChannelCacheViewImpl<>(GuildChannel.class);
+
+        when(guild.getChannelView()).thenReturn(guildChannelCache);
+        when(jda.getChannelsView()).thenReturn(globalChannelCache);
+        when(jda.getTextChannelById(eq(Constants.CHANNEL_ID))).then(
+            invocation -> globalChannelCache.getElementById(Constants.CHANNEL_ID)
+        );
+        when(guild.getTextChannelById(eq(Constants.CHANNEL_ID))).then(
+            invocation -> guildChannelCache.getElementById(Constants.CHANNEL_ID)
+        );
+        when(jda.getEventCache()).thenReturn(mock(EventCache.class));
+
+        entityBuilder.createTextChannel(guild, TestData.CHANNEL_CREATE, Constants.GUILD_ID);
+
+        GuildImpl newGuild = mock(GuildImpl.class);
+        when(newGuild.getChannelView()).thenReturn(new SortedChannelCacheViewImpl<>(GuildChannel.class));
+        when(newGuild.getTextChannelById(eq(Constants.CHANNEL_ID))).then(
+            invocation -> newGuild.getChannelView().getElementById(Constants.CHANNEL_ID)
+        );
+
+        TextChannel createdChannel = entityBuilder.createTextChannel(newGuild, TestData.CHANNEL_CREATE, Constants.GUILD_ID);
+
+        assertThat(newGuild.getChannelView().getElementById(Constants.CHANNEL_ID)).isNotNull();
+        assertThat(createdChannel)
+            .isSameAs(newGuild.getChannelView().getElementById(Constants.CHANNEL_ID));
+    }
+
+    static class TestData
+    {
+        static final DataObject CHANNEL_CREATE = DataObject.empty()
+                .put("id", Constants.CHANNEL_ID)
+                .put("name", "test-channel")
+                .put("position", 1)
+                .put("permission_overwrites", DataArray.empty());
+    }
+}


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes #2756

## Description

Changes the order of cache checks, using the guild as the source of truth. This means that whenever a channel is created, it will definitely be in the guild's cache. If a channel is created in an uncached guild, the `channel.getGuild()` automatically updates its reference to a cached guild anyway.
