### PR TITLE
Add missing exceptions when attempting to move entities before selecting

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/OrderActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/OrderActionImpl.java
@@ -208,6 +208,8 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
     {
         Checks.notNegative(position, "Provided position");
         Checks.check(position < orderList.size(), "Provided position is too big and is out of bounds.");
+        if (selectedPosition == -1)
+            throw new IllegalStateException("Cannot move until an item has been selected. Use #selectPosition first.");
 
         T selectedItem = orderList.remove(selectedPosition);
         orderList.add(position, selectedItem);
@@ -250,6 +252,8 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
         Checks.notNegative(swapPosition, "Provided swapPosition");
         Checks.check(swapPosition < orderList.size(), "Provided swapPosition is too big and is out of bounds. swapPosition: "
                 + swapPosition);
+        if (selectedPosition == -1)
+            throw new IllegalStateException("Cannot move until an item has been selected. Use #selectPosition first.");
 
         T selectedItem = orderList.get(selectedPosition);
         T swapItem = orderList.get(swapPosition);


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes `IndexOutOfBoundsException` when an user attempts to use `OrderAction#moveTo` or `OrderAction#swapTo` without first selecting an entity
