### PR TITLE
Include possible ErrorResponse at Guild#unban Javadoc.

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -4257,6 +4257,9 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
      *     <br>The target Member cannot be unbanned due to a permission discrepancy</li>
      *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_BAN UNKNOWN_BAN}
+     *     <br>The specified User is not banned from the current Guild</li>
+     *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_USER UNKNOWN_USER}
      *     <br>The specified User does not exist</li>
      * </ul>


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette
- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The docs at `Guild#unban(UserSnowflake)` do not include the possible `ErrorResponse.UNKNOWN_BAN` that can be returned by Discord, when the provided user is not banned from the Guild.