### PR TITLE
Make IEventManager a FunctionalInterface

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/hooks/IEventManager.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/IEventManager.java
@@ -43,6 +43,7 @@ import java.util.List;
  * @see net.dv8tion.jda.api.hooks.InterfacedEventManager
  * @see net.dv8tion.jda.api.hooks.AnnotatedEventManager
  */
+@FunctionalInterface
 public interface IEventManager
 {
     /**
@@ -55,7 +56,9 @@ public interface IEventManager
      * @throws java.lang.UnsupportedOperationException
      *         If the implementation does not support this method
      */
-    void register(@Nonnull Object listener);
+    default void register(@Nonnull Object listener) {
+        throw new UnsupportedOperationException("register is not supported by this IEventManager");
+    }
 
     /**
      * Removes the specified listener
@@ -66,7 +69,9 @@ public interface IEventManager
      * @throws java.lang.UnsupportedOperationException
      *         If the implementation does not support this method
      */
-    void unregister(@Nonnull Object listener);
+    default void unregister(@Nonnull Object listener) {
+        throw new UnsupportedOperationException("unregister is not supported by this IEventManager");
+    }
 
     /**
      * Handles the provided {@link net.dv8tion.jda.api.events.GenericEvent GenericEvent}.
@@ -88,5 +93,7 @@ public interface IEventManager
      * @return A list of listeners that have already been registered
      */
     @Nonnull
-    List<Object> getRegisteredListeners();
+    default List<Object> getRegisteredListeners() {
+        throw new UnsupportedOperationException("getRegisteredListeners is not supported by this IEventManager");
+    }
 }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Makes `IEventManager` into a `FunctionalInterface` so you can do something like `.setEventManager(System.out::println)` if you want to.