### PR TITLE
Add note about editing previously locally-uploaded attachments

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -538,6 +538,11 @@ public class EmbedBuilder
      * (using {@link net.dv8tion.jda.api.entities.channel.middleman.MessageChannel#sendFiles(net.dv8tion.jda.api.utils.FileUpload...) MessageChannel.sendFiles(...)})
      * you can reference said image using the specified filename as URI {@code attachment://filename.ext}.
      *
+     * <p><b>Note that the uploaded attachment will not be accessible in the resulting {@linkplain net.dv8tion.jda.api.entities.Message#getAttachments() message's attachments}.</b>
+     * <br>If you later edit with new attachments, Discord will consider the previous embed's attachments to be deleted.
+     * You can work around that by keeping the original message's data ({@link net.dv8tion.jda.api.utils.messages.MessageCreateData MessageCreateData} / {@link net.dv8tion.jda.api.utils.messages.MessageEditData MessageEditData}),
+     * and edit the message with this data, plus the new content.
+     *
      * <p><u>Example</u>
      * <pre><code>
      * MessageChannel channel; // = reference of a MessageChannel
@@ -584,6 +589,11 @@ public class EmbedBuilder
      * <br>When uploading an <u>image</u>
      * (using {@link net.dv8tion.jda.api.entities.channel.middleman.MessageChannel#sendFiles(net.dv8tion.jda.api.utils.FileUpload...) MessageChannel.sendFiles(...)})
      * you can reference said image using the specified filename as URI {@code attachment://filename.ext}.
+     *
+     * <p><b>Note that the uploaded attachment will not be accessible in the resulting {@linkplain net.dv8tion.jda.api.entities.Message#getAttachments() message's attachments}.</b>
+     * <br>If you later edit with new attachments, Discord will consider the previous embed's attachments to be deleted.
+     * You can work around that by keeping the original message's data ({@link net.dv8tion.jda.api.utils.messages.MessageCreateData MessageCreateData} / {@link net.dv8tion.jda.api.utils.messages.MessageEditData MessageEditData}),
+     * and edit the message with this data, plus the new content.
      *
      * <p><u>Example</u>
      * <pre><code>
@@ -686,6 +696,11 @@ public class EmbedBuilder
      * (using {@link net.dv8tion.jda.api.entities.channel.middleman.MessageChannel#sendFiles(net.dv8tion.jda.api.utils.FileUpload...) MessageChannel.sendFiles(...)})
      * you can reference said image using the specified filename as URI {@code attachment://filename.ext}.
      *
+     * <p><b>Note that the uploaded attachment will not be accessible in the resulting {@linkplain net.dv8tion.jda.api.entities.Message#getAttachments() message's attachments}.</b>
+     * <br>If you later edit with new attachments, Discord will consider the previous embed's attachments to be deleted.
+     * You can work around that by keeping the original message's data ({@link net.dv8tion.jda.api.utils.messages.MessageCreateData MessageCreateData} / {@link net.dv8tion.jda.api.utils.messages.MessageEditData MessageEditData}),
+     * and edit the message with this data, plus the new content.
+     *
      * <p><u>Example</u>
      * <pre><code>
      * MessageChannel channel; // = reference of a MessageChannel
@@ -764,6 +779,11 @@ public class EmbedBuilder
      * <br>When uploading an <u>image</u>
      * (using {@link net.dv8tion.jda.api.entities.channel.middleman.MessageChannel#sendFiles(net.dv8tion.jda.api.utils.FileUpload...) MessageChannel.sendFiles(...)})
      * you can reference said image using the specified filename as URI {@code attachment://filename.ext}.
+     *
+     * <p><b>Note that the uploaded attachment will not be accessible in the resulting {@linkplain net.dv8tion.jda.api.entities.Message#getAttachments() message's attachments}.</b>
+     * <br>If you later edit with new attachments, Discord will consider the previous embed's attachments to be deleted.
+     * You can work around that by keeping the original message's data ({@link net.dv8tion.jda.api.utils.messages.MessageCreateData MessageCreateData} / {@link net.dv8tion.jda.api.utils.messages.MessageEditData MessageEditData}),
+     * and edit the message with this data, plus the new content.
      *
      * <p><u>Example</u>
      * <pre><code>


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds a note about editing messages containing embeds with locally-uploaded files, as their attachments will get deleted if they are not fully re-uploaded, this is due to local uploads not generating an attachment on the resulting `Message`.
