### PR TITLE
remove wrong ephemeral part from javadocs

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/InteractionHook.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/InteractionHook.java
@@ -141,7 +141,6 @@ public interface InteractionHook extends WebhookClient<Message>
 
     /**
      * Retrieves the original reply to this interaction.
-     * <br>This doesn't work for ephemeral messages and will always cause an unknown message error response.
      *
      * @return {@link RestAction} - Type: {@link Message}
      */
@@ -412,7 +411,7 @@ public interface InteractionHook extends WebhookClient<Message>
      *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
      *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
-     *         the message it referred to has already been deleted. This might also be triggered for ephemeral messages.</li>
+     *         the message it referred to has already been deleted.</li>
      *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
      *     <br>The request was attempted after the channel was deleted.</li>
@@ -466,7 +465,7 @@ public interface InteractionHook extends WebhookClient<Message>
      *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
      *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
-     *         the message it referred to has already been deleted. This might also be triggered for ephemeral messages.</li>
+     *         the message it referred to has already been deleted.</li>
      *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
      *     <br>The request was attempted after the channel was deleted.</li>


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description
Removes the parts about ephemeral messages from the InteractionHook docs that are wrong

see [`#lib-dev`](https://discord.com/channels/125227483518861312/869965829024915466/1350928721560735754)
