### PR TITLE
Updated ThreadChannel#isLocked and ThreadChannelManager#setLocked

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/ThreadChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/ThreadChannel.java
@@ -117,8 +117,9 @@ public interface ThreadChannel extends GuildMessageChannel, IMemberContainer, IS
     /**
      * Whether this thread is locked or not.
      *
-     * <p>Locked threads cannot have new messages posted to them, or members join or leave them.
-     * Threads can only be locked and unlocked by moderators.
+     * <p>Locked threads make its members unable to post new messages unless they are moderators. Actions such as react to messages, leave, get removed and get invited to the thread remain unaffected.
+     * <br>Threads can only be locked and unlocked by moderators.
+     *
      *
      * @return true if this thread is locked, false otherwise.
      *

--- a/src/main/java/net/dv8tion/jda/api/managers/channel/concrete/ThreadChannelManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/channel/concrete/ThreadChannelManager.java
@@ -85,7 +85,10 @@ public interface ThreadChannelManager extends ChannelManager<ThreadChannel, Thre
     /**
      * Sets the locked state of this ThreadChannel.
      *
-     * <p>This is the equivalent of archiving as a moderator.
+     * <p> Locking will prevent any new messages from being sent in the thread except by moderators.
+     * Actions such as react to messages, leave, get removed and get invited to the thread are still possible.
+     * <p>Locking a thread will not archive it.
+     *
      *
      * @param  locked
      *         The new locked state for the selected {@link ThreadChannel}


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue:

## Description

Updated ThreadChannel#isLocked and ThreadChannelManager#setLocked according to their actual behaviour. Using setLocked(true) does not really archive a thread which is quite misleading and needs to be changed.

