### PR TITLE
Fix assumptions in friend DM interactions 

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/PrivateChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/PrivateChannel.java
@@ -26,6 +26,15 @@ import javax.annotation.Nullable;
 /**
  * Represents the connection used for direct messaging.
  *
+ * <p>This channel may communicate with different users in interactions triggered by user-installed apps:
+ * <ul>
+ *     <li>In bot DMs, this channel will send messages to the interaction caller.</li>
+ *     <li>In friend DMs, this channel will send messages to that friend,
+ *         from the bot itself, this is different from where the interaction was executed.
+ *         <br>Note: As friend DMs are detached channels, you will need to retrieve an open channel from the user first.
+ *     </li>
+ * </ul>
+ *
  * @see User#openPrivateChannel()
  */
 public interface PrivateChannel extends MessageChannel

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/PrivateChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/PrivateChannel.java
@@ -58,9 +58,6 @@ public interface PrivateChannel extends MessageChannel
      *
      * <br>This method fetches the channel from the API and retrieves the User from that.
      *
-     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
-     *         For channels from interactions with context type {@link net.dv8tion.jda.api.interactions.InteractionContextType#PRIVATE_CHANNEL PRIVATE_CHANNEL}
-     *
      * @return A {@link RestAction RestAction} to retrieve the {@link User User} that this {@link PrivateChannel PrivateChannel} communicates with.
      */
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/PrivateChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/concrete/PrivateChannel.java
@@ -26,14 +26,8 @@ import javax.annotation.Nullable;
 /**
  * Represents the connection used for direct messaging.
  *
- * <p>This channel may communicate with different users in interactions triggered by user-installed apps:
- * <ul>
- *     <li>In bot DMs, this channel will send messages to the interaction caller.</li>
- *     <li>In friend DMs, this channel will send messages to that friend,
- *         from the bot itself, this is different from where the interaction was executed.
- *         <br>Note: As friend DMs are detached channels, you will need to retrieve an open channel from the user first.
- *     </li>
- * </ul>
+ * <p>When this channel comes from a user-installed interaction, bots cannot send messages outside their own DMs.
+ * <br>For friend DMs, you can open a private channel directly with the user.
  *
  * @see User#openPrivateChannel()
  */

--- a/src/main/java/net/dv8tion/jda/internal/entities/InteractionEntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/InteractionEntityBuilder.java
@@ -258,16 +258,17 @@ public class InteractionEntityBuilder extends AbstractEntityBuilder
 
         final PrivateChannelMixin<?> channel;
         if (recipientObj != null) {
-            // We only get recipient in Bot DMs and Group DMs
-            if (interactionUser.getIdLong() == recipientObj.getLong("id")) {
+            // Let's try not to DM ourselves
+            if (api.getSelfUser().getIdLong() == recipientObj.getLong("id"))
                 channel = new PrivateChannelImpl(getJDA(), channelId, interactionUser);
-            } else {
-                // Friend DMs don't have recipients
-                throw new IllegalArgumentException("Recipient should only be present in Bot DMs");
+            else
+            {
+                // This still needs to be detached, as there is no open channel between the bot and the friend,
+                channel = new DetachedPrivateChannelImpl(getJDA(), channelId, entityBuilder.createUser(recipientObj));
             }
         } else {
-            // Friend DMs, no info
-            channel = new DetachedPrivateChannelImpl(getJDA(), channelId);
+            LOG.warn("Private channel has no recipient and will fallback to a detached PrivateChannel with no user, please report to the devs, channel JSON: {}", json.toPrettyString());
+            channel = new DetachedPrivateChannelImpl(getJDA(), channelId, null);
         }
         configurePrivateChannel(json, channel);
         return channel;

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/PrivateChannelImpl.java
@@ -20,13 +20,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel;
-import net.dv8tion.jda.api.requests.RestAction;
-import net.dv8tion.jda.api.requests.Route;
-import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.channel.AbstractChannelImpl;
 import net.dv8tion.jda.internal.entities.channel.mixin.concrete.PrivateChannelMixin;
-import net.dv8tion.jda.internal.requests.CompletedRestAction;
-import net.dv8tion.jda.internal.requests.RestActionImpl;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -63,38 +58,6 @@ public class PrivateChannelImpl extends AbstractChannelImpl<PrivateChannelImpl> 
     {
         updateUser();
         return user;
-    }
-
-    @Nonnull
-    @Override
-    public RestAction<User> retrieveUser()
-    {
-        User user = getUser();
-        if (user != null)
-            return new CompletedRestAction<>(getJDA(), user);
-        //even if the user blocks the bot, this does not fail.
-        return retrievePrivateChannel()
-                .map(PrivateChannel::getUser);
-    }
-
-    @Nonnull
-    @Override
-    public String getName()
-    {
-        User user = getUser();
-        if (user == null)
-        {
-            //don't break or override the contract of @NonNull
-            return "";
-        }
-        return user.getName();
-    }
-
-    @Nonnull
-    private RestAction<PrivateChannel> retrievePrivateChannel()
-    {
-        Route.CompiledRoute route = Route.Channels.GET_CHANNEL.compile(getId());
-        return new RestActionImpl<>(getJDA(), route, (response, request) -> ((JDAImpl) getJDA()).getEntityBuilder().createPrivateChannel(response.getObject()));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedPrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedPrivateChannelImpl.java
@@ -32,11 +32,13 @@ public class DetachedPrivateChannelImpl extends AbstractChannelImpl<DetachedPriv
         PrivateChannel,
         PrivateChannelMixin<DetachedPrivateChannelImpl>
 {
+    private final User user;
     private long latestMessageId;
 
-    public DetachedPrivateChannelImpl(JDA api, long id)
+    public DetachedPrivateChannelImpl(JDA api, long id, @Nullable User user)
     {
         super(id, api);
+        this.user = user;
     }
 
     @Nonnull
@@ -63,7 +65,7 @@ public class DetachedPrivateChannelImpl extends AbstractChannelImpl<DetachedPriv
     @Override
     public User getUser()
     {
-        return null;
+        return user;
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedPrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedPrivateChannelImpl.java
@@ -21,7 +21,6 @@ import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel;
 import net.dv8tion.jda.api.exceptions.DetachedEntityException;
-import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.internal.entities.channel.AbstractChannelImpl;
 import net.dv8tion.jda.internal.entities.channel.mixin.concrete.PrivateChannelMixin;
 
@@ -66,21 +65,6 @@ public class DetachedPrivateChannelImpl extends AbstractChannelImpl<DetachedPriv
     public User getUser()
     {
         return user;
-    }
-
-    @Nonnull
-    @Override
-    public RestAction<User> retrieveUser()
-    {
-        throw detachedException();
-    }
-
-    @Nonnull
-    @Override
-    public String getName()
-    {
-        //don't break or override the contract of @NonNull
-        return "";
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2817

## Description

Since Discord now sends recipients of Friend DMs, assumptions on how to detect friend DMs failed, this is now fixed.

Additionally:
- If the recipient is absent, a warn will be logged and a detached channel will be used
- Bot DMs from interactions will now target the interaction caller, this should be considered as a fix
- Detached private channels will now be able to return an `User` in some situations
- A new method `PrivateChannel#retrieveOpenPrivateChannel()` was added, this is intended for cases where the user wants the bot to *attempt to* send a DM to the friend on which the interaction was called
  - This is necessary as interactions started in friend DMs don't open a channel between the bot and the recipient