### PR TITLE
Fix `PrivateChannel#getName` returning `null`

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/PrivateChannelImpl.java
@@ -60,6 +60,13 @@ public class PrivateChannelImpl extends AbstractChannelImpl<PrivateChannelImpl> 
         return user;
     }
 
+    @Nonnull
+    @Override
+    public String getName()
+    {
+        return PrivateChannelMixin.super.getName();
+    }
+
     @Override
     public long getLatestMessageIdLong()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedPrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedPrivateChannelImpl.java
@@ -67,6 +67,13 @@ public class DetachedPrivateChannelImpl extends AbstractChannelImpl<DetachedPriv
         return user;
     }
 
+    @Nonnull
+    @Override
+    public String getName()
+    {
+        return PrivateChannelMixin.super.getName();
+    }
+
     @Override
     public long getLatestMessageIdLong()
     {


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2819

## Description

Superclass methods are prioritized from interfaces, this PR brings back the getters in their classes and calls the interface method explicitly
