### PR TITLE
No regex url check for EmbedBuilder

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -907,12 +907,29 @@ public class EmbedBuilder
         return fields;
     }
 
+    private boolean hasUrlFormat(@Nonnull String url)
+    {
+        if (url.regionMatches(true, 0, "https://", 0, "https://".length()))
+        {
+            return url.length() > "https://".length();
+        }
+        if (url.regionMatches(true, 0, "http://", 0, "http://".length()))
+        {
+            return url.length() > "http://".length();
+        }
+        if (url.regionMatches(true, 0, "attachment://", 0, "attachment://".length()))
+        {
+            return url.length() > "attachment://".length();
+        }
+        return false;
+    }
+
     private void urlCheck(@Nullable String url)
     {
         if (url != null)
         {
             Checks.notLonger(url, MessageEmbed.URL_MAX_LENGTH, "URL");
-            Checks.check(URL_PATTERN.matcher(url).matches(), "URL must be a valid http(s) or attachment url.");
+            Checks.check(hasUrlFormat(url), "URL must be a valid http(s) or attachment url.");
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -907,7 +907,7 @@ public class EmbedBuilder
         return fields;
     }
 
-    private boolean hasUrlFormat(@Nonnull String url)
+    private static boolean hasUrlFormat(@Nonnull String url)
     {
         if (url.regionMatches(true, 0, "https://", 0, "https://".length()))
         {
@@ -922,6 +922,23 @@ public class EmbedBuilder
             return url.length() > "attachment://".length();
         }
         return false;
+    }
+
+    /**
+     * Checks if the provided {@code url} is a valid http(s) or attachment url.
+     * The length of the {@code url} can't exceed {@link MessageEmbed#URL_MAX_LENGTH}.
+     * Note that this check is case-insensitive and at least one character is required
+     * after the url prefix. Meaning that "HtTpS://" will return {@code false}, while
+     * "HtTpS://a" will return {@code true}.
+     *
+     * @param url The string to check.
+     *
+     * @return {@code true} if {@code url} is a valid http(s) or attachment url,
+     * {@code false} otherwise.
+     */
+    public static boolean isUrlOrAttachment(@Nullable String url)
+    {
+        return url != null && url.length() <= MessageEmbed.URL_MAX_LENGTH && hasUrlFormat(url);
     }
 
     private void urlCheck(@Nullable String url)


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Just a simple change to avoid using a regex Pattern when checking if a URL is valid on the EmbedBuilder class. Instead, it relies on String#regionMatches (Case insensitive) and a simple length check to have the exact same behaviour as the current pattern. I know this may be considered micro optimization, but I found it and thought it could be an easy first PR for me.
