### PR TITLE
Move voice state cache to guild

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -1021,8 +1021,8 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     int getBoostCount();
 
     /**
-     * Sorted list of {@link net.dv8tion.jda.api.entities.Member Members} that boost this guild.
-     * <br>The list is sorted by {@link net.dv8tion.jda.api.entities.Member#getTimeBoosted()} ascending.
+     * Sorted list of {@link Member Members} that boost this guild.
+     * <br>The list is sorted by {@link Member#getTimeBoosted()} ascending.
      * This means the first element will be the member who has been boosting for the longest time.
      *
      * <p>This will only check cached members!
@@ -1130,7 +1130,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
 
     /**
      * Provides the {@link VoiceChannel VoiceChannel} that has been set as the channel
-     * which {@link net.dv8tion.jda.api.entities.Member Members} will be moved to after they have been inactive in a
+     * which {@link Member Members} will be moved to after they have been inactive in a
      * {@link VoiceChannel VoiceChannel} for longer than {@link #getAfkTimeout()}.
      * <br>If no channel has been set as the AFK channel, this returns {@code null}.
      * <p>
@@ -1146,7 +1146,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
 
     /**
      * Provides the {@link TextChannel TextChannel} that has been set as the channel
-     * which newly joined {@link net.dv8tion.jda.api.entities.Member Members} will be announced in.
+     * which newly joined {@link Member Members} will be announced in.
      * <br>If no channel has been set as the system channel, this returns {@code null}.
      * <p>
      * This value can be modified using {@link GuildManager#setSystemChannel(TextChannel)}.
@@ -1199,7 +1199,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     TextChannel getSafetyAlertsChannel();
 
     /**
-     * The {@link net.dv8tion.jda.api.entities.Member Member} object for the owner of this Guild.
+     * The {@link Member Member} object for the owner of this Guild.
      * <br>This is null when the owner is no longer in this guild or not yet loaded (lazy loading).
      * Sometimes owners of guilds delete their account or get banned by Discord.
      *
@@ -1309,7 +1309,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     boolean isMember(@Nonnull UserSnowflake user);
 
     /**
-     * Gets the {@link net.dv8tion.jda.api.entities.Member Member} object of the currently logged in account in this guild.
+     * Gets the {@link Member Member} object of the currently logged in account in this guild.
      * <br>This is basically {@link net.dv8tion.jda.api.JDA#getSelfUser()} being provided to {@link #getMember(UserSnowflake)}.
      *
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
@@ -1335,7 +1335,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     NSFWLevel getNSFWLevel();
 
     /**
-     * Gets the Guild specific {@link net.dv8tion.jda.api.entities.Member Member} object for the provided
+     * Gets the Guild specific {@link Member Member} object for the provided
      * {@link UserSnowflake}.
      * <br>If the user is not in this guild or currently uncached, {@code null} is returned.
      *
@@ -1350,7 +1350,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
      *         If this entity is {@link #isDetached() detached}
      *
-     * @return Possibly-null {@link net.dv8tion.jda.api.entities.Member Member} for the related {@link net.dv8tion.jda.api.entities.User User}.
+     * @return Possibly-null {@link Member Member} for the related {@link net.dv8tion.jda.api.entities.User User}.
      *
      * @see    #retrieveMember(UserSnowflake)
      */
@@ -1358,7 +1358,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     Member getMember(@Nonnull UserSnowflake user);
 
     /**
-     * Gets a {@link net.dv8tion.jda.api.entities.Member Member} object via the id of the user. The id relates to
+     * Gets a {@link Member Member} object via the id of the user. The id relates to
      * {@link net.dv8tion.jda.api.entities.User#getId()}, and this method is similar to {@link JDA#getUserById(String)}
      * <br>This is more efficient that using {@link JDA#getUserById(String)} and {@link #getMember(UserSnowflake)}.
      * <br>If no Member in this Guild has the {@code userId} provided, this returns {@code null}.
@@ -1373,7 +1373,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
      *         If this entity is {@link #isDetached() detached}
      *
-     * @return Possibly-null {@link net.dv8tion.jda.api.entities.Member Member} with the related {@code userId}.
+     * @return Possibly-null {@link Member Member} with the related {@code userId}.
      *
      * @see    #retrieveMemberById(String)
      */
@@ -1384,7 +1384,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     }
 
     /**
-     * Gets a {@link net.dv8tion.jda.api.entities.Member Member} object via the id of the user. The id relates to
+     * Gets a {@link Member Member} object via the id of the user. The id relates to
      * {@link net.dv8tion.jda.api.entities.User#getIdLong()}, and this method is similar to {@link JDA#getUserById(long)}
      * <br>This is more efficient that using {@link JDA#getUserById(long)} and {@link #getMember(UserSnowflake)}.
      * <br>If no Member in this Guild has the {@code userId} provided, this returns {@code null}.
@@ -1398,7 +1398,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
      *         If this entity is {@link #isDetached() detached}
      *
-     * @return Possibly-null {@link net.dv8tion.jda.api.entities.Member Member} with the related {@code userId}.
+     * @return Possibly-null {@link Member Member} with the related {@code userId}.
      *
      * @see    #retrieveMemberById(long)
      */
@@ -1409,11 +1409,11 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     }
 
     /**
-     * Searches for a {@link net.dv8tion.jda.api.entities.Member} that has the matching Discord Tag.
+     * Searches for a {@link Member} that has the matching Discord Tag.
      * <br>Format has to be in the form {@code Username#Discriminator} where the
      * username must be between 2 and 32 characters (inclusive) matching the exact casing and the discriminator
      * must be exactly 4 digits.
-     * <br>This does not check the {@link net.dv8tion.jda.api.entities.Member#getNickname() nickname} of the member
+     * <br>This does not check the {@link Member#getNickname() nickname} of the member
      * but the username.
      *
      * <p>This will only check cached members!
@@ -1431,7 +1431,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
      *         If this entity is {@link #isDetached() detached}
      *
-     * @return The {@link net.dv8tion.jda.api.entities.Member} for the discord tag or null if no member has the provided tag
+     * @return The {@link Member} for the discord tag or null if no member has the provided tag
      *
      * @see    net.dv8tion.jda.api.JDA#getUserByTag(String)
      */
@@ -1443,11 +1443,11 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     }
 
     /**
-     * Searches for a {@link net.dv8tion.jda.api.entities.Member} that has the matching Discord Tag.
+     * Searches for a {@link Member} that has the matching Discord Tag.
      * <br>Format has to be in the form {@code Username#Discriminator} where the
      * username must be between 2 and 32 characters (inclusive) matching the exact casing and the discriminator
      * must be exactly 4 digits.
-     * <br>This does not check the {@link net.dv8tion.jda.api.entities.Member#getNickname() nickname} of the member
+     * <br>This does not check the {@link Member#getNickname() nickname} of the member
      * but the username.
      *
      * <p>This will only check cached members!
@@ -1467,7 +1467,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
      *         If this entity is {@link #isDetached() detached}
      *
-     * @return The {@link net.dv8tion.jda.api.entities.Member} for the discord tag or null if no member has the provided tag
+     * @return The {@link Member} for the discord tag or null if no member has the provided tag
      *
      * @see    #getMemberByTag(String)
      */
@@ -1479,7 +1479,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     }
 
     /**
-     * A list of all {@link net.dv8tion.jda.api.entities.Member Members} in this Guild.
+     * A list of all {@link Member Members} in this Guild.
      * <br>The Members are not provided in any particular order.
      *
      * <p>This will only check cached members!
@@ -1505,9 +1505,9 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     }
 
     /**
-     * Gets a list of all {@link net.dv8tion.jda.api.entities.Member Members} who have the same name as the one provided.
-     * <br>This compares against {@link net.dv8tion.jda.api.entities.Member#getUser()}{@link net.dv8tion.jda.api.entities.User#getName() .getName()}
-     * <br>If there are no {@link net.dv8tion.jda.api.entities.Member Members} with the provided name, then this returns an empty list.
+     * Gets a list of all {@link Member Members} who have the same name as the one provided.
+     * <br>This compares against {@link Member#getUser()}{@link net.dv8tion.jda.api.entities.User#getName() .getName()}
+     * <br>If there are no {@link Member Members} with the provided name, then this returns an empty list.
      *
      * <p>This will only check cached members!
      * <br>See {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
@@ -1537,9 +1537,9 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     }
 
     /**
-     * Gets a list of all {@link net.dv8tion.jda.api.entities.Member Members} who have the same nickname as the one provided.
+     * Gets a list of all {@link Member Members} who have the same nickname as the one provided.
      * <br>This compares against {@link Member#getNickname()}. If a Member does not have a nickname, the comparison results as false.
-     * <br>If there are no {@link net.dv8tion.jda.api.entities.Member Members} with the provided name, then this returns an empty list.
+     * <br>If there are no {@link Member Members} with the provided name, then this returns an empty list.
      *
      * <p>This will only check cached members!
      * <br>See {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
@@ -1564,9 +1564,9 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     }
 
     /**
-     * Gets a list of all {@link net.dv8tion.jda.api.entities.Member Members} who have the same effective name as the one provided.
-     * <br>This compares against {@link net.dv8tion.jda.api.entities.Member#getEffectiveName()}.
-     * <br>If there are no {@link net.dv8tion.jda.api.entities.Member Members} with the provided name, then this returns an empty list.
+     * Gets a list of all {@link Member Members} who have the same effective name as the one provided.
+     * <br>This compares against {@link Member#getEffectiveName()}.
+     * <br>If there are no {@link Member Members} with the provided name, then this returns an empty list.
      *
      * <p>This will only check cached members!
      * <br>See {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
@@ -1593,14 +1593,14 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     }
 
     /**
-     * Gets a list of {@link net.dv8tion.jda.api.entities.Member Members} that have all {@link Role Roles} provided.
-     * <br>If there are no {@link net.dv8tion.jda.api.entities.Member Members} with all provided roles, then this returns an empty list.
+     * Gets a list of {@link Member Members} that have all {@link Role Roles} provided.
+     * <br>If there are no {@link Member Members} with all provided roles, then this returns an empty list.
      *
      * <p>This will only check cached members!
      * <br>See {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
      *
      * @param  roles
-     *         The {@link Role Roles} that a {@link net.dv8tion.jda.api.entities.Member Member}
+     *         The {@link Role Roles} that a {@link Member Member}
      *         must have to be included in the returned list.
      *
      * @throws java.lang.IllegalArgumentException
@@ -1621,14 +1621,14 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     }
 
     /**
-     * Gets a list of {@link net.dv8tion.jda.api.entities.Member Members} that have all provided {@link Role Roles}.
-     * <br>If there are no {@link net.dv8tion.jda.api.entities.Member Members} with all provided roles, then this returns an empty list.
+     * Gets a list of {@link Member Members} that have all provided {@link Role Roles}.
+     * <br>If there are no {@link Member Members} with all provided roles, then this returns an empty list.
      *
      * <p>This will only check cached members!
      * <br>See {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
      *
      * @param  roles
-     *         The {@link Role Roles} that a {@link net.dv8tion.jda.api.entities.Member Member}
+     *         The {@link Role Roles} that a {@link Member Member}
      *         must have to be included in the returned list.
      *
      * @throws java.lang.IllegalArgumentException
@@ -1652,7 +1652,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
 
     /**
      * {@link net.dv8tion.jda.api.utils.cache.MemberCacheView MemberCacheView} for all cached
-     * {@link net.dv8tion.jda.api.entities.Member Members} of this Guild.
+     * {@link Member Members} of this Guild.
      *
      * <p>This will only provide cached members!
      * <br>See {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
@@ -2644,7 +2644,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * <br>This role is special because its {@link Role#getPosition() position} is calculated as
      * {@code -1}. All other role positions are 0 or greater. This implies that the public role is <b>always</b> below
      * any custom roles created in this Guild. Additionally, all members of this guild are implied to have this role so
-     * it is not included in the list returned by {@link net.dv8tion.jda.api.entities.Member#getRoles() Member.getRoles()}.
+     * it is not included in the list returned by {@link Member#getRoles() Member.getRoles()}.
      * <br>The ID of this Role is the Guild's ID thus it is equivalent to using {@link #getRoleById(long) getRoleById(getIdLong())}.
      *
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
@@ -2737,7 +2737,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
 
     /**
      * Used to leave a Guild. If the currently logged in account is the owner of this guild ({@link net.dv8tion.jda.api.entities.Guild#getOwner()})
-     * then ownership of the Guild needs to be transferred to a different {@link net.dv8tion.jda.api.entities.Member Member}
+     * then ownership of the Guild needs to be transferred to a different {@link Member Member}
      * before leaving using {@link #transferOwnership(Member)}.
      *
      * @throws java.lang.IllegalStateException
@@ -2977,15 +2977,15 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     RestAction<GuildWelcomeScreen> retrieveWelcomeScreen();
 
     /**
-     * A list containing the {@link net.dv8tion.jda.api.entities.GuildVoiceState GuildVoiceState} of every {@link net.dv8tion.jda.api.entities.Member Member}
-     * in this {@link net.dv8tion.jda.api.entities.Guild Guild}.
-     * <br>This will never return an empty list because if it were empty, that would imply that there are no
-     * {@link net.dv8tion.jda.api.entities.Member Members} in this {@link net.dv8tion.jda.api.entities.Guild Guild}, which is
-     * impossible.
+     * A list containing the cached {@link GuildVoiceState} of every {@link Member}
+     * connected to an audio channel in this guild.
      *
-     * @return Never-empty immutable list containing all the {@link GuildVoiceState GuildVoiceStates} on this {@link net.dv8tion.jda.api.entities.Guild Guild}.
+     * <p>This requires {@link CacheFlag#VOICE_STATE} to be enabled.
+     *
+     * @return Immutable list containing all cached {@link GuildVoiceState GuildVoiceStates} for this guild.
      */
     @Nonnull
+    @Unmodifiable
     List<GuildVoiceState> getVoiceStates();
 
     /**
@@ -3840,7 +3840,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     /* From GuildController */
 
     /**
-     * Used to move a {@link net.dv8tion.jda.api.entities.Member Member} from one {@link AudioChannel AudioChannel}
+     * Used to move a {@link Member Member} from one {@link AudioChannel AudioChannel}
      * to another {@link AudioChannel AudioChannel}.
      * <br>As a note, you cannot move a Member that isn't already in a AudioChannel. Also they must be in a AudioChannel
      * in the same Guild as the one that you are moving them to.
@@ -3862,7 +3862,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * </ul>
      *
      * @param  member
-     *         The {@link net.dv8tion.jda.api.entities.Member Member} that you are moving.
+     *         The {@link Member Member} that you are moving.
      * @param  audioChannel
      *         The destination {@link AudioChannel AudioChannel} to which the member is being
      *         moved to. Or null to perform a voice kick.
@@ -3892,7 +3892,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     RestAction<Void> moveVoiceMember(@Nonnull Member member, @Nullable AudioChannel audioChannel);
 
     /**
-     * Used to kick a {@link net.dv8tion.jda.api.entities.Member Member} from a {@link AudioChannel AudioChannel}.
+     * Used to kick a {@link Member Member} from a {@link AudioChannel AudioChannel}.
      * <br>As a note, you cannot kick a Member that isn't already in a AudioChannel. Also they must be in a AudioChannel
      * in the same Guild.
      *
@@ -3912,7 +3912,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * </ul>
      *
      * @param  member
-     *         The {@link net.dv8tion.jda.api.entities.Member Member} that you are moving.
+     *         The {@link Member Member} that you are moving.
      *
      * @throws IllegalStateException
      *         If the Member isn't currently in a AudioChannel in this Guild, or {@link net.dv8tion.jda.api.utils.cache.CacheFlag#VOICE_STATE} is disabled.
@@ -3943,7 +3943,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      *
      * <p>To change the nickname for the currently logged in account
      * only the Permission {@link net.dv8tion.jda.api.Permission#NICKNAME_CHANGE NICKNAME_CHANGE} is required.
-     * <br>To change the nickname of <b>any</b> {@link net.dv8tion.jda.api.entities.Member Member} for this {@link net.dv8tion.jda.api.entities.Guild Guild}
+     * <br>To change the nickname of <b>any</b> {@link Member Member} for this {@link net.dv8tion.jda.api.entities.Guild Guild}
      * the Permission {@link net.dv8tion.jda.api.Permission#NICKNAME_MANAGE NICKNAME_MANAGE} is required.
      *
      * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
@@ -3957,13 +3957,13 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * </ul>
      *
      * @param  member
-     *         The {@link net.dv8tion.jda.api.entities.Member Member} for which the nickname should be changed.
+     *         The {@link Member Member} for which the nickname should be changed.
      * @param  nickname
-     *         The new nickname of the {@link net.dv8tion.jda.api.entities.Member Member}, provide {@code null} or an
+     *         The new nickname of the {@link Member Member}, provide {@code null} or an
      *         empty String to reset the nickname
      *
      * @throws IllegalArgumentException
-     *         If the specified {@link net.dv8tion.jda.api.entities.Member Member}
+     *         If the specified {@link Member Member}
      *         is not from the same {@link net.dv8tion.jda.api.entities.Guild Guild}.
      *         Or if the provided member is {@code null}
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
@@ -4147,7 +4147,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     }
 
     /**
-     * Kicks a {@link net.dv8tion.jda.api.entities.Member Member} from the {@link net.dv8tion.jda.api.entities.Guild Guild}.
+     * Kicks a {@link Member Member} from the {@link net.dv8tion.jda.api.entities.Guild Guild}.
      *
      * <p><b>Note:</b> {@link net.dv8tion.jda.api.entities.Guild#getMembers()} will still contain the {@link net.dv8tion.jda.api.entities.User User}
      * until Discord sends the {@link net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent GuildMemberRemoveEvent}.
@@ -4190,7 +4190,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * <p>You can unban a user with {@link net.dv8tion.jda.api.entities.Guild#unban(UserSnowflake) Guild.unban(UserReference)}.
      *
      * <p><b>Note:</b> {@link net.dv8tion.jda.api.entities.Guild#getMembers()} will still contain the {@link net.dv8tion.jda.api.entities.User User's}
-     * {@link net.dv8tion.jda.api.entities.Member Member} object (if the User was in the Guild)
+     * {@link Member Member} object (if the User was in the Guild)
      * until Discord sends the {@link net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent GuildMemberRemoveEvent}.
      *
      * <p><b>Examples</b><br>
@@ -4534,10 +4534,10 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     AuditableRestAction<Void> removeTimeout(@Nonnull UserSnowflake user);
 
     /**
-     * Sets the Guild Deafened state of the {@link net.dv8tion.jda.api.entities.Member Member} based on the provided
+     * Sets the Guild Deafened state of the {@link Member Member} based on the provided
      * boolean.
      *
-     * <p><b>Note:</b> The Member's {@link net.dv8tion.jda.api.entities.GuildVoiceState#isGuildDeafened() GuildVoiceState.isGuildDeafened()} value won't change
+     * <p><b>Note:</b> The Member's {@link GuildVoiceState#isGuildDeafened() GuildVoiceState.isGuildDeafened()} value won't change
      * until JDA receives the {@link net.dv8tion.jda.api.events.guild.voice.GuildVoiceGuildDeafenEvent GuildVoiceGuildDeafenEvent} event related to this change.
      *
      * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
@@ -4557,7 +4557,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      *         The {@link UserSnowflake} who's {@link GuildVoiceState} to change.
      *         This can be a member or user instance or {@link User#fromId(long)}.
      * @param  deafen
-     *         Whether this {@link net.dv8tion.jda.api.entities.Member Member} should be deafened or undeafened.
+     *         Whether this {@link Member Member} should be deafened or undeafened.
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the logged in account does not have the {@link net.dv8tion.jda.api.Permission#VOICE_DEAF_OTHERS} permission
@@ -4576,10 +4576,10 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     AuditableRestAction<Void> deafen(@Nonnull UserSnowflake user, boolean deafen);
 
     /**
-     * Sets the Guild Muted state of the {@link net.dv8tion.jda.api.entities.Member Member} based on the provided
+     * Sets the Guild Muted state of the {@link Member Member} based on the provided
      * boolean.
      *
-     * <p><b>Note:</b> The Member's {@link net.dv8tion.jda.api.entities.GuildVoiceState#isGuildMuted() GuildVoiceState.isGuildMuted()} value won't change
+     * <p><b>Note:</b> The Member's {@link GuildVoiceState#isGuildMuted() GuildVoiceState.isGuildMuted()} value won't change
      * until JDA receives the {@link net.dv8tion.jda.api.events.guild.voice.GuildVoiceGuildMuteEvent GuildVoiceGuildMuteEvent} event related to this change.
      *
      * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
@@ -4599,7 +4599,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      *         The {@link UserSnowflake} who's {@link GuildVoiceState} to change.
      *         This can be a member or user instance or {@link User#fromId(long)}.
      * @param  mute
-     *         Whether this {@link net.dv8tion.jda.api.entities.Member Member} should be muted or unmuted.
+     *         Whether this {@link Member Member} should be muted or unmuted.
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the logged in account does not have the {@link net.dv8tion.jda.api.Permission#VOICE_DEAF_OTHERS} permission
@@ -4618,7 +4618,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     AuditableRestAction<Void> mute(@Nonnull UserSnowflake user, boolean mute);
 
     /**
-     * Atomically assigns the provided {@link Role Role} to the specified {@link net.dv8tion.jda.api.entities.Member Member}.
+     * Atomically assigns the provided {@link Role Role} to the specified {@link Member Member}.
      * <br><b>This can be used together with other role modification methods as it does not require an updated cache!</b>
      *
      * <p>If multiple roles should be added/removed (efficiently) in one request
@@ -4665,7 +4665,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     AuditableRestAction<Void> addRoleToMember(@Nonnull UserSnowflake user, @Nonnull Role role);
 
     /**
-     * Atomically removes the provided {@link Role Role} from the specified {@link net.dv8tion.jda.api.entities.Member Member}.
+     * Atomically removes the provided {@link Role Role} from the specified {@link Member Member}.
      * <br><b>This can be used together with other role modification methods as it does not require an updated cache!</b>
      *
      * <p>If multiple roles should be added/removed (efficiently) in one request
@@ -4712,7 +4712,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     AuditableRestAction<Void> removeRoleFromMember(@Nonnull UserSnowflake user, @Nonnull Role role);
 
     /**
-     * Modifies the {@link Role Roles} of the specified {@link net.dv8tion.jda.api.entities.Member Member}
+     * Modifies the {@link Role Roles} of the specified {@link Member Member}
      * by adding and removing a collection of roles.
      * <br>None of the provided roles may be the <u>Public Role</u> of the current Guild.
      * <br>If a role is both in {@code rolesToAdd} and {@code rolesToRemove} it will be removed.
@@ -4756,13 +4756,13 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * </ul>
      *
      * @param  member
-     *         The {@link net.dv8tion.jda.api.entities.Member Member} that should be modified
+     *         The {@link Member Member} that should be modified
      * @param  rolesToAdd
      *         A {@link java.util.Collection Collection} of {@link Role Roles}
-     *         to add to the current Roles the specified {@link net.dv8tion.jda.api.entities.Member Member} already has, or null
+     *         to add to the current Roles the specified {@link Member Member} already has, or null
      * @param  rolesToRemove
      *         A {@link java.util.Collection Collection} of {@link Role Roles}
-     *         to remove from the current Roles the specified {@link net.dv8tion.jda.api.entities.Member Member} already has, or null
+     *         to remove from the current Roles the specified {@link Member Member} already has, or null
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_ROLES Permission.MANAGE_ROLES}
@@ -4784,7 +4784,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     AuditableRestAction<Void> modifyMemberRoles(@Nonnull Member member, @Nullable Collection<Role> rolesToAdd, @Nullable Collection<Role> rolesToRemove);
 
     /**
-     * Modifies the complete {@link Role Role} set of the specified {@link net.dv8tion.jda.api.entities.Member Member}
+     * Modifies the complete {@link Role Role} set of the specified {@link Member Member}
      * <br>The provided roles will replace all current Roles of the specified Member.
      *
      * <p><b>Warning</b><br>
@@ -4815,7 +4815,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * }</pre>
      *
      * @param  member
-     *         A {@link net.dv8tion.jda.api.entities.Member Member} of which to override the Roles of
+     *         A {@link Member Member} of which to override the Roles of
      * @param  roles
      *         New collection of {@link Role Roles} for the specified Member
      *
@@ -4846,7 +4846,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     }
 
     /**
-     * Modifies the complete {@link Role Role} set of the specified {@link net.dv8tion.jda.api.entities.Member Member}
+     * Modifies the complete {@link Role Role} set of the specified {@link Member Member}
      * <br>The provided roles will replace all current Roles of the specified Member.
      *
      * <p><u>The new roles <b>must not</b> contain the Public Role of the Guild</u>
@@ -4880,7 +4880,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * }</pre>
      *
      * @param  member
-     *         A {@link net.dv8tion.jda.api.entities.Member Member} of which to override the Roles of
+     *         A {@link Member Member} of which to override the Roles of
      * @param  roles
      *         New collection of {@link Role Roles} for the specified Member
      *
@@ -4908,7 +4908,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     AuditableRestAction<Void> modifyMemberRoles(@Nonnull Member member, @Nonnull Collection<Role> roles);
 
     /**
-     * Transfers the Guild ownership to the specified {@link net.dv8tion.jda.api.entities.Member Member}
+     * Transfers the Guild ownership to the specified {@link Member Member}
      * <br>Only available if the currently logged in account is the owner of this Guild
      *
      * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
@@ -5907,7 +5907,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * <br>Providing {@code true} to {@link #modifyRolePositions(boolean)} will result in the ordering being
      * in ascending order, with the highest role at index {@code n - 1} and the lowest at index {@code 0}.
      *
-     * <br>As a note: {@link net.dv8tion.jda.api.entities.Member#getRoles() Member.getRoles()}
+     * <br>As a note: {@link Member#getRoles() Member.getRoles()}
      * and {@link net.dv8tion.jda.api.entities.Guild#getRoles() Guild.getRoles()} are both in descending order, just like this method.
      *
      * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
@@ -5951,7 +5951,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      *         defined by Discord for roles, which is Descending. This means that the highest role appears at index {@code 0}
      *         and the lowest role at index {@code n - 1}. Providing {@code true} will result in the ordering being
      *         in ascending order, with the lower role at index {@code 0} and the highest at index {@code n - 1}.
-     *         <br>As a note: {@link net.dv8tion.jda.api.entities.Member#getRoles() Member.getRoles()}
+     *         <br>As a note: {@link Member#getRoles() Member.getRoles()}
      *         and {@link net.dv8tion.jda.api.entities.Guild#getRoles() Guild.getRoles()} are both in descending order.
      *
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -3007,7 +3007,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      */
     @Nonnull
     @CheckReturnValue
-    RestAction<GuildVoiceState> retrieveMemberVoiceStateById(long id);
+    CacheRestAction<GuildVoiceState> retrieveMemberVoiceStateById(long id);
 
     /**
      * Load the member's voice state for the specified user.

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
@@ -31,6 +31,8 @@ import java.time.OffsetDateTime;
 /**
  * Represents the voice state of a {@link net.dv8tion.jda.api.entities.Member Member} in a
  * {@link net.dv8tion.jda.api.entities.Guild Guild}.
+ * 
+ * <p>Voice states are only cached while the member is connected to a channel.
  *
  * @see Member#getVoiceState()
  */
@@ -47,14 +49,14 @@ public interface GuildVoiceState extends ISnowflake
     /**
      * Returns whether the {@link net.dv8tion.jda.api.entities.Member Member} muted themselves.
      *
-     * @return The User's self-mute status
+     * @return The User's self-mute status, or false if the member is not connected to an audio channel
      */
     boolean isSelfMuted();
 
     /**
      * Returns whether the {@link net.dv8tion.jda.api.entities.Member Member} deafened themselves.
      *
-     * @return The User's self-deaf status
+     * @return The User's self-deaf status, or false if the member is not connected to an audio channel
      */
     boolean isSelfDeafened();
 
@@ -62,7 +64,7 @@ public interface GuildVoiceState extends ISnowflake
      * Returns whether the {@link net.dv8tion.jda.api.entities.Member Member} is muted, either
      * by choice {@link #isSelfMuted()} or muted by an admin {@link #isGuildMuted()}
      *
-     * @return the Member's mute status
+     * @return the Member's mute status, or false if the member is not connected to an audio channel
      */
     boolean isMuted();
 
@@ -70,21 +72,21 @@ public interface GuildVoiceState extends ISnowflake
      * Returns whether the {@link net.dv8tion.jda.api.entities.Member Member} is deafened, either
      * by choice {@link #isSelfDeafened()} or deafened by an admin {@link #isGuildDeafened()}
      *
-     * @return the Member's deaf status
+     * @return the Member's deaf status, or false if the member is not connected to an audio channel
      */
     boolean isDeafened();
 
     /**
      * Returns whether the {@link net.dv8tion.jda.api.entities.Member Member} got muted by an Admin
      *
-     * @return the Member's guild-mute status
+     * @return the Member's guild-mute status, or false if the member is not connected to an audio channel
      */
     boolean isGuildMuted();
 
     /**
      * Returns whether the {@link net.dv8tion.jda.api.entities.Member Member} got deafened by an Admin
      *
-     * @return the Member's guild-deaf status
+     * @return the Member's guild-deaf status, or false if the member is not connected to an audio channel
      */
     boolean isGuildDeafened();
 
@@ -125,7 +127,7 @@ public interface GuildVoiceState extends ISnowflake
      * You can use {@link net.dv8tion.jda.api.utils.MemberCachePolicy#VOICE MemberCachePolicy.VOICE}
      * to cache members in voice channels.
      *
-     * @return The AudioChannelUnion that the Member is connected to, or null.
+     * @return The AudioChannelUnion that the Member is connected to, or null if the member is not connected to an audio channel.
      */
     @Nullable
     AudioChannelUnion getChannel();
@@ -140,9 +142,8 @@ public interface GuildVoiceState extends ISnowflake
 
     /**
      * Returns the {@link net.dv8tion.jda.api.entities.Member Member} corresponding to this GuildVoiceState instance
-     * (BackReference)
      *
-     * @return the Member that holds this GuildVoiceState
+     * @return The member related to this voice state, might not be cached and thus have outdated information.
      */
     @Nonnull
     Member getMember();
@@ -159,7 +160,7 @@ public interface GuildVoiceState extends ISnowflake
     /**
      * The Session-Id for this VoiceState
      *
-     * @return The Session-Id
+     * @return The Session-Id, or null if the member is not connected to an audio channel.
      */
     @Nullable
     String getSessionId();

--- a/src/main/java/net/dv8tion/jda/api/entities/Member.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Member.java
@@ -166,7 +166,8 @@ public interface Member extends IMentionable, IPermissionHolder, IDetachableEnti
      *
      * <p>This can be used to get the Member's VoiceChannel using {@link GuildVoiceState#getChannel()}.
      *
-     * <p>This requires {@link net.dv8tion.jda.api.utils.cache.CacheFlag#VOICE_STATE CacheFlag.VOICE_STATE} to be enabled!
+     * <p>Voice states are only cached while the member is connected to a channel.
+     * When the member is disconnected, this either returns null or an empty voice state.
      *
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
      *         If this entity is {@link #isDetached() detached}

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GenericGuildVoiceEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GenericGuildVoiceEvent.java
@@ -35,11 +35,6 @@ import javax.annotation.Nonnull;
  * the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_VOICE_STATES GUILD_VOICE_STATES} intent.
  *
  * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables that CacheFlag by default!
- *
- * <p>Additionally, these events require the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
- * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
- * member was updated and gives us the updated member object. In order to fire specific events like these we
- * need to have the old member cached to compare against.
  */
 public abstract class GenericGuildVoiceEvent extends GenericGuildEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceDeafenEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceDeafenEvent.java
@@ -34,11 +34,6 @@ import javax.annotation.Nonnull;
  * the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_VOICE_STATES GUILD_VOICE_STATES} intent.
  *
  * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables that CacheFlag by default!
- *
- * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
- * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
- * member was updated and gives us the updated member object. In order to fire a specific event like this we
- * need to have the old member cached to compare against.
  */
 public class GuildVoiceDeafenEvent extends GenericGuildVoiceEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceGuildDeafenEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceGuildDeafenEvent.java
@@ -32,11 +32,6 @@ import javax.annotation.Nonnull;
  * the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_VOICE_STATES GUILD_VOICE_STATES} intent.
  *
  * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables that CacheFlag by default!
- *
- * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
- * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
- * member was updated and gives us the updated member object. In order to fire a specific event like this we
- * need to have the old member cached to compare against.
  */
 public class GuildVoiceGuildDeafenEvent extends GenericGuildVoiceEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceGuildMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceGuildMuteEvent.java
@@ -32,11 +32,6 @@ import javax.annotation.Nonnull;
  * the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_VOICE_STATES GUILD_VOICE_STATES} intent.
  *
  * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables that CacheFlag by default!
- *
- * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
- * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
- * member was updated and gives us the updated member object. In order to fire a specific event like this we
- * need to have the old member cached to compare against.
  */
 public class GuildVoiceGuildMuteEvent extends GenericGuildVoiceEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceMuteEvent.java
@@ -34,11 +34,6 @@ import javax.annotation.Nonnull;
  * the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_VOICE_STATES GUILD_VOICE_STATES} intent.
  *
  * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables that CacheFlag by default!
- *
- * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
- * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
- * member was updated and gives us the updated member object. In order to fire a specific event like this we
- * need to have the old member cached to compare against.
  */
 public class GuildVoiceMuteEvent extends GenericGuildVoiceEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceRequestToSpeakEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceRequestToSpeakEvent.java
@@ -39,11 +39,6 @@ import java.time.OffsetDateTime;
  * the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_VOICE_STATES GUILD_VOICE_STATES} intent.
  *
  * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables that CacheFlag by default!
- *
- * <p>Additionally, these events require the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
- * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
- * member was updated and gives us the updated member object. In order to fire specific events like these we
- * need to have the old member cached to compare against.
  */
 public class GuildVoiceRequestToSpeakEvent extends GenericGuildVoiceEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSelfDeafenEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSelfDeafenEvent.java
@@ -32,11 +32,6 @@ import javax.annotation.Nonnull;
  * the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_VOICE_STATES GUILD_VOICE_STATES} intent.
  *
  * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables that CacheFlag by default!
- *
- * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
- * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
- * member was updated and gives us the updated member object. In order to fire a specific event like this we
- * need to have the old member cached to compare against.
  */
 public class GuildVoiceSelfDeafenEvent extends GenericGuildVoiceEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSelfMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSelfMuteEvent.java
@@ -32,11 +32,6 @@ import javax.annotation.Nonnull;
  * the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_VOICE_STATES GUILD_VOICE_STATES} intent.
  *
  * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables that CacheFlag by default!
- *
- * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
- * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
- * member was updated and gives us the updated member object. In order to fire a specific event like this we
- * need to have the old member cached to compare against.
  */
 public class GuildVoiceSelfMuteEvent extends GenericGuildVoiceEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceStreamEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceStreamEvent.java
@@ -32,11 +32,6 @@ import javax.annotation.Nonnull;
  * the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_VOICE_STATES GUILD_VOICE_STATES} intent.
  *
  * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables that CacheFlag by default!
- *
- * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
- * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
- * member was updated and gives us the updated member object. In order to fire a specific event like this we
- * need to have the old member cached to compare against.
  */
 public class GuildVoiceStreamEvent extends GenericGuildVoiceEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSuppressEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSuppressEvent.java
@@ -33,11 +33,6 @@ import javax.annotation.Nonnull;
  *
  * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables that CacheFlag by default!
  *
- * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
- * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
- * member was updated and gives us the updated member object. In order to fire a specific event like this we
- * need to have the old member cached to compare against.
- *
  * @see net.dv8tion.jda.api.entities.GuildVoiceState#isSuppressed() GuildVoiceState.isSuppressed()
  */
 public class GuildVoiceSuppressEvent extends GenericGuildVoiceEvent

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceUpdateEvent.java
@@ -52,11 +52,6 @@ import javax.annotation.Nullable;
  *
  * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables that CacheFlag by default!
  *
- * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
- * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
- * member was updated and gives us the updated member object. In order to fire a specific event like this we
- * need to have the old member cached to compare against.
- *
  * <p>Identifier: {@code audio-channel}
  */
 public class GuildVoiceUpdateEvent extends GenericGuildVoiceEvent implements UpdateEvent<Member, AudioChannel>

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceVideoEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceVideoEvent.java
@@ -33,11 +33,6 @@ import javax.annotation.Nonnull;
  * the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_VOICE_STATES GUILD_VOICE_STATES} intent.
  *
  * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables that CacheFlag by default!
- *
- * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
- * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
- * member was updated and gives us the updated member object. In order to fire a specific event like this we
- * need to have the old member cached to compare against.
  */
 public class GuildVoiceVideoEvent extends GenericGuildVoiceEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/package-info.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/package-info.java
@@ -26,10 +26,5 @@
  * the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_VOICE_STATES GUILD_VOICE_STATES} intent.
  *
  * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables that CacheFlag by default!
- *
- * <p>Additionally, these events require the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
- * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
- * member was updated and gives us the updated member object. In order to fire specific events like these we
- * need to have the old member cached to compare against.
  */
 package net.dv8tion.jda.api.events.guild.voice;

--- a/src/main/java/net/dv8tion/jda/api/utils/cache/CacheFlag.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/CacheFlag.java
@@ -43,6 +43,8 @@ public enum CacheFlag
      * Enables cache for {@link Member#getVoiceState()}
      * <br>This will always be cached for self member.
      *
+     * <p><b>Voice states are only cached when the member is connected to an audio channel.</b>
+     *
      * <p>Requires {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_VOICE_STATES GUILD_VOICE_STATES} intent to be enabled.
      */
     VOICE_STATE(GatewayIntent.GUILD_VOICE_STATES),

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -657,6 +657,9 @@ public class EntityBuilder extends AbstractEntityBuilder
             createGuildVoiceState(member, voiceStateJson);
         if (presence != null)
             createPresence(member, presence);
+
+        // Make sure the voice states always have the latest member reference, even when member is uncached
+        guild.updateCacheVoiceStateMember(member);
         return member;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -582,14 +582,6 @@ public class EntityBuilder extends AbstractEntityBuilder
                 // we no longer share any guilds/channels with this user so remove it from cache
                 getJDA().getUsersView().remove(user.getIdLong());
             }
-
-            GuildVoiceStateImpl voiceState = member.getVoiceState();
-            if (voiceState != null)
-            {
-                voiceState.setConnectedChannel(null);
-                guild.handleVoiceStateUpdate(voiceState);
-            }
-
             return false;
         }
         else if (guild.getMemberById(member.getIdLong()) != null)
@@ -703,9 +695,7 @@ public class EntityBuilder extends AbstractEntityBuilder
                 .setSessionId(newVoiceStateJson.getString("session_id"))
                 .setStream(newVoiceStateJson.getBoolean("self_stream"))
                 .setRequestToSpeak(timestamp)
-                .setConnectedChannel(audioChannel);
-
-        guild.handleVoiceStateUpdate(currentVoiceState);
+                .updateConnectedChannel(audioChannel);
     }
 
     public void updateMember(GuildImpl guild, MemberImpl member, DataObject content, List<Role> newRoles)

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -2432,10 +2432,15 @@ public class GuildImpl implements Guild
         memberCount++;
     }
 
-    public void onMemberRemove()
+    public void onMemberRemove(long memberId)
     {
         memberCount--;
+        this.voiceStateCache.remove(memberId);
+        if (this.memberPresences != null)
+            this.memberPresences.remove(memberId);
     }
+
+    // -- Voice State Cache Handling --
 
     public boolean shouldCacheVoiceState(long userId)
     {
@@ -2464,6 +2469,17 @@ public class GuildImpl implements Guild
             else
                 this.voiceStateCache.getMap().remove(voiceState.getIdLong());
         }
+    }
+
+    public List<Member> getConnectedMembers(GuildChannel channel)
+    {
+        return this.voiceStateCache.applyStream(stream ->
+            stream
+                .filter(state -> channel.equals(state.getChannel()))
+                .map(GuildVoiceStateImpl::getMember)
+                .filter(Objects::nonNull) // sanity filter
+                .collect(Helpers.toUnmodifiableList())
+        );
     }
 
     // -- Object overrides --

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -2448,6 +2448,19 @@ public class GuildImpl implements Guild
         return null;
     }
 
+    public void updateCacheVoiceStateMember(MemberImpl member)
+    {
+        if (!shouldCacheVoiceState(member.getIdLong()))
+            return;
+
+        try (UnlockHook hook = this.voiceStateCache.writeLock())
+        {
+            GuildVoiceStateImpl voiceState = this.voiceStateCache.get(member.getIdLong());
+            if (voiceState != null)
+                voiceState.setMember(member);
+        }
+    }
+
     public void handleVoiceStateUpdate(GuildVoiceStateImpl voiceState)
     {
         if (!shouldCacheVoiceState(voiceState.getIdLong()))

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1717,19 +1717,15 @@ public class GuildImpl implements Guild
     {
         Checks.notNull(user, "User");
 
-        Member member = resolveMember(user);
-        if (member != null)
+        if (shouldCacheVoiceState(user.getIdLong()))
         {
-            GuildVoiceState voiceState = member.getVoiceState();
-            if (voiceState != null)
-            {
-                final AudioChannelUnion channel = voiceState.getChannel();
-                if (channel == null)
-                    throw new IllegalStateException("Can only deafen members who are currently in a voice channel");
-                if (voiceState.isGuildDeafened() == deafen)
-                    return new CompletedRestAction<>(getJDA(), null);
-                ((GuildChannelMixin<?>) channel).checkPermission(Permission.VOICE_DEAF_OTHERS);
-            }
+            GuildVoiceStateImpl voiceState = voiceStateCache.get(user.getIdLong());
+            AudioChannelUnion channel = voiceState != null ? voiceState.getChannel() : null;
+            if (channel == null)
+                throw new IllegalStateException("Can only deafen members who are currently in a voice channel");
+            if (voiceState.isGuildDeafened() == deafen)
+                return new CompletedRestAction<>(getJDA(), null);
+            ((GuildChannelMixin<?>) channel).checkPermission(Permission.VOICE_DEAF_OTHERS);
         }
 
         DataObject body = DataObject.empty().put("deaf", deafen);
@@ -1743,19 +1739,15 @@ public class GuildImpl implements Guild
     {
         Checks.notNull(user, "User");
 
-        Member member = resolveMember(user);
-        if (member != null)
+        if (shouldCacheVoiceState(user.getIdLong()))
         {
-            GuildVoiceState voiceState = member.getVoiceState();
-            if (voiceState != null)
-            {
-                final AudioChannelUnion channel = voiceState.getChannel();
-                if (channel == null)
-                    throw new IllegalStateException("Can only mute members who are currently in a voice channel");
-                if (voiceState.isGuildMuted() == mute && (mute || !voiceState.isSuppressed()))
-                    return new CompletedRestAction<>(getJDA(), null);
-                ((GuildChannelMixin<?>) channel).checkPermission(Permission.VOICE_MUTE_OTHERS);
-            }
+            GuildVoiceStateImpl voiceState = voiceStateCache.get(user.getIdLong());
+            AudioChannelUnion channel = voiceState != null ? voiceState.getChannel() : null;
+            if (channel == null)
+                throw new IllegalStateException("Can only mute members who are currently in a voice channel");
+            if (voiceState.isGuildMuted() == mute && (mute || !voiceState.isSuppressed()))
+                return new CompletedRestAction<>(getJDA(), null);
+            ((GuildChannelMixin<?>) channel).checkPermission(Permission.VOICE_MUTE_OTHERS);
         }
 
         DataObject body = DataObject.empty().put("mute", mute);

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1199,10 +1199,9 @@ public class GuildImpl implements Guild
     @Override
     public List<GuildVoiceState> getVoiceStates()
     {
-        return getMembersView().stream()
-                .map(Member::getVoiceState)
-                .filter(Objects::nonNull)
-                .collect(Helpers.toUnmodifiableList());
+        return this.voiceStateCache.applyStream(stream ->
+            stream.collect(Helpers.toUnmodifiableList())
+        );
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
@@ -251,9 +251,10 @@ public class GuildVoiceStateImpl implements GuildVoiceState
 
     // -- Setters --
 
-    public GuildVoiceStateImpl setConnectedChannel(AudioChannel connectedChannel)
+    public GuildVoiceStateImpl updateConnectedChannel(AudioChannel connectedChannel)
     {
         this.connectedChannel = connectedChannel;
+        ((GuildImpl) guild).handleVoiceStateUpdate(this);
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
@@ -251,6 +251,11 @@ public class GuildVoiceStateImpl implements GuildVoiceState
 
     // -- Setters --
 
+    public void setMember(Member member)
+    {
+        this.member = member;
+    }
+
     public GuildVoiceStateImpl updateConnectedChannel(AudioChannel connectedChannel)
     {
         this.connectedChannel = connectedChannel;

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -25,7 +25,6 @@ import net.dv8tion.jda.api.entities.channel.attribute.IPermissionContainer;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.entities.channel.unions.DefaultGuildChannelUnion;
 import net.dv8tion.jda.api.entities.emoji.RichCustomEmoji;
-import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.channel.mixin.attribute.IPermissionContainerMixin;
@@ -48,7 +47,6 @@ public class MemberImpl implements Member, MemberMixin<MemberImpl>
 {
     private final JDAImpl api;
     private final Set<Role> roles = ConcurrentHashMap.newKeySet();
-    private final GuildVoiceState voiceState;
 
     private GuildImpl guild;
     private User user;
@@ -64,8 +62,6 @@ public class MemberImpl implements Member, MemberMixin<MemberImpl>
         this.guild = guild;
         this.user = user;
         this.joinDate = 0;
-        boolean cacheState = api.isCacheFlagSet(CacheFlag.VOICE_STATE) || user.equals(api.getSelfUser());
-        this.voiceState = cacheState ? new GuildVoiceStateImpl(this) : null;
     }
 
     @Override
@@ -144,9 +140,9 @@ public class MemberImpl implements Member, MemberMixin<MemberImpl>
     }
 
     @Override
-    public GuildVoiceState getVoiceState()
+    public GuildVoiceStateImpl getVoiceState()
     {
-        return voiceState;
+       return guild.getVoiceState(this);
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/StageChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/StageChannelImpl.java
@@ -16,7 +16,6 @@
 
 package net.dv8tion.jda.internal.entities.channel.concrete;
 
-import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
@@ -28,7 +27,6 @@ import net.dv8tion.jda.api.managers.channel.concrete.StageChannelManager;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.Route;
 import net.dv8tion.jda.api.requests.restaction.StageInstanceAction;
-import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.channel.middleman.AbstractStandardGuildChannelImpl;
@@ -41,8 +39,6 @@ import net.dv8tion.jda.internal.utils.Checks;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -50,8 +46,6 @@ public class StageChannelImpl extends AbstractStandardGuildChannelImpl<StageChan
         StageChannel,
         StageChannelMixin<StageChannelImpl>
 {
-    private final TLongObjectMap<Member> connectedMembers = MiscUtil.newLongMap();
-
     private StageInstance instance;
     private String region;
     private int bitrate;
@@ -115,7 +109,7 @@ public class StageChannelImpl extends AbstractStandardGuildChannelImpl<StageChan
     @Override
     public List<Member> getMembers()
     {
-        return Collections.unmodifiableList(new ArrayList<>(connectedMembers.valueCollection()));
+        return getGuild().getConnectedMembers(this);
     }
 
     @Nonnull
@@ -197,12 +191,6 @@ public class StageChannelImpl extends AbstractStandardGuildChannelImpl<StageChan
         if (!this.equals(guild.getSelfMember().getVoiceState().getChannel()))
             throw new IllegalStateException("Cannot cancel request to speak without being connected to the stage channel!");
         return new RestActionImpl<>(getJDA(), route, body);
-    }
-
-    @Override
-    public TLongObjectMap<Member> getConnectedMembersMap()
-    {
-        return connectedMembers;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/VoiceChannelImpl.java
@@ -16,7 +16,6 @@
 
 package net.dv8tion.jda.internal.entities.channel.concrete;
 
-import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
@@ -24,7 +23,6 @@ import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 import net.dv8tion.jda.api.managers.channel.concrete.VoiceChannelManager;
 import net.dv8tion.jda.api.requests.Route;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
-import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.channel.middleman.AbstractStandardGuildChannelImpl;
@@ -35,16 +33,12 @@ import net.dv8tion.jda.internal.utils.Checks;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class VoiceChannelImpl extends AbstractStandardGuildChannelImpl<VoiceChannelImpl> implements
         VoiceChannel,
         VoiceChannelMixin<VoiceChannelImpl>
 {
-    private final TLongObjectMap<Member> connectedMembers = MiscUtil.newLongMap();
-
     private String region;
     private String status = "";
     private long latestMessageId;
@@ -119,7 +113,7 @@ public class VoiceChannelImpl extends AbstractStandardGuildChannelImpl<VoiceChan
     @Override
     public List<Member> getMembers()
     {
-        return Collections.unmodifiableList(new ArrayList<>(connectedMembers.valueCollection()));
+        return getGuild().getConnectedMembers(this);
     }
 
     @Nonnull
@@ -150,12 +144,6 @@ public class VoiceChannelImpl extends AbstractStandardGuildChannelImpl<VoiceChan
         Route.CompiledRoute route = Route.Channels.SET_STATUS.compile(getId());
         DataObject body = DataObject.empty().put("status", status);
         return new AuditableRestActionImpl<>(api, route, body);
-    }
-
-    @Override
-    public TLongObjectMap<Member> getConnectedMembersMap()
-    {
-        return connectedMembers;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedStageChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedStageChannelImpl.java
@@ -16,7 +16,6 @@
 
 package net.dv8tion.jda.internal.entities.channel.concrete.detached;
 
-import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.StageInstance;
@@ -151,12 +150,6 @@ public class DetachedStageChannelImpl extends AbstractStandardGuildChannelImpl<D
     @Nonnull
     @Override
     public RestAction<Void> cancelRequestToSpeak()
-    {
-        throw detachedException();
-    }
-
-    @Override
-    public TLongObjectMap<Member> getConnectedMembersMap()
     {
         throw detachedException();
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedVoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedVoiceChannelImpl.java
@@ -16,7 +16,6 @@
 
 package net.dv8tion.jda.internal.entities.channel.concrete.detached;
 
-import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
@@ -127,12 +126,6 @@ public class DetachedVoiceChannelImpl extends AbstractStandardGuildChannelImpl<D
     @Nonnull
     @Override
     public AuditableRestAction<Void> modifyStatus(@Nonnull String status)
-    {
-        throw detachedException();
-    }
-
-    @Override
-    public TLongObjectMap<Member> getConnectedMembersMap()
     {
         throw detachedException();
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/mixin/middleman/AudioChannelMixin.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/mixin/middleman/AudioChannelMixin.java
@@ -16,9 +16,7 @@
 
 package net.dv8tion.jda.internal.entities.channel.mixin.middleman;
 
-import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.unions.AudioChannelUnion;
 import net.dv8tion.jda.api.exceptions.MissingAccessException;
 
@@ -26,7 +24,6 @@ public interface AudioChannelMixin<T extends AudioChannelMixin<T>>
         extends AudioChannelUnion, StandardGuildChannelMixin<T>
 {
     // ---- State Accessors ----
-    TLongObjectMap<Member> getConnectedMembersMap();
 
     T setBitrate(int bitrate);
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/detached/DetachedGuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/detached/DetachedGuildImpl.java
@@ -721,7 +721,7 @@ public class DetachedGuildImpl implements Guild, IDetachableEntityMixin
 
     @Nonnull
     @Override
-    public RestAction<GuildVoiceState> retrieveMemberVoiceStateById(long id)
+    public CacheRestAction<GuildVoiceState> retrieveMemberVoiceStateById(long id)
     {
         throw detachedException();
     }

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberRemoveHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberRemoveHandler.java
@@ -76,7 +76,7 @@ public class GuildMemberRemoveHandler extends SocketHandler
             if (voiceState != null && voiceState.inAudioChannel()) //If this user was in an AudioChannel, fire VoiceLeaveEvent.
             {
                 AudioChannel channel = voiceState.getChannel();
-                voiceState.setConnectedChannel(null);
+                voiceState.updateConnectedChannel(null);
 
                 getJDA().handleEvent(
                     new GuildVoiceUpdateEvent(

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberRemoveHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberRemoveHandler.java
@@ -15,20 +15,15 @@
  */
 package net.dv8tion.jda.internal.handle;
 
-import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent;
-import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.GuildVoiceStateImpl;
 import net.dv8tion.jda.internal.entities.MemberImpl;
-import net.dv8tion.jda.internal.entities.MemberPresenceImpl;
-import net.dv8tion.jda.internal.entities.channel.concrete.VoiceChannelImpl;
-import net.dv8tion.jda.internal.entities.channel.mixin.middleman.AudioChannelMixin;
 import net.dv8tion.jda.internal.utils.UnlockHook;
 import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
 
@@ -62,69 +57,56 @@ public class GuildMemberRemoveHandler extends SocketHandler
             return null;
         }
 
-        // Update the memberCount
-        guild.onMemberRemove();
-        CacheView.SimpleCacheView<MemberPresenceImpl> presences = guild.getPresenceView();
-        if (presences != null)
-            presences.remove(userId);
-
-        User user = api.getEntityBuilder().createUser(content.getObject("user"));
-        MemberImpl member = (MemberImpl) guild.getMembersView().remove(userId);
-
-        if (member == null)
+        try
         {
-//            WebSocketClient.LOG.debug("Received GUILD_MEMBER_REMOVE for a Member that does not exist in the specified Guild. UserId: {} GuildId: {}", userId, id);
-            // Remove user from voice channel if applicable
-            guild.getVoiceChannelCache().forEachUnordered((channel) -> {
-                VoiceChannelImpl impl = (VoiceChannelImpl) channel;
-                Member connected = impl.getConnectedMembersMap().remove(userId);
-                if (connected != null) // user left channel!
-                {
-                    getJDA().handleEvent(
-                        new GuildVoiceUpdateEvent(
-                            getJDA(), responseNumber,
-                            connected, channel));
-                }
-            });
+            User user = api.getEntityBuilder().createUser(content.getObject("user"));
+            MemberImpl member = (MemberImpl) guild.getMembersView().remove(userId);
 
-            // Fire cache independent event, we can still inform the library user about the member removal
+            if (member == null)
+            {
+                // Fire cache independent event, we can still inform the library user about the member removal
+                getJDA().handleEvent(
+                    new GuildMemberRemoveEvent(
+                        getJDA(), responseNumber,
+                        guild, user, null));
+                return null;
+            }
+
+            GuildVoiceStateImpl voiceState = member.getVoiceState();
+            if (voiceState != null && voiceState.inAudioChannel()) //If this user was in an AudioChannel, fire VoiceLeaveEvent.
+            {
+                AudioChannel channel = voiceState.getChannel();
+                voiceState.setConnectedChannel(null);
+
+                getJDA().handleEvent(
+                    new GuildVoiceUpdateEvent(
+                        getJDA(), responseNumber,
+                        member, channel));
+            }
+
+            //The user is not in a different guild that we share
+            SnowflakeCacheViewImpl<User> userView = getJDA().getUsersView();
+            try (UnlockHook hook = userView.writeLock())
+            {
+                if (userId != getJDA().getSelfUser().getIdLong() // don't remove selfUser from cache
+                        && getJDA().getGuildsView().stream()
+                        .noneMatch(g -> g.getMemberById(userId) != null))
+                {
+                    userView.remove(userId);
+                    getJDA().getEventCache().clear(EventCache.Type.USER, userId);
+                }
+            }
+            // Cache independent event
             getJDA().handleEvent(
                 new GuildMemberRemoveEvent(
                     getJDA(), responseNumber,
-                    guild, user, null));
+                    guild, user, member));
             return null;
         }
-
-        GuildVoiceStateImpl voiceState = (GuildVoiceStateImpl) member.getVoiceState();
-        if (voiceState != null && voiceState.inAudioChannel()) //If this user was in an AudioChannel, fire VoiceLeaveEvent.
+        finally
         {
-            AudioChannel channel = voiceState.getChannel();
-            voiceState.setConnectedChannel(null);
-            ((AudioChannelMixin<?>) channel).getConnectedMembersMap().remove(userId);
-
-            getJDA().handleEvent(
-                new GuildVoiceUpdateEvent(
-                    getJDA(), responseNumber,
-                    member, channel));
+            // Reduce member count and remove dependent caches
+            guild.onMemberRemove(userId);
         }
-
-        //The user is not in a different guild that we share
-        SnowflakeCacheViewImpl<User> userView = getJDA().getUsersView();
-        try (UnlockHook hook = userView.writeLock())
-        {
-            if (userId != getJDA().getSelfUser().getIdLong() // don't remove selfUser from cache
-                    && getJDA().getGuildsView().stream()
-                               .noneMatch(g -> g.getMemberById(userId) != null))
-            {
-                userView.remove(userId);
-                getJDA().getEventCache().clear(EventCache.Type.USER, userId);
-            }
-        }
-        // Cache independent event
-        getJDA().handleEvent(
-            new GuildMemberRemoveEvent(
-                getJDA(), responseNumber,
-                guild, user, member));
-        return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
@@ -174,7 +174,7 @@ public class VoiceStateUpdateHandler extends SocketHandler
         if (!Objects.equals(channel, vState.getChannel()))
         {
             AudioChannel oldChannel = vState.getChannel();
-            vState.setConnectedChannel(channel);
+            vState.updateConnectedChannel(channel);
 
             if (oldChannel == null)
             {
@@ -223,6 +223,5 @@ public class VoiceStateUpdateHandler extends SocketHandler
         }
 
         guild.updateRequestToSpeak();
-        guild.handleVoiceStateUpdate(vState);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.GuildVoiceStateImpl;
 import net.dv8tion.jda.internal.entities.MemberImpl;
 import net.dv8tion.jda.internal.managers.AudioManagerImpl;
+import net.dv8tion.jda.internal.requests.WebSocketClient;
 
 import java.time.OffsetDateTime;
 import java.util.Objects;
@@ -44,6 +45,12 @@ public class VoiceStateUpdateHandler extends SocketHandler
             return null; //unhandled for calls
         if (getJDA().getGuildSetupController().isLocked(guildId))
             return guildId;
+
+        if (content.isNull("member"))
+        {
+            WebSocketClient.LOG.debug("Discarding VOICE_STATE_UPDATE with missing member. JSON: {}", content);
+            return null;
+        }
 
         handleGuildVoiceState(content);
         return null;

--- a/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
@@ -24,7 +24,6 @@ import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.GuildVoiceStateImpl;
 import net.dv8tion.jda.internal.entities.MemberImpl;
-import net.dv8tion.jda.internal.entities.channel.mixin.middleman.AudioChannelMixin;
 import net.dv8tion.jda.internal.managers.AudioManagerImpl;
 
 import java.time.OffsetDateTime;
@@ -172,12 +171,10 @@ public class VoiceStateUpdateHandler extends SocketHandler
 
             if (oldChannel == null)
             {
-                ((AudioChannelMixin<?>) channel).getConnectedMembersMap().put(userId, member);
                 getJDA().getEntityBuilder().updateMemberCache(member);
             }
             else if (channel == null)
             {
-                ((AudioChannelMixin<?>) oldChannel).getConnectedMembersMap().remove(userId);
                 if (isSelf)
                     getJDA().getDirectAudioController().update(guild, null);
                 getJDA().getEntityBuilder().updateMemberCache(member, memberJson.isNull("joined_at"));
@@ -202,8 +199,6 @@ public class VoiceStateUpdateHandler extends SocketHandler
                     //If we are not already connected this will be removed by VOICE_SERVER_UPDATE
                 }
 
-                ((AudioChannelMixin<?>) channel).getConnectedMembersMap().put(userId, member);
-                ((AudioChannelMixin<?>) oldChannel).getConnectedMembersMap().remove(userId);
                 getJDA().getEntityBuilder().updateMemberCache(member);
 
             }

--- a/src/test/java/net/dv8tion/jda/test/IntegrationTest.java
+++ b/src/test/java/net/dv8tion/jda/test/IntegrationTest.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.test;
 import net.dv8tion.jda.api.requests.Request;
 import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
@@ -33,6 +34,7 @@ import org.mockito.Mock;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import java.util.EnumSet;
 import java.util.Random;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
@@ -110,5 +112,10 @@ public class IntegrationTest
     protected String randomSnowflake()
     {
         return Long.toUnsignedString(random.nextLong());
+    }
+
+    protected void withCacheFlags(EnumSet<CacheFlag> flags)
+    {
+        when(jda.getCacheFlags()).thenReturn(flags);
     }
 }

--- a/src/test/java/net/dv8tion/jda/test/entities/guild/GuildLevelCacheTest.java
+++ b/src/test/java/net/dv8tion/jda/test/entities/guild/GuildLevelCacheTest.java
@@ -120,9 +120,8 @@ public class GuildLevelCacheTest extends IntegrationTest
             MemberImpl member = new MemberImpl(guild, user);
 
             GuildVoiceStateImpl voiceState = new GuildVoiceStateImpl(member);
-            voiceState.setConnectedChannel(channel);
+            voiceState.updateConnectedChannel(channel);
 
-            guild.handleVoiceStateUpdate(voiceState);
             assertThatVoiceStateIsNotCached(guild, member);
         }
 
@@ -134,9 +133,8 @@ public class GuildLevelCacheTest extends IntegrationTest
 
             GuildVoiceStateImpl voiceState = member.getVoiceState();
             assertThat(voiceState).isNotNull();
-            voiceState.setConnectedChannel(channel);
+            voiceState.updateConnectedChannel(channel);
 
-            guild.handleVoiceStateUpdate(voiceState);
             assertThatVoiceStateIsCached(guild, member);
         }
     }
@@ -177,9 +175,8 @@ public class GuildLevelCacheTest extends IntegrationTest
 
             GuildVoiceStateImpl voiceState = member.getVoiceState();
             assertThat(voiceState).isNotNull();
-            voiceState.setConnectedChannel(channel);
+            voiceState.updateConnectedChannel(channel);
 
-            guild.handleVoiceStateUpdate(voiceState);
             assertThatVoiceStateIsCached(guild, member);
         }
 
@@ -192,14 +189,12 @@ public class GuildLevelCacheTest extends IntegrationTest
             GuildVoiceStateImpl voiceState = member.getVoiceState();
             assertThat(voiceState).isNotNull();
 
-            voiceState.setConnectedChannel(channel);
+            voiceState.updateConnectedChannel(channel);
 
-            guild.handleVoiceStateUpdate(voiceState);
             assertThatVoiceStateIsCached(guild, member);
 
-            voiceState.setConnectedChannel(null);
+            voiceState.updateConnectedChannel(null);
 
-            guild.handleVoiceStateUpdate(voiceState);
             assertThatVoiceStateIsNotCached(guild, member);
         }
     }

--- a/src/test/java/net/dv8tion/jda/test/entities/guild/GuildLevelCacheTest.java
+++ b/src/test/java/net/dv8tion/jda/test/entities/guild/GuildLevelCacheTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.test.entities.guild;
+
+import net.dv8tion.jda.api.utils.cache.CacheFlag;
+import net.dv8tion.jda.internal.entities.*;
+import net.dv8tion.jda.internal.entities.channel.concrete.VoiceChannelImpl;
+import net.dv8tion.jda.internal.utils.UnlockHook;
+import net.dv8tion.jda.internal.utils.cache.MemberCacheViewImpl;
+import net.dv8tion.jda.test.Constants;
+import net.dv8tion.jda.test.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class GuildLevelCacheTest extends IntegrationTest
+{
+    @Mock
+    UserImpl user;
+    @Mock
+    SelfUserImpl selfUser;
+    @Mock
+    MemberImpl selfMember;
+    @Mock
+    VoiceChannelImpl channel;
+
+    @BeforeEach
+    void setupMocks()
+    {
+        when(user.getJDA()).thenReturn(jda);
+        when(user.getIdLong()).thenReturn(Constants.MINN_USER_ID);
+
+        when(jda.getSelfUser()).thenReturn(selfUser);
+        when(selfUser.getJDA()).thenReturn(jda);
+        when(selfUser.getIdLong()).thenReturn(Constants.BUTLER_USER_ID);
+    }
+
+    private GuildImpl getGuild()
+    {
+        GuildImpl guild = new GuildImpl(jda, random.nextLong());
+        MemberCacheViewImpl membersView = guild.getMembersView();
+        try (UnlockHook hook = membersView.writeLock())
+        {
+            membersView.getMap().put(Constants.BUTLER_USER_ID, selfMember);
+        }
+
+        when(selfMember.getGuild()).thenReturn(guild);
+        return guild;
+    }
+
+    @Nested
+    class VoiceStateCacheDisabledTest
+    {
+        @BeforeEach
+        void setupCacheFlags()
+        {
+            withCacheFlags(EnumSet.noneOf(CacheFlag.class));
+        }
+
+
+        @Test
+        void shouldReturnNullForOtherMembers()
+        {
+            GuildImpl guild = getGuild();
+            MemberImpl member = new MemberImpl(guild, user);
+
+            assertThat(member.getVoiceState()).isNull();
+        }
+
+        @Test
+        void shouldReturnNonNullForSelfUser()
+        {
+            GuildImpl guild = getGuild();
+            MemberImpl member = new MemberImpl(guild, selfUser);
+
+            assertThat(member.getVoiceState()).isNotNull();
+        }
+
+        @Test
+        void shouldNotCacheVoiceStateForConnectedMembers()
+        {
+            GuildImpl guild = getGuild();
+            MemberImpl member = new MemberImpl(guild, user);
+
+            GuildVoiceStateImpl voiceState = new GuildVoiceStateImpl(member);
+            voiceState.setConnectedChannel(channel);
+
+            guild.handleVoiceStateUpdate(voiceState);
+            assertThat(guild.getVoiceStateView().get(user.getIdLong())).isNull();
+        }
+    }
+
+    @Nested
+    class VoiceStateCacheEnabledTest
+    {
+        @BeforeEach
+        void setupCacheFlags()
+        {
+            withCacheFlags(EnumSet.of(CacheFlag.VOICE_STATE));
+        }
+
+
+        @Test
+        void shouldReturnNonNullForOtherMembers()
+        {
+            GuildImpl guild = getGuild();
+            MemberImpl member = new MemberImpl(guild, user);
+
+            assertThat(member.getVoiceState()).isNotNull();
+        }
+
+        @Test
+        void shouldReturnNonNullForSelfUser()
+        {
+            GuildImpl guild = getGuild();
+            MemberImpl member = new MemberImpl(guild, selfUser);
+
+            assertThat(member.getVoiceState()).isNotNull();
+        }
+
+        @Test
+        void shouldCacheVoiceStateForConnectedMembers()
+        {
+            GuildImpl guild = getGuild();
+            MemberImpl member = new MemberImpl(guild, user);
+
+            GuildVoiceStateImpl voiceState = member.getVoiceState();
+            assertThat(voiceState).isNotNull();
+
+            voiceState.setConnectedChannel(channel);
+
+            guild.handleVoiceStateUpdate(voiceState);
+            assertThat(guild.getVoiceStateView().get(user.getIdLong())).isSameAs(voiceState);
+        }
+
+        @Test
+        void shouldUncacheVoiceStateForDisconnectedMembers()
+        {
+            GuildImpl guild = getGuild();
+            MemberImpl member = new MemberImpl(guild, user);
+
+            GuildVoiceStateImpl voiceState = member.getVoiceState();
+            assertThat(voiceState).isNotNull();
+
+            voiceState.setConnectedChannel(channel);
+
+            guild.handleVoiceStateUpdate(voiceState);
+            assertThat(guild.getVoiceStateView().get(user.getIdLong())).isSameAs(voiceState);
+
+            voiceState.setConnectedChannel(null);
+
+            guild.handleVoiceStateUpdate(voiceState);
+            assertThat(guild.getVoiceStateView().get(user.getIdLong())).isNull();
+        }
+    }
+}


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This changes how we handle voice state caching, moving it into the guild allows us to track voice states for uncached members.
