### PR TITLE
Fix checks in CommandEditAction

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/interactions/CommandDataImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/CommandDataImpl.java
@@ -33,6 +33,7 @@ import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -70,6 +71,13 @@ public class CommandDataImpl implements SlashCommandData
         Checks.notNull(type, "Command Type");
         Checks.check(type != Command.Type.SLASH, "Cannot create slash command without description. Use `new CommandDataImpl(name, description)` instead.");
         setName(name);
+    }
+
+    public static CommandDataImpl of(@Nonnull Command.Type type, @Nonnull String name, @Nullable String description)
+    {
+        if (type == Command.Type.SLASH)
+            return new CommandDataImpl(name, description);
+        return new CommandDataImpl(type, name);
     }
 
     protected void checkType(Command.Type required, String action)

--- a/src/main/java/net/dv8tion/jda/internal/interactions/CommandDataImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/CommandDataImpl.java
@@ -74,6 +74,8 @@ public class CommandDataImpl implements SlashCommandData
 
     protected void checkType(Command.Type required, String action)
     {
+        if (type == Command.Type.UNKNOWN)
+            return;
         if (required != type)
             throw new IllegalStateException("Cannot " + action + " for commands of type " + type);
     }

--- a/src/main/java/net/dv8tion/jda/internal/interactions/CommandDataImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/CommandDataImpl.java
@@ -433,6 +433,12 @@ public class CommandDataImpl implements SlashCommandData
         return modified;
     }
 
+    public void removeAllOptions()
+    {
+        this.options.clear();
+        this.updateAllowedOptions();
+    }
+
     // Update allowed conditions after removing options
     private void updateAllowedOptions()
     {

--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/CommandImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/CommandImpl.java
@@ -150,7 +150,8 @@ public class CommandImpl implements Command
     public CommandEditAction editCommand()
     {
         checkSelfUser("Cannot edit a command from another bot!");
-        return guild == null ? new CommandEditActionImpl(api, getId()) : new CommandEditActionImpl(guild, getId());
+        CommandEditActionImpl action = guild == null ? new CommandEditActionImpl(api, getId()) : new CommandEditActionImpl(guild, getId());
+        return action.withType(type);
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandEditActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandEditActionImpl.java
@@ -242,8 +242,7 @@ public class CommandEditActionImpl extends RestActionImpl<Command> implements Co
             json.remove("contexts");
         if (isUnchanged(INTEGRATION_TYPES_SET))
             json.remove("integration_types");
-        mask = 0;
-        data = new CommandDataImpl(Command.Type.UNKNOWN, UNDEFINED);
+        reset();
         return getRequestBody(json);
     }
 
@@ -252,5 +251,11 @@ public class CommandEditActionImpl extends RestActionImpl<Command> implements Co
     {
         DataObject json = response.getObject();
         request.onSuccess(new CommandImpl(api, guild, json));
+    }
+
+    private void reset()
+    {
+        mask = 0;
+        data = new CommandDataImpl(data.getType(), UNDEFINED);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandEditActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandEditActionImpl.java
@@ -55,19 +55,22 @@ public class CommandEditActionImpl extends RestActionImpl<Command> implements Co
     private static final int INTERACTION_CONTEXTS_SET = 1 << 6;
     private static final int INTEGRATION_TYPES_SET    = 1 << 7;
     private final Guild guild;
-    private int mask = 0;
-    private CommandDataImpl data = new CommandDataImpl(Command.Type.UNKNOWN, UNDEFINED);
+
+    private int mask;
+    private CommandDataImpl data;
 
     public CommandEditActionImpl(JDA api, String id)
     {
         super(api, Route.Interactions.EDIT_COMMAND.compile(api.getSelfUser().getApplicationId(), id));
         this.guild = null;
+        this.reset();
     }
 
     public CommandEditActionImpl(Guild guild, String id)
     {
         super(guild.getJDA(), Route.Interactions.EDIT_GUILD_COMMAND.compile(guild.getJDA().getSelfUser().getApplicationId(), guild.getId(), id));
         this.guild = guild;
+        this.reset();
     }
 
     @Nonnull
@@ -82,6 +85,14 @@ public class CommandEditActionImpl extends RestActionImpl<Command> implements Co
     public CommandEditAction deadline(long timestamp)
     {
         return (CommandEditAction) super.deadline(timestamp);
+    }
+
+    @Nonnull
+    public CommandEditActionImpl withType(Command.Type type)
+    {
+        this.mask = 0;
+        this.data = CommandDataImpl.of(type, UNDEFINED, UNDEFINED);
+        return this;
     }
 
     @Nonnull
@@ -256,6 +267,6 @@ public class CommandEditActionImpl extends RestActionImpl<Command> implements Co
     private void reset()
     {
         mask = 0;
-        data = new CommandDataImpl(data.getType(), UNDEFINED);
+        data = CommandDataImpl.of(data.getType(), UNDEFINED, UNDEFINED);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandEditActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandEditActionImpl.java
@@ -185,8 +185,8 @@ public class CommandEditActionImpl extends RestActionImpl<Command> implements Co
     @Override
     public CommandEditAction clearOptions()
     {
-        data = new CommandDataImpl(data.getName(), data.getDescription());
-        mask &= ~OPTIONS_SET;
+        data.removeAllOptions();
+        mask |= OPTIONS_SET;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandEditActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandEditActionImpl.java
@@ -56,7 +56,7 @@ public class CommandEditActionImpl extends RestActionImpl<Command> implements Co
     private static final int INTEGRATION_TYPES_SET    = 1 << 7;
     private final Guild guild;
     private int mask = 0;
-    private CommandDataImpl data = new CommandDataImpl(UNDEFINED, UNDEFINED);
+    private CommandDataImpl data = new CommandDataImpl(Command.Type.UNKNOWN, UNDEFINED);
 
     public CommandEditActionImpl(JDA api, String id)
     {
@@ -243,7 +243,7 @@ public class CommandEditActionImpl extends RestActionImpl<Command> implements Co
         if (isUnchanged(INTEGRATION_TYPES_SET))
             json.remove("integration_types");
         mask = 0;
-        data = new CommandDataImpl(UNDEFINED, UNDEFINED);
+        data = new CommandDataImpl(Command.Type.UNKNOWN, UNDEFINED);
         return getRequestBody(json);
     }
 


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2805

## Description

Fixes the checks in CommandEditAction to no longer assume type is slash.
