### PR TITLE
Fix editCommandById

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -17,6 +17,7 @@
 package net.dv8tion.jda.api;
 
 import net.dv8tion.jda.annotations.Incubating;
+import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.attribute.IGuildChannelContainer;
@@ -820,10 +821,17 @@ public interface JDA extends IGuildChannelContainer<Channel>
      *         If the provided id is not a valid snowflake
      *
      * @return {@link CommandEditAction} used to edit the command
+     *
+     * @deprecated Use {@link #editCommandById(Command.Type, String)} instead
      */
     @Nonnull
     @CheckReturnValue
-    CommandEditAction editCommandById(@Nonnull String id);
+    @Deprecated
+    @ReplaceWith("editCommandById(Command.Type, id)")
+    default CommandEditAction editCommandById(@Nonnull String id)
+    {
+        return editCommandById(Command.Type.SLASH, id);
+    }
 
     /**
      * Edit an existing global command by id.
@@ -835,12 +843,59 @@ public interface JDA extends IGuildChannelContainer<Channel>
      *         The id of the command to edit
      *
      * @return {@link CommandEditAction} used to edit the command
+     *
+     * @deprecated Use {@link #editCommandById(Command.Type, long)} instead
      */
     @Nonnull
     @CheckReturnValue
+    @Deprecated
+    @ReplaceWith("editCommandById(Command.Type, id)")
     default CommandEditAction editCommandById(long id)
     {
         return editCommandById(Long.toUnsignedString(id));
+    }
+
+    /**
+     * Edit an existing global command by id.
+     *
+     * <p>If there is no command with the provided ID,
+     * this RestAction fails with {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_COMMAND ErrorResponse.UNKNOWN_COMMAND}
+     *
+     * @param  type
+     *         The command type
+     * @param  id
+     *         The id of the command to edit
+     *
+     * @throws IllegalArgumentException
+     *         If the provided id is not a valid snowflake or the type is {@link Command.Type#UNKNOWN}
+     *
+     * @return {@link CommandEditAction} used to edit the command
+     */
+    @Nonnull
+    @CheckReturnValue
+    CommandEditAction editCommandById(@Nonnull Command.Type type, @Nonnull String id);
+
+    /**
+     * Edit an existing global command by id.
+     *
+     * <p>If there is no command with the provided ID,
+     * this RestAction fails with {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_COMMAND ErrorResponse.UNKNOWN_COMMAND}
+     *
+     * @param  type
+     *         The command type
+     * @param  id
+     *         The id of the command to edit
+     *
+     * @throws IllegalArgumentException
+     *         If the type is {@link Command.Type#UNKNOWN}
+     *
+     * @return {@link CommandEditAction} used to edit the command
+     */
+    @Nonnull
+    @CheckReturnValue
+    default CommandEditAction editCommandById(@Nonnull Command.Type type, long id)
+    {
+        return editCommandById(type, Long.toUnsignedString(id));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -288,10 +288,17 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      *         If this entity is {@link #isDetached() detached}
      *
      * @return {@link CommandEditAction} used to edit the command
+     *
+     * @deprecated Use {@link #editCommandById(Command.Type, String)} instead
      */
     @Nonnull
+    @Deprecated
+    @ReplaceWith("editCommandById(Command.Type, id)")
     @CheckReturnValue
-    CommandEditAction editCommandById(@Nonnull String id);
+    default CommandEditAction editCommandById(@Nonnull String id)
+    {
+        return editCommandById(Command.Type.SLASH, id);
+    }
 
     /**
      * Edit an existing command by id.
@@ -306,12 +313,63 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      *         If this entity is {@link #isDetached() detached}
      *
      * @return {@link CommandEditAction} used to edit the command
+     *
+     * @deprecated Use {@link #editCommandById(Command.Type, long)} instead
      */
     @Nonnull
+    @Deprecated
+    @ReplaceWith("editCommandById(Command.Type, id)")
     @CheckReturnValue
     default CommandEditAction editCommandById(long id)
     {
         return editCommandById(Long.toUnsignedString(id));
+    }
+
+    /**
+     * Edit an existing command by id.
+     *
+     * <p>If there is no command with the provided ID,
+     * this RestAction fails with {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_COMMAND ErrorResponse.UNKNOWN_COMMAND}
+     *
+     * @param  type
+     *         The command type
+     * @param  id
+     *         The id of the command to edit
+     *
+     * @throws IllegalArgumentException
+     *         If the provided id is not a valid snowflake or the type is {@link Command.Type#UNKNOWN}
+     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
+     *         If this entity is {@link #isDetached() detached}
+     *
+     * @return {@link CommandEditAction} used to edit the command
+     */
+    @Nonnull
+    @CheckReturnValue
+    CommandEditAction editCommandById(@Nonnull Command.Type type, @Nonnull String id);
+
+    /**
+     * Edit an existing command by id.
+     *
+     * <p>If there is no command with the provided ID,
+     * this RestAction fails with {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_COMMAND ErrorResponse.UNKNOWN_COMMAND}
+     *
+     * @param  type
+     *         The command type
+     * @param  id
+     *         The id of the command to edit
+     *
+     * @throws IllegalArgumentException
+     *         If the type is {@link Command.Type#UNKNOWN}
+     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
+     *         If this entity is {@link #isDetached() detached}
+     *
+     * @return {@link CommandEditAction} used to edit the command
+     */
+    @Nonnull
+    @CheckReturnValue
+    default CommandEditAction editCommandById(@Nonnull Command.Type type, long id)
+    {
+        return editCommandById(type, Long.toUnsignedString(id));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -1129,10 +1129,12 @@ public class JDAImpl implements JDA
 
     @Nonnull
     @Override
-    public CommandEditAction editCommandById(@Nonnull String id)
+    public CommandEditAction editCommandById(@Nonnull Command.Type type, @Nonnull String id)
     {
         Checks.isSnowflake(id);
-        return new CommandEditActionImpl(this, id);
+        Checks.notNull(type, "CommandType");
+        Checks.check(type != Command.Type.UNKNOWN, "Type must not be UNKNOWN");
+        return new CommandEditActionImpl(this, type, id);
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -274,10 +274,12 @@ public class GuildImpl implements Guild
 
     @Nonnull
     @Override
-    public CommandEditAction editCommandById(@Nonnull String id)
+    public CommandEditAction editCommandById(@Nonnull Command.Type type, @Nonnull String id)
     {
         Checks.isSnowflake(id);
-        return new CommandEditActionImpl(this, id);
+        Checks.notNull(type, "CommandType");
+        Checks.check(type != Command.Type.UNKNOWN, "Type must not be UNKNOWN");
+        return new CommandEditActionImpl(this, type, id);
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/detached/DetachedGuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/detached/DetachedGuildImpl.java
@@ -116,7 +116,7 @@ public class DetachedGuildImpl implements Guild, IDetachableEntityMixin
 
     @Nonnull
     @Override
-    public CommandEditAction editCommandById(@Nonnull String id)
+    public CommandEditAction editCommandById(@Nonnull Command.Type type, @Nonnull String id)
     {
         throw detachedException();
     }

--- a/src/main/java/net/dv8tion/jda/internal/interactions/CommandDataImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/CommandDataImpl.java
@@ -82,8 +82,6 @@ public class CommandDataImpl implements SlashCommandData
 
     protected void checkType(Command.Type required, String action)
     {
-        if (type == Command.Type.UNKNOWN)
-            return;
         if (required != type)
             throw new IllegalStateException("Cannot " + action + " for commands of type " + type);
     }

--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/CommandImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/CommandImpl.java
@@ -150,8 +150,7 @@ public class CommandImpl implements Command
     public CommandEditAction editCommand()
     {
         checkSelfUser("Cannot edit a command from another bot!");
-        CommandEditActionImpl action = guild == null ? new CommandEditActionImpl(api, getId()) : new CommandEditActionImpl(guild, getId());
-        return action.withType(type);
+        return guild == null ? new CommandEditActionImpl(api, type, getId()) : new CommandEditActionImpl(guild, type, getId());
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandEditActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandEditActionImpl.java
@@ -57,19 +57,21 @@ public class CommandEditActionImpl extends RestActionImpl<Command> implements Co
     private final Guild guild;
 
     private int mask;
-    private CommandDataImpl data = new CommandDataImpl(Command.Type.UNKNOWN, UNDEFINED);
+    private CommandDataImpl data;
 
-    public CommandEditActionImpl(JDA api, String id)
+    public CommandEditActionImpl(JDA api, Command.Type type, String id)
     {
         super(api, Route.Interactions.EDIT_COMMAND.compile(api.getSelfUser().getApplicationId(), id));
         this.guild = null;
+        this.data = CommandDataImpl.of(type, UNDEFINED, UNDEFINED);
         this.reset();
     }
 
-    public CommandEditActionImpl(Guild guild, String id)
+    public CommandEditActionImpl(Guild guild, Command.Type type, String id)
     {
         super(guild.getJDA(), Route.Interactions.EDIT_GUILD_COMMAND.compile(guild.getJDA().getSelfUser().getApplicationId(), guild.getId(), id));
         this.guild = guild;
+        this.data = CommandDataImpl.of(type, UNDEFINED, UNDEFINED);
         this.reset();
     }
 
@@ -85,14 +87,6 @@ public class CommandEditActionImpl extends RestActionImpl<Command> implements Co
     public CommandEditAction deadline(long timestamp)
     {
         return (CommandEditAction) super.deadline(timestamp);
-    }
-
-    @Nonnull
-    public CommandEditActionImpl withType(Command.Type type)
-    {
-        this.mask = 0;
-        this.data = CommandDataImpl.of(type, UNDEFINED, UNDEFINED);
-        return this;
     }
 
     @Nonnull
@@ -237,8 +231,6 @@ public class CommandEditActionImpl extends RestActionImpl<Command> implements Co
     protected RequestBody finalizeData()
     {
         DataObject json = data.toData();
-        json.remove("type");
-
         if (isUnchanged(NAME_SET))
             json.remove("name");
         if (isUnchanged(DESCRIPTION_SET))

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandEditActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandEditActionImpl.java
@@ -57,7 +57,7 @@ public class CommandEditActionImpl extends RestActionImpl<Command> implements Co
     private final Guild guild;
 
     private int mask;
-    private CommandDataImpl data;
+    private CommandDataImpl data = new CommandDataImpl(Command.Type.UNKNOWN, UNDEFINED);
 
     public CommandEditActionImpl(JDA api, String id)
     {
@@ -237,6 +237,8 @@ public class CommandEditActionImpl extends RestActionImpl<Command> implements Co
     protected RequestBody finalizeData()
     {
         DataObject json = data.toData();
+        json.remove("type");
+
         if (isUnchanged(NAME_SET))
             json.remove("name");
         if (isUnchanged(DESCRIPTION_SET))

--- a/src/test/java/net/dv8tion/jda/test/restaction/CommandEditActionTest.java
+++ b/src/test/java/net/dv8tion/jda/test/restaction/CommandEditActionTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.test.restaction;
+
+import net.dv8tion.jda.api.entities.SelfUser;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.requests.Method;
+import net.dv8tion.jda.internal.requests.restaction.CommandEditActionImpl;
+import net.dv8tion.jda.test.Constants;
+import net.dv8tion.jda.test.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+public class CommandEditActionTest extends IntegrationTest
+{
+    @Mock
+    private SelfUser selfUser;
+
+    @BeforeEach
+    void setupMocks()
+    {
+        when(jda.getSelfUser()).thenReturn(selfUser);
+        when(selfUser.getApplicationId()).thenReturn(Long.toUnsignedString(Constants.BUTLER_USER_ID));
+    }
+
+    @Test
+    void testEditSlashCommandById()
+    {
+        String id = randomSnowflake();
+        CommandEditActionImpl action = new CommandEditActionImpl(jda, Command.Type.SLASH, id);
+
+        assertThatNoException().isThrownBy(() -> {
+            action.setName("updated-name");
+            action.setDescription("Updated description");
+            action.setNSFW(true);
+        });
+
+        assertThatIllegalArgumentException().isThrownBy(() -> action.setName("updated name with space"));
+
+        assertThatRequestFrom(action)
+            .hasMethod(Method.PATCH)
+            .hasCompiledRoute("applications/" + Constants.BUTLER_USER_ID + "/commands/" + id)
+            .hasBodyEqualTo(getSampleObject())
+            .whenQueueCalled();
+    }
+
+    @Test
+    void testEditMessageCommandById()
+    {
+        String id = randomSnowflake();
+        CommandEditActionImpl action = new CommandEditActionImpl(jda, Command.Type.MESSAGE, id);
+
+        assertThatNoException().isThrownBy(() -> action.setName("updated name with space"));
+        assertThatIllegalStateException().isThrownBy(() -> action.setDescription("Updated description"));
+
+        action.setNSFW(true);
+
+        assertThatRequestFrom(action)
+            .hasMethod(Method.PATCH)
+            .hasCompiledRoute("applications/" + Constants.BUTLER_USER_ID + "/commands/" + id)
+            .hasBodyEqualTo(getSampleObject())
+            .whenQueueCalled();
+    }
+
+    @Test
+    void testEditUserCommandById()
+    {
+        String id = randomSnowflake();
+        CommandEditActionImpl action = new CommandEditActionImpl(jda, Command.Type.USER, id);
+
+        assertThatNoException().isThrownBy(() -> action.setName("updated name with space"));
+        assertThatIllegalStateException().isThrownBy(() -> action.setDescription("Updated description"));
+
+        action.setNSFW(true);
+
+        assertThatRequestFrom(action)
+            .hasMethod(Method.PATCH)
+            .hasCompiledRoute("applications/" + Constants.BUTLER_USER_ID + "/commands/" + id)
+            .hasBodyEqualTo(getSampleObject())
+            .whenQueueCalled();
+    }
+}

--- a/src/test/resources/net/dv8tion/jda/test/restaction/CommandEditActionTest_testEditMessageCommandById.json
+++ b/src/test/resources/net/dv8tion/jda/test/restaction/CommandEditActionTest_testEditMessageCommandById.json
@@ -1,0 +1,6 @@
+{
+    "name" : "updated name with space",
+    "name_localizations" : { },
+    "nsfw" : true,
+    "type" : 3
+}

--- a/src/test/resources/net/dv8tion/jda/test/restaction/CommandEditActionTest_testEditSlashCommandById.json
+++ b/src/test/resources/net/dv8tion/jda/test/restaction/CommandEditActionTest_testEditSlashCommandById.json
@@ -1,0 +1,8 @@
+{
+    "description" : "Updated description",
+    "description_localizations" : { },
+    "name" : "updated-name",
+    "name_localizations" : { },
+    "nsfw" : true,
+    "type" : 1
+}

--- a/src/test/resources/net/dv8tion/jda/test/restaction/CommandEditActionTest_testEditUserCommandById.json
+++ b/src/test/resources/net/dv8tion/jda/test/restaction/CommandEditActionTest_testEditUserCommandById.json
@@ -1,0 +1,6 @@
+{
+    "name" : "updated name with space",
+    "name_localizations" : { },
+    "nsfw" : true,
+    "type" : 2
+}


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2838

## Description

We now always require knowing the type of the command we edit. Otherwise our checks and serialization can't work properly. By default, the now deprecated `editCommandById` will assume `Command.Type.SLASH` to avoid breaking existing code.
