### PR TITLE
Add Member#getUnsortedRoles

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -3275,7 +3275,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
         if (rolesWithoutPublicRole.isEmpty())
             return loadMembers();
 
-        return findMembers(member -> member.getRoles().containsAll(rolesWithoutPublicRole));
+        return findMembers(member -> member.getUnsortedRoles().containsAll(rolesWithoutPublicRole));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Member.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Member.java
@@ -43,6 +43,7 @@ import java.time.temporal.TemporalAccessor;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -339,7 +340,7 @@ public interface Member extends IMentionable, IPermissionHolder, IDetachableEnti
     /**
      * The roles applied to this Member.
      * <br>The roles are ordered based on their position. The highest role being at index 0
-     * and the lowest at the last index.
+     * and the lowest at the last index. Prefer {@link #getUnsortedRoles()} if the order is not relevant.
      *
      * <p>A Member's roles can be changed using the {@link Guild#addRoleToMember(UserSnowflake, Role)}, {@link Guild#removeRoleFromMember(UserSnowflake, Role)}, and {@link Guild#modifyMemberRoles(Member, Collection, Collection)}
      * methods in {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -359,6 +360,31 @@ public interface Member extends IMentionable, IPermissionHolder, IDetachableEnti
     @Nonnull
     @Unmodifiable
     List<Role> getRoles();
+
+    /**
+     * The roles applied to this Member.
+     * <br>This is an unmodifiable reference to the role set of this member.
+     * This set has no defined order, use {@link #getRoles()} to get an ordered list.
+     *
+     * <p>A Member's roles can be changed using the {@link Guild#addRoleToMember(UserSnowflake, Role)}, {@link Guild#removeRoleFromMember(UserSnowflake, Role)}, and {@link Guild#modifyMemberRoles(Member, Collection, Collection)}
+     * methods in {@link net.dv8tion.jda.api.entities.Guild Guild}.
+     *
+     * <p><b>The Public Role ({@code @everyone}) is not included in the returned immutable set of roles
+     * <br>It is implicit that every member holds the Public Role in a Guild thus it is not listed here!</b>
+     *
+     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
+     *         If this entity is {@link #isDetached() detached}
+     *
+     * @return An unmodifiable reference to the Set of {@link net.dv8tion.jda.api.entities.Role Roles} for this Member.
+     *
+     * @see    #getRoles()
+     * @see    Guild#addRoleToMember(UserSnowflake, Role)
+     * @see    Guild#removeRoleFromMember(UserSnowflake, Role)
+     * @see    Guild#modifyMemberRoles(Member, Collection, Collection)
+     */
+    @Nonnull
+    @Unmodifiable
+    Set<Role> getUnsortedRoles();
 
     /**
      * The {@link java.awt.Color Color} of this Member's name in a Guild.

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -206,8 +206,14 @@ public class MemberImpl implements Member, MemberMixin<MemberImpl>
     {
         List<Role> roleList = new ArrayList<>(roles);
         roleList.sort(Comparator.reverseOrder());
-
         return Collections.unmodifiableList(roleList);
+    }
+
+    @Nonnull
+    @Override
+    public Set<Role> getUnsortedRoles()
+    {
+        return Collections.unmodifiableSet(roles);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/SelectMenuMentions.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/SelectMenuMentions.java
@@ -299,7 +299,7 @@ public class SelectMenuMentions implements Mentions
             case ROLE:
                 if (mentionable instanceof Member)
                 {
-                    boolean mentioned = ((Member) mentionable).getRoles().stream().anyMatch(role -> isMentioned(role, Message.MentionType.ROLE));
+                    boolean mentioned = ((Member) mentionable).getUnsortedRoles().stream().anyMatch(role -> isMentioned(role, Message.MentionType.ROLE));
                     if (mentioned)
                         return true;
                 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/detached/DetachedMemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/detached/DetachedMemberImpl.java
@@ -38,10 +38,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.awt.*;
 import java.time.OffsetDateTime;
-import java.util.Collection;
-import java.util.EnumSet;
 import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 public class DetachedMemberImpl implements Member, MemberMixin<DetachedMemberImpl>
 {
@@ -189,6 +187,13 @@ public class DetachedMemberImpl implements Member, MemberMixin<DetachedMemberImp
     @Nonnull
     @Override
     public List<Role> getRoles()
+    {
+        throw detachedException();
+    }
+
+    @Nonnull
+    @Override
+    public Set<Role> getUnsortedRoles()
     {
         throw detachedException();
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/mentions/AbstractMentions.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/mentions/AbstractMentions.java
@@ -370,7 +370,7 @@ public abstract class AbstractMentions implements Mentions
             member = (Member) mentionable;
         else if (guild != null && mentionable instanceof User)
             member = guild.getMember((User) mentionable);
-        return member != null && CollectionUtils.containsAny(getRoles(), member.getRoles());
+        return member != null && CollectionUtils.containsAny(getRoles(), member.getUnsortedRoles());
     }
 
     protected boolean isSlashCommandMentioned(IMentionable mentionable)

--- a/src/main/java/net/dv8tion/jda/internal/utils/PermissionUtil.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/PermissionUtil.java
@@ -321,7 +321,7 @@ public class PermissionUtil
             return ALL_PERMISSIONS;
         //Default to binary OR of all global permissions in this guild
         long permission = member.getGuild().getPublicRole().getPermissionsRaw();
-        for (Role role : member.getRoles())
+        for (Role role : member.getUnsortedRoles())
         {
             permission |= role.getPermissionsRaw();
             if (isApplied(permission, Permission.ADMINISTRATOR.getRawValue()))
@@ -469,7 +469,7 @@ public class PermissionUtil
         final Guild guild = member.getGuild();
         long permission = guild.getPublicRole().getPermissionsRaw();
 
-        for (Role role : member.getRoles())
+        for (Role role : member.getUnsortedRoles())
             permission |= role.getPermissionsRaw();
 
         return permission;
@@ -654,7 +654,7 @@ public class PermissionUtil
         long allowRole = 0;
         long denyRole = 0;
         // create temporary bit containers for role cascade
-        for (Role role : member.getRoles())
+        for (Role role : member.getUnsortedRoles())
         {
             override = permsChannel.getPermissionOverride(role);
             if (override != null)

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/MemberCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/MemberCacheViewImpl.java
@@ -102,7 +102,7 @@ public class MemberCacheViewImpl extends SnowflakeCacheViewImpl<Member> implemen
         List<Member> members = new ArrayList<>();
         forEach(member ->
         {
-            if (member.getRoles().containsAll(rolesWithoutPublicRole))
+            if (member.getUnsortedRoles().containsAll(rolesWithoutPublicRole))
                 members.add(member);
         });
         return members;

--- a/src/test/java/net/dv8tion/jda/test/util/PermissionUtilTest.java
+++ b/src/test/java/net/dv8tion/jda/test/util/PermissionUtilTest.java
@@ -82,6 +82,7 @@ public class PermissionUtilTest extends IntegrationTest
         when(member.getGuild()).thenReturn(guild);
         when(guild.getPublicRole()).thenReturn(publicRole);
         when(member.getRoles()).thenReturn(Collections.singletonList(role));
+        when(member.getUnsortedRoles()).thenReturn(Collections.singleton(role));
 
         mockChannel(textChannel, ChannelType.TEXT);
         mockChannel(voiceChannel, ChannelType.VOICE);


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2840

## Description

Add `Member#getUnsortedRoles` to avoid the overhead of sorting the role list, when the order is not relevant. This is now used by `getMembersWithRoles` and permission checks.
