### PR TITLE
Add `AbstractThreadCreateAction#setSlowmode`

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/AbstractThreadCreateAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/AbstractThreadCreateAction.java
@@ -103,6 +103,9 @@ public interface AbstractThreadCreateAction<T, R extends AbstractThreadCreateAct
      * @throws IllegalArgumentException
      *         If the provided slowmode is negative or greater than {@value ISlowmodeChannel#MAX_SLOWMODE}
      *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the bot does not have {@link Permission#MANAGE_THREADS} in the parent channel
+     *
      * @return The current action, for chaining convenience
      *
      * @see net.dv8tion.jda.api.entities.channel.attribute.ISlowmodeChannel#getSlowmode()

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/AbstractThreadCreateAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/AbstractThreadCreateAction.java
@@ -16,9 +16,11 @@
 
 package net.dv8tion.jda.api.requests.restaction;
 
+import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.entities.channel.attribute.ISlowmodeChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.requests.RestAction;
@@ -84,4 +86,32 @@ public interface AbstractThreadCreateAction<T, R extends AbstractThreadCreateAct
     @Nonnull
     @CheckReturnValue
     R setAutoArchiveDuration(@Nonnull ThreadChannel.AutoArchiveDuration autoArchiveDuration);
+
+    /**
+     * Sets the <b><u>slowmode</u></b> for the new thread.
+     *
+     * <p>A channel slowmode <b>must not</b> be negative nor greater than {@link ISlowmodeChannel#MAX_SLOWMODE}!
+     *
+     * <p>Note: Bots are unaffected by this.
+     * <br>Having {@link Permission#MESSAGE_MANAGE MESSAGE_MANAGE} or
+     * {@link Permission#MANAGE_CHANNEL MANAGE_CHANNEL} permission also
+     * grants immunity to slowmode.
+     *
+     * <p><b>Special case</b><br>
+     * {@link net.dv8tion.jda.api.entities.channel.concrete.ForumChannel ForumChannels} use this to limit how many posts a user can create.
+     * The client refers to this as the post slowmode.
+     *
+     * @param  slowmode
+     *         The new slowmode
+     *
+     * @throws IllegalArgumentException
+     *         If the provided slowmode is negative or greater than {@value ISlowmodeChannel#MAX_SLOWMODE}
+     *
+     * @return The current action, for chaining convenience
+     *
+     * @see net.dv8tion.jda.api.entities.channel.attribute.ISlowmodeChannel#getSlowmode()
+     */
+    @Nonnull
+    @CheckReturnValue
+    R setSlowmode(int slowmode);
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/AbstractThreadCreateAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/AbstractThreadCreateAction.java
@@ -97,10 +97,6 @@ public interface AbstractThreadCreateAction<T, R extends AbstractThreadCreateAct
      * {@link Permission#MANAGE_CHANNEL MANAGE_CHANNEL} permission also
      * grants immunity to slowmode.
      *
-     * <p><b>Special case</b><br>
-     * {@link net.dv8tion.jda.api.entities.channel.concrete.ForumChannel ForumChannels} use this to limit how many posts a user can create.
-     * The client refers to this as the post slowmode.
-     *
      * @param  slowmode
      *         The new slowmode
      *

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/ForumPostActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/ForumPostActionImpl.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.internal.requests.restaction;
 
 import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
+import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.Channel;
@@ -28,6 +29,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.forums.ForumPost;
 import net.dv8tion.jda.api.entities.channel.forums.ForumTagSnowflake;
+import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.requests.Request;
 import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.api.requests.Route;
@@ -142,6 +144,8 @@ public class ForumPostActionImpl extends RestActionImpl<ForumPost> implements Fo
     {
         Checks.checkSupportedChannelTypes(ChannelUtil.SLOWMODE_SUPPORTED, getType(), "slowmode");
         Checks.check(slowmode <= ISlowmodeChannel.MAX_SLOWMODE && slowmode >= 0, "Slowmode per user must be between 0 and %d (seconds)!", ISlowmodeChannel.MAX_SLOWMODE);
+        if (!getGuild().getSelfMember().hasPermission(channel, Permission.MANAGE_THREADS))
+            throw new InsufficientPermissionException(channel, Permission.MANAGE_THREADS, "You must have Permission.MANAGE_THREADS on the parent forum channel to set a slowmode!");
         this.slowmode = slowmode;
         return this;
     }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/ThreadChannelActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/ThreadChannelActionImpl.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.internal.requests.restaction;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.entities.channel.attribute.ISlowmodeChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.requests.Request;
@@ -26,6 +27,7 @@ import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.api.requests.Route;
 import net.dv8tion.jda.api.requests.restaction.ThreadChannelAction;
 import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.utils.ChannelUtil;
 import net.dv8tion.jda.internal.utils.Checks;
 import okhttp3.RequestBody;
 
@@ -42,6 +44,7 @@ public class ThreadChannelActionImpl extends AuditableRestActionImpl<ThreadChann
 
     protected String name;
     protected ThreadChannel.AutoArchiveDuration autoArchiveDuration = null;
+    protected Integer slowmode = null;
     protected Boolean invitable = null;
 
     public ThreadChannelActionImpl(GuildChannel channel, String name, ChannelType type)
@@ -128,6 +131,16 @@ public class ThreadChannelActionImpl extends AuditableRestActionImpl<ThreadChann
 
     @Nonnull
     @Override
+    public ThreadChannelAction setSlowmode(int slowmode)
+    {
+        Checks.checkSupportedChannelTypes(ChannelUtil.SLOWMODE_SUPPORTED, type, "slowmode");
+        Checks.check(slowmode <= ISlowmodeChannel.MAX_SLOWMODE && slowmode >= 0, "Slowmode per user must be between 0 and %d (seconds)!", ISlowmodeChannel.MAX_SLOWMODE);
+        this.slowmode = slowmode;
+        return this;
+    }
+
+    @Nonnull
+    @Override
     public ThreadChannelAction setInvitable(boolean invitable)
     {
         if (type != ChannelType.GUILD_PRIVATE_THREAD)
@@ -150,6 +163,8 @@ public class ThreadChannelActionImpl extends AuditableRestActionImpl<ThreadChann
 
         if (autoArchiveDuration != null)
             object.put("auto_archive_duration", autoArchiveDuration.getMinutes());
+        if(slowmode != null)
+            object.put("rate_limit_per_user", slowmode);
         if (invitable != null)
             object.put("invitable", invitable);
 


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code (Only additions)
- [x] Library interface (affecting end-user code)  (Only additions)
- [x] Documentation (Only additions)
- [ ] Other: \_____

## Description

This adds the ability to set the slowmode when creating a thread channel or forum post. Just like [`ChannelAction.setSlowmode`](https://github.com/discord-jda/JDA/blob/b1f2e2873db1a95ae6da34c9d6479accadcd3fa1/src/main/java/net/dv8tion/jda/internal/requests/restaction/ChannelActionImpl.java#L215), the slowmode can be set when creating forum or thread channels. This utilizes the `rate_limit_per_user` value in the [Start Thread](https://discord.com/developers/docs/resources/channel#start-thread-without-message) endpoints.