### PR TITLE
Add  `with_components=true` query param to WebhookClient requests

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/WebhookClient.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/WebhookClient.java
@@ -1178,13 +1178,7 @@ public interface WebhookClient<T> extends ISnowflake
     @Nonnull
     static IncomingWebhookClient createClient(@Nonnull JDA api, @Nonnull String url)
     {
-        Checks.notNull(url, "URL");
-        Matcher matcher = Webhook.WEBHOOK_URL.matcher(url);
-        if (!matcher.matches())
-            throw new IllegalArgumentException("Provided invalid webhook URL");
-        String id = matcher.group(1);
-        String token = matcher.group(2);
-        return createClient(api, id, token);
+        return createClient(api, url, false);
     }
 
     /**
@@ -1210,8 +1204,68 @@ public interface WebhookClient<T> extends ISnowflake
     @Nonnull
     static IncomingWebhookClient createClient(@Nonnull JDA api, @Nonnull String webhookId, @Nonnull String webhookToken)
     {
+        return createClient(api, webhookId, webhookToken, false);
+    }
+
+    /**
+     * Creates an instance of {@link IncomingWebhookClient} capable of executing webhook requests.
+     * <p>Messages created by this client may not have a fully accessible channel or guild available.
+     * The messages might report a channel of type {@link net.dv8tion.jda.api.entities.channel.ChannelType#UNKNOWN UNKNOWN},
+     * in which case the channel is assumed to be inaccessible and limited to only webhook requests.
+     *
+     * @param  api
+     *         The JDA instance, used to handle rate-limits
+     * @param  url
+     *         The webhook url, must include a webhook token
+     * @param  withComponents
+     *         Whether to allow sending webhook messages containing components
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided or the provided url is not a valid webhook url
+     *
+     * @return The {@link IncomingWebhookClient} instance
+     *
+     * @see    InteractionHook#from(JDA, String)
+     */
+    @Nonnull
+    static IncomingWebhookClient createClient(@Nonnull JDA api, @Nonnull String url, boolean withComponents)
+    {
+        Checks.notNull(url, "URL");
+        Matcher matcher = Webhook.WEBHOOK_URL.matcher(url);
+        if (!matcher.matches())
+            throw new IllegalArgumentException("Provided invalid webhook URL");
+        String id = matcher.group(1);
+        String token = matcher.group(2);
+        return createClient(api, id, token, withComponents);
+    }
+
+    /**
+     * Creates an instance of {@link IncomingWebhookClient} capable of executing webhook requests.
+     * <p>Messages created by this client may not have a fully accessible channel or guild available.
+     * The messages might report a channel of type {@link net.dv8tion.jda.api.entities.channel.ChannelType#UNKNOWN UNKNOWN},
+     * in which case the channel is assumed to be inaccessible and limited to only webhook requests.
+     *
+     * @param  api
+     *         The JDA instance, used to handle rate-limits
+     * @param  webhookId
+     *         The id of the webhook, for interactions this is the application id
+     * @param  webhookToken
+     *         The token of the webhook, for interactions this is the interaction token
+     * @param  withComponents
+     *         Whether to allow sending webhook messages containing components
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided or the provided webhook id is not a valid snowflake or the token is blank
+     *
+     * @return The {@link IncomingWebhookClient} instance
+     *
+     * @see    InteractionHook#from(JDA, String)
+     */
+    @Nonnull
+    static IncomingWebhookClient createClient(@Nonnull JDA api, @Nonnull String webhookId, @Nonnull String webhookToken, boolean withComponents)
+    {
         Checks.notNull(api, "JDA");
         Checks.notBlank(webhookToken, "Token");
-        return new IncomingWebhookClientImpl(MiscUtil.parseSnowflake(webhookId), webhookToken, api);
+        return new IncomingWebhookClientImpl(MiscUtil.parseSnowflake(webhookId), webhookToken, api, withComponents);
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/WebhookClient.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/WebhookClient.java
@@ -1178,7 +1178,13 @@ public interface WebhookClient<T> extends ISnowflake
     @Nonnull
     static IncomingWebhookClient createClient(@Nonnull JDA api, @Nonnull String url)
     {
-        return createClient(api, url, false);
+        Checks.notNull(url, "URL");
+        Matcher matcher = Webhook.WEBHOOK_URL.matcher(url);
+        if (!matcher.matches())
+            throw new IllegalArgumentException("Provided invalid webhook URL");
+        String id = matcher.group(1);
+        String token = matcher.group(2);
+        return createClient(api, id, token);
     }
 
     /**
@@ -1204,68 +1210,8 @@ public interface WebhookClient<T> extends ISnowflake
     @Nonnull
     static IncomingWebhookClient createClient(@Nonnull JDA api, @Nonnull String webhookId, @Nonnull String webhookToken)
     {
-        return createClient(api, webhookId, webhookToken, false);
-    }
-
-    /**
-     * Creates an instance of {@link IncomingWebhookClient} capable of executing webhook requests.
-     * <p>Messages created by this client may not have a fully accessible channel or guild available.
-     * The messages might report a channel of type {@link net.dv8tion.jda.api.entities.channel.ChannelType#UNKNOWN UNKNOWN},
-     * in which case the channel is assumed to be inaccessible and limited to only webhook requests.
-     *
-     * @param  api
-     *         The JDA instance, used to handle rate-limits
-     * @param  url
-     *         The webhook url, must include a webhook token
-     * @param  withComponents
-     *         Whether to allow sending webhook messages containing components
-     *
-     * @throws IllegalArgumentException
-     *         If null is provided or the provided url is not a valid webhook url
-     *
-     * @return The {@link IncomingWebhookClient} instance
-     *
-     * @see    InteractionHook#from(JDA, String)
-     */
-    @Nonnull
-    static IncomingWebhookClient createClient(@Nonnull JDA api, @Nonnull String url, boolean withComponents)
-    {
-        Checks.notNull(url, "URL");
-        Matcher matcher = Webhook.WEBHOOK_URL.matcher(url);
-        if (!matcher.matches())
-            throw new IllegalArgumentException("Provided invalid webhook URL");
-        String id = matcher.group(1);
-        String token = matcher.group(2);
-        return createClient(api, id, token, withComponents);
-    }
-
-    /**
-     * Creates an instance of {@link IncomingWebhookClient} capable of executing webhook requests.
-     * <p>Messages created by this client may not have a fully accessible channel or guild available.
-     * The messages might report a channel of type {@link net.dv8tion.jda.api.entities.channel.ChannelType#UNKNOWN UNKNOWN},
-     * in which case the channel is assumed to be inaccessible and limited to only webhook requests.
-     *
-     * @param  api
-     *         The JDA instance, used to handle rate-limits
-     * @param  webhookId
-     *         The id of the webhook, for interactions this is the application id
-     * @param  webhookToken
-     *         The token of the webhook, for interactions this is the interaction token
-     * @param  withComponents
-     *         Whether to allow sending webhook messages containing components
-     *
-     * @throws IllegalArgumentException
-     *         If null is provided or the provided webhook id is not a valid snowflake or the token is blank
-     *
-     * @return The {@link IncomingWebhookClient} instance
-     *
-     * @see    InteractionHook#from(JDA, String)
-     */
-    @Nonnull
-    static IncomingWebhookClient createClient(@Nonnull JDA api, @Nonnull String webhookId, @Nonnull String webhookToken, boolean withComponents)
-    {
         Checks.notNull(api, "JDA");
         Checks.notBlank(webhookToken, "Token");
-        return new IncomingWebhookClientImpl(MiscUtil.parseSnowflake(webhookId), webhookToken, api, withComponents);
+        return new IncomingWebhookClientImpl(MiscUtil.parseSnowflake(webhookId), webhookToken, api);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/IncomingWebhookClientImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/IncomingWebhookClientImpl.java
@@ -39,9 +39,12 @@ import java.util.function.Function;
 
 public class IncomingWebhookClientImpl extends AbstractWebhookClient<Message> implements IncomingWebhookClient
 {
-    public IncomingWebhookClientImpl(long webhookId, String webhookToken, JDA api)
+    private final boolean withComponents;
+
+    public IncomingWebhookClientImpl(long webhookId, String webhookToken, JDA api, boolean withComponents)
     {
         super(webhookId, webhookToken, api);
+        this.withComponents = withComponents;
     }
 
     @Override
@@ -49,6 +52,8 @@ public class IncomingWebhookClientImpl extends AbstractWebhookClient<Message> im
     {
         Route.CompiledRoute route = Route.Webhooks.EXECUTE_WEBHOOK.compile(Long.toUnsignedString(id), token);
         route = route.withQueryParams("wait", "true");
+        if (withComponents)
+            route = route.withQueryParams("with_components", "true");
         WebhookMessageCreateActionImpl<Message> action = new WebhookMessageCreateActionImpl<>(api, route, builder());
         action.run();
         action.setInteraction(false);
@@ -62,6 +67,8 @@ public class IncomingWebhookClientImpl extends AbstractWebhookClient<Message> im
             Checks.isSnowflake(messageId);
         Route.CompiledRoute route = Route.Webhooks.EXECUTE_WEBHOOK_EDIT.compile(Long.toUnsignedString(id), token, messageId);
         route = route.withQueryParams("wait", "true");
+        if (withComponents)
+            route = route.withQueryParams("with_components", "true");
         WebhookMessageEditActionImpl<Message> action = new WebhookMessageEditActionImpl<>(api, route, builder());
         action.run();
         return action;
@@ -100,5 +107,4 @@ public class IncomingWebhookClientImpl extends AbstractWebhookClient<Message> im
             return message;
         };
     }
-
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/IncomingWebhookClientImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/IncomingWebhookClientImpl.java
@@ -39,12 +39,9 @@ import java.util.function.Function;
 
 public class IncomingWebhookClientImpl extends AbstractWebhookClient<Message> implements IncomingWebhookClient
 {
-    private final boolean withComponents;
-
-    public IncomingWebhookClientImpl(long webhookId, String webhookToken, JDA api, boolean withComponents)
+    public IncomingWebhookClientImpl(long webhookId, String webhookToken, JDA api)
     {
         super(webhookId, webhookToken, api);
-        this.withComponents = withComponents;
     }
 
     @Override
@@ -52,8 +49,7 @@ public class IncomingWebhookClientImpl extends AbstractWebhookClient<Message> im
     {
         Route.CompiledRoute route = Route.Webhooks.EXECUTE_WEBHOOK.compile(Long.toUnsignedString(id), token);
         route = route.withQueryParams("wait", "true");
-        if (withComponents)
-            route = route.withQueryParams("with_components", "true");
+        route = route.withQueryParams("with_components", "true");
         WebhookMessageCreateActionImpl<Message> action = new WebhookMessageCreateActionImpl<>(api, route, builder());
         action.run();
         action.setInteraction(false);
@@ -67,8 +63,7 @@ public class IncomingWebhookClientImpl extends AbstractWebhookClient<Message> im
             Checks.isSnowflake(messageId);
         Route.CompiledRoute route = Route.Webhooks.EXECUTE_WEBHOOK_EDIT.compile(Long.toUnsignedString(id), token, messageId);
         route = route.withQueryParams("wait", "true");
-        if (withComponents)
-            route = route.withQueryParams("with_components", "true");
+        route = route.withQueryParams("with_components", "true");
         WebhookMessageEditActionImpl<Message> action = new WebhookMessageEditActionImpl<>(api, route, builder());
         action.run();
         return action;


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Make `IncomingWebhookClient` use `with_components=true` query param. This allows users to send non-interactive message components like link buttons. Also needed for Components V2
