### PR TITLE
Fix message content intent warning being logged when accessing messag…

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -179,7 +179,7 @@ public class ReceivedMessage implements Message
         if (!didContentIntentWarning && !api.isIntent(GatewayIntent.MESSAGE_CONTENT))
         {
             SelfUser selfUser = api.getSelfUser();
-            boolean isBotOwnedWebhookMessage = selfUser.getApplicationId().equals(getApplicationId()) && isWebhookMessage();
+            boolean isBotOwnedWebhookMessage = selfUser.getApplicationIdLong() == getApplicationIdLong() && isWebhookMessage();
 
             if (!Objects.equals(selfUser, author) && !mentions.getUsers().contains(selfUser) && isFromGuild() && !isBotOwnedWebhookMessage)
             {

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -179,7 +179,7 @@ public class ReceivedMessage implements Message
         if (!didContentIntentWarning && !api.isIntent(GatewayIntent.MESSAGE_CONTENT))
         {
             SelfUser selfUser = api.getSelfUser();
-            boolean isBotOwnedWebhookMessage = selfUser.getApplicationId().equals(getApplicationId());
+            boolean isBotOwnedWebhookMessage = selfUser.getApplicationId().equals(getApplicationId()) && isWebhookMessage();
 
             if (!Objects.equals(selfUser, author) && !mentions.getUsers().contains(selfUser) && isFromGuild() && !isBotOwnedWebhookMessage)
             {

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -179,7 +179,9 @@ public class ReceivedMessage implements Message
         if (!didContentIntentWarning && !api.isIntent(GatewayIntent.MESSAGE_CONTENT))
         {
             SelfUser selfUser = api.getSelfUser();
-            if (!Objects.equals(selfUser, author) && !mentions.getUsers().contains(selfUser) && isFromGuild())
+            boolean isBotOwnedWebhookMessage = selfUser.getApplicationId().equals(getApplicationId());
+
+            if (!Objects.equals(selfUser, author) && !mentions.getUsers().contains(selfUser) && isFromGuild() && !isBotOwnedWebhookMessage)
             {
                 didContentIntentWarning = true;
                 JDAImpl.LOG.warn(


### PR DESCRIPTION
…e in bot owned webhook interactions

[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [ ] I have checked the PRs for upcoming features/bug fixes.
- [ ] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes message content intent warning being logged when accessing message in bot owned webhook interactions
