### PR TITLE
Require a `UserSnowflake` in `moveVoiceMember` and `kickVoiceMember`

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -3898,7 +3898,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
     /* From GuildController */
 
     /**
-     * Used to move a {@link Member Member} from one {@link AudioChannel AudioChannel}
+     * Used to move a Member from one {@link AudioChannel AudioChannel}
      * to another {@link AudioChannel AudioChannel}.
      * <br>As a note, you cannot move a Member that isn't already in a AudioChannel. Also they must be in a AudioChannel
      * in the same Guild as the one that you are moving them to.
@@ -3919,17 +3919,17 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      *     <br>The specified channel was deleted before finishing the task</li>
      * </ul>
      *
-     * @param  member
-     *         The {@link Member Member} that you are moving.
+     * @param  user
+     *         The member that you are moving.
      * @param  audioChannel
      *         The destination {@link AudioChannel AudioChannel} to which the member is being
      *         moved to. Or null to perform a voice kick.
      *
      * @throws IllegalStateException
-     *         If the Member isn't currently in a AudioChannel in this Guild, or {@link net.dv8tion.jda.api.utils.cache.CacheFlag#VOICE_STATE} is disabled.
+     *         If the user is a Member and isn't currently in a AudioChannel in this Guild, or {@link net.dv8tion.jda.api.utils.cache.CacheFlag#VOICE_STATE} is disabled.
      * @throws IllegalArgumentException
      *         <ul>
-     *             <li>If the provided member is {@code null}</li>
+     *             <li>If the provided user is {@code null}</li>
      *             <li>If the provided Member isn't part of this {@link net.dv8tion.jda.api.entities.Guild Guild}</li>
      *             <li>If the provided AudioChannel isn't part of this {@link net.dv8tion.jda.api.entities.Guild Guild}</li>
      *         </ul>
@@ -3947,10 +3947,10 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      */
     @Nonnull
     @CheckReturnValue
-    RestAction<Void> moveVoiceMember(@Nonnull Member member, @Nullable AudioChannel audioChannel);
+    RestAction<Void> moveVoiceMember(@Nonnull UserSnowflake user, @Nullable AudioChannel audioChannel);
 
     /**
-     * Used to kick a {@link Member Member} from a {@link AudioChannel AudioChannel}.
+     * Used to kick a member from a {@link AudioChannel AudioChannel}.
      * <br>As a note, you cannot kick a Member that isn't already in a AudioChannel. Also they must be in a AudioChannel
      * in the same Guild.
      *
@@ -3969,11 +3969,11 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      *     <br>The specified channel was deleted before finishing the task</li>
      * </ul>
      *
-     * @param  member
-     *         The {@link Member Member} that you are moving.
+     * @param  user
+     *         The member that you are kicking.
      *
      * @throws IllegalStateException
-     *         If the Member isn't currently in a AudioChannel in this Guild, or {@link net.dv8tion.jda.api.utils.cache.CacheFlag#VOICE_STATE} is disabled.
+     *         If the user is a Member and isn't currently in a AudioChannel in this Guild, or {@link net.dv8tion.jda.api.utils.cache.CacheFlag#VOICE_STATE} is disabled.
      * @throws IllegalArgumentException
      *         <ul>
      *             <li>If any of the provided arguments is {@code null}</li>
@@ -3990,9 +3990,9 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      */
     @Nonnull
     @CheckReturnValue
-    default RestAction<Void> kickVoiceMember(@Nonnull Member member)
+    default RestAction<Void> kickVoiceMember(@Nonnull UserSnowflake user)
     {
-        return moveVoiceMember(member, null);
+        return moveVoiceMember(user, null);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
@@ -123,10 +123,6 @@ public interface GuildVoiceState extends ISnowflake
      * Returns the current {@link AudioChannelUnion} that the {@link Member} is in.
      * If the {@link Member} is currently not connected to a {@link AudioChannel}, this returns null.
      *
-     * <p><b>Note:</b> This will return {@code null} if the member is not cached!
-     * You can use {@link net.dv8tion.jda.api.utils.MemberCachePolicy#VOICE MemberCachePolicy.VOICE}
-     * to cache members in voice channels.
-     *
      * @return The AudioChannelUnion that the Member is connected to, or null if the member is not connected to an audio channel.
      */
     @Nullable

--- a/src/main/java/net/dv8tion/jda/internal/entities/detached/DetachedGuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/detached/DetachedGuildImpl.java
@@ -833,7 +833,7 @@ public class DetachedGuildImpl implements Guild, IDetachableEntityMixin
 
     @Nonnull
     @Override
-    public RestAction<Void> moveVoiceMember(@Nonnull Member member, @Nullable AudioChannel audioChannel)
+    public RestAction<Void> moveVoiceMember(@Nonnull UserSnowflake user, @Nullable AudioChannel audioChannel)
     {
         throw detachedException();
     }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR allows users to move/kick voice members without requiring them to be cached.

I also updated some documentation that mentioned `MemberCachePolicy#VOICE`, as it is not necessary anymore
