### PR TITLE
Remove deprecated GUILD_EMOJIS_AND_STICKERS GatewayIntent

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/GatewayIntent.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/GatewayIntent.java
@@ -55,7 +55,7 @@ import java.util.EnumSet;
  * <ol>
  *     <li><b>GUILD_MEMBERS</b> - This is a <b>privileged</b> gateway intent that is used to update user information and join/leaves (including kicks). This is required to cache all members of a guild (including chunking)</li>
  *     <li><b>GUILD_MODERATION</b> - This will only track guild moderation events, such as bans, unbans, and audit-logs.</li>
- *     <li><b>GUILD_EMOJIS</b> - This will only track custom emoji create/modify/delete. Most bots don't need this since they just use the emoji id anyway.</li>
+ *     <li><b>GUILD_EXPRESSIONS</b> - This will only track custom emoji, sticker, and soundboard sound create/update/delete.</li>
  *     <li><b>GUILD_WEBHOOKS</b> - This will only track guild webhook create/update/delete. Most bots don't need this since related events don't contain any useful information about webhook changes.</li>
  *     <li><b>GUILD_INVITES</b> - This will only track invite create/delete. Most bots don't make use of invites since they are added through OAuth2 authorization by administrators.</li>
  *     <li><b>GUILD_VOICE_STATES</b> - Required to properly get information of members in voice channels and cache them. <u>You cannot connect to a voice channel without this intent</u>.</li>

--- a/src/main/java/net/dv8tion/jda/api/requests/GatewayIntent.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/GatewayIntent.java
@@ -16,8 +16,6 @@
 
 package net.dv8tion.jda.api.requests;
 
-import net.dv8tion.jda.annotations.ForRemoval;
-import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.GenericEvent;
@@ -100,15 +98,6 @@ public enum GatewayIntent
      * Moderation events, such as ban/unban/audit-log.
      */
     GUILD_MODERATION(2),
-    /**
-     * Custom emoji and sticker add/update/delete events.
-     *
-     * @deprecated Replaced with {@link #GUILD_EXPRESSIONS}
-     */
-    @ForRemoval(deadline = "5.3.0")
-    @ReplaceWith("GUILD_EXPRESSIONS")
-    @Deprecated
-    GUILD_EMOJIS_AND_STICKERS(3),
     /**
      * Custom emoji, sticker and soundboard sound add/update/delete events.
      */

--- a/src/test/java/net/dv8tion/jda/test/JDABuilderTest.java
+++ b/src/test/java/net/dv8tion/jda/test/JDABuilderTest.java
@@ -140,43 +140,6 @@ public class JDABuilderTest extends AbstractSnapshotTest
             .matchesSnapshot();
     }
 
-    @EnumSource
-    @ParameterizedTest
-    @SuppressWarnings("deprecation")
-    void testDeprecatedIntentDoesNotDisableCache(IntentTestCase testCase)
-    {
-        TestJDABuilder builder;
-
-        switch (testCase)
-        {
-        case PASSED_TO_FACTORY:
-            builder = new TestJDABuilder(GatewayIntent.GUILD_EMOJIS_AND_STICKERS.getRawValue());
-            builder.applyIntents();
-            break;
-        case PASSED_TO_RELATIVE:
-            builder = new TestJDABuilder(0);
-            builder.applyLight();
-            builder.enableIntents(GatewayIntent.GUILD_EMOJIS_AND_STICKERS);
-            builder.enableCache(CacheFlag.EMOJI, CacheFlag.STICKER);
-            break;
-        case PASSED_TO_SETTER:
-            builder = new TestJDABuilder(0);
-            builder.applyLight();
-            builder.setEnabledIntents(GatewayIntent.GUILD_EMOJIS_AND_STICKERS);
-            builder.enableCache(CacheFlag.EMOJI, CacheFlag.STICKER);
-            break;
-        default:
-            throw new AssertionError("Unexpected test case " + testCase);
-        }
-
-
-        assertThatLoggingFrom(
-            () -> assertThatNoException().isThrownBy(builder::checkIntents)
-        )
-            .doesNotContainLineMatching(log -> log.contains("CacheFlag." + CacheFlag.EMOJI))
-            .doesNotContainLineMatching(log -> log.contains("CacheFlag." + CacheFlag.STICKER));
-    }
-
     static class TestJDABuilder extends JDABuilder
     {
         public TestJDABuilder(int intents)
@@ -207,12 +170,5 @@ public class JDABuilderTest extends AbstractSnapshotTest
         {
             super.checkIntents();
         }
-    }
-
-    enum IntentTestCase
-    {
-        PASSED_TO_FACTORY,
-        PASSED_TO_RELATIVE,
-        PASSED_TO_SETTER;
     }
 }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This removes the deprecated `GatewayIntent.GUILD_EMOJIS_AND_STICKERS`, which was scheduled for removal in `5.3.0` and has since been fully replaced by `GUILD_EXPRESSIONS` (sharing the same bit offset 3).

The related test method `testDeprecatedIntentDoesNotDisableCache` has also been removed, as it only applied to the deprecated intent.