### PR TITLE
Use `DELETE_GUILD` route according to the Discord Docs

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/Route.java
@@ -151,10 +151,10 @@ public class Route
 
         public static final Route GET_WELCOME_SCREEN    =  new Route(GET,   "guilds/{guild_id}/welcome-screen");
         public static final Route MODIFY_WELCOME_SCREEN =  new Route(PATCH, "guilds/{guild_id}/welcome-screen");
-        public static final Route MODIFY_GUILD_INCIDENTS = new Route(PUT,  "guilds/{guild_id}/incident-actions");
+        public static final Route MODIFY_GUILD_INCIDENTS = new Route(PUT,   "guilds/{guild_id}/incident-actions");
 
-        public static final Route CREATE_GUILD = new Route(POST, "guilds");
-        public static final Route DELETE_GUILD = new Route(POST, "guilds/{guild_id}/delete");
+        public static final Route CREATE_GUILD = new Route(POST,   "guilds");
+        public static final Route DELETE_GUILD = new Route(DELETE, "guilds/{guild_id}");
     }
 
     public static class Emojis


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

The old route used by Discord to delete guilds was the `[POST] /guilds/{guild_id}/delete`, but according to their [Documentation](https://discord.com/developers/docs/resources/guild#delete-guild), the `[DELETE] /guilds/{guild_id}` is the new correct route to be used. While it behaves the same way, this endpoint follows better REST conventions.