### PR TITLE
Make JDA#getMutualGuilds accept UserSnowflake instead of User objects

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -1188,7 +1188,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      */
     @Nonnull
     @Unmodifiable
-    List<Guild> getMutualGuilds(@Nonnull Collection<UserSnowflake> users);
+    List<Guild> getMutualGuilds(@Nonnull Collection<? extends UserSnowflake> users);
 
     /**
      * Attempts to retrieve a {@link net.dv8tion.jda.api.entities.User User} object based on the provided id.

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -1170,13 +1170,13 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @param  users
      *         The users which all the returned {@link Guild Guilds} must contain.
      *
-     * @return Immutable list of all {@link Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.User Users} in them.
+     * @return Immutable list of all {@link Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.UserSnowflake Users} in them.
      *
      * @see    Guild#isMember(UserSnowflake)
      */
     @Nonnull
     @Unmodifiable
-    List<Guild> getMutualGuilds(@Nonnull User... users);
+    List<Guild> getMutualGuilds(@Nonnull UserSnowflake... users);
 
     /**
      * Gets all {@link Guild Guilds} that contain all given users as their members.
@@ -1184,11 +1184,11 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * @param users
      *        The users which all the returned {@link Guild Guilds} must contain.
      *
-     * @return Immutable list of all {@link Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.User Users} in them.
+     * @return Immutable list of all {@link Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.UserSnowflake Users} in them.
      */
     @Nonnull
     @Unmodifiable
-    List<Guild> getMutualGuilds(@Nonnull Collection<User> users);
+    List<Guild> getMutualGuilds(@Nonnull Collection<UserSnowflake> users);
 
     /**
      * Attempts to retrieve a {@link net.dv8tion.jda.api.entities.User User} object based on the provided id.

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -307,7 +307,7 @@ public interface User extends UserSnowflake
 
     /**
      * Finds and collects all {@link net.dv8tion.jda.api.entities.Guild Guild} instances that contain this {@link net.dv8tion.jda.api.entities.User User} within the current {@link net.dv8tion.jda.api.JDA JDA} instance.<br>
-     * <p>This method is a shortcut for {@link net.dv8tion.jda.api.JDA#getMutualGuilds(User...) JDA.getMutualGuilds(User)}.</p>
+     * <p>This method is a shortcut for {@link net.dv8tion.jda.api.JDA#getMutualGuilds(UserSnowflake...) JDA.getMutualGuilds(User)}.</p>
      *
      * @return Immutable list of all {@link net.dv8tion.jda.api.entities.Guild Guilds} that this user is a member of.
      */

--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -433,7 +433,7 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      */
     @Nonnull
     @Unmodifiable
-    default List<Guild> getMutualGuilds(@Nonnull final Collection<UserSnowflake> users)
+    default List<Guild> getMutualGuilds(@Nonnull final Collection<? extends UserSnowflake> users)
     {
         Checks.noneNull(users, "users");
         return this.getGuildCache().stream()

--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -429,11 +429,11 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      * @param  users
      *         The users which all the returned {@link net.dv8tion.jda.api.entities.Guild Guilds} must contain.
      *
-     * @return Unmodifiable list of all {@link net.dv8tion.jda.api.entities.Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.User Users} in them.
+     * @return Unmodifiable list of all {@link net.dv8tion.jda.api.entities.Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.UserSnowflake Users} in them.
      */
     @Nonnull
     @Unmodifiable
-    default List<Guild> getMutualGuilds(@Nonnull final Collection<User> users)
+    default List<Guild> getMutualGuilds(@Nonnull final Collection<UserSnowflake> users)
     {
         Checks.noneNull(users, "users");
         return this.getGuildCache().stream()
@@ -448,11 +448,11 @@ public interface ShardManager extends IGuildChannelContainer<Channel>
      * @param  users
      *         The users which all the returned {@link net.dv8tion.jda.api.entities.Guild Guilds} must contain.
      *
-     * @return Unmodifiable list of all {@link net.dv8tion.jda.api.entities.Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.User Users} in them.
+     * @return Unmodifiable list of all {@link net.dv8tion.jda.api.entities.Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.UserSnowflake Users} in them.
      */
     @Nonnull
     @Unmodifiable
-    default List<Guild> getMutualGuilds(@Nonnull final User... users)
+    default List<Guild> getMutualGuilds(@Nonnull final UserSnowflake... users)
     {
         Checks.notNull(users, "users");
         return this.getMutualGuilds(Arrays.asList(users));

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -610,7 +610,7 @@ public class JDAImpl implements JDA
 
     @Nonnull
     @Override
-    public List<Guild> getMutualGuilds(@Nonnull Collection<UserSnowflake> users)
+    public List<Guild> getMutualGuilds(@Nonnull Collection<? extends UserSnowflake> users)
     {
         Checks.notNull(users, "users");
         for(UserSnowflake u : users)

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -613,7 +613,7 @@ public class JDAImpl implements JDA
     public List<Guild> getMutualGuilds(@Nonnull Collection<UserSnowflake> users)
     {
         Checks.notNull(users, "users");
-        for(User u : users)
+        for(UserSnowflake u : users)
             Checks.notNull(u, "All users");
         return getGuilds().stream()
                 .filter(guild -> users.stream().allMatch(guild::isMember))

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -602,7 +602,7 @@ public class JDAImpl implements JDA
 
     @Nonnull
     @Override
-    public List<Guild> getMutualGuilds(@Nonnull User... users)
+    public List<Guild> getMutualGuilds(@Nonnull UserSnowflake... users)
     {
         Checks.notNull(users, "users");
         return getMutualGuilds(Arrays.asList(users));
@@ -610,7 +610,7 @@ public class JDAImpl implements JDA
 
     @Nonnull
     @Override
-    public List<Guild> getMutualGuilds(@Nonnull Collection<User> users)
+    public List<Guild> getMutualGuilds(@Nonnull Collection<UserSnowflake> users)
     {
         Checks.notNull(users, "users");
         for(User u : users)


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Changes the parameter type of `JDA#getMutualGuild` to `Collection<UserSnowflake>` instead of `Collection<User>` (Same for the vararg overloads and the corresponding methods in ShardManager).
