### PR TITLE
Fix gradle build cache

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -318,17 +318,15 @@ tasks.withType<JavaCompile> {
         args.add("8")
     }
 
-    doFirst {
-        options.compilerArgs = args
-    }
+    options.compilerArgs.addAll(args)
 }
 
-val compileJava by tasks.getting(JavaCompile::class) {
+tasks.named<JavaCompile>("compileJava").configure {
     dependsOn(generateJavaSources)
     source = generateJavaSources.get().source
 }
 
-val build by tasks.getting(Task::class) {
+tasks.named("build").configure {
     dependsOn(jar)
     dependsOn(javadocJar)
     dependsOn(sourcesJar)
@@ -351,16 +349,14 @@ tasks.named("processTestResources").configure {
     dependsOn(downloadRecipeClasspath)
 }
 
-val test by tasks.getting(Test::class) {
-    useJUnitPlatform()
-    failFast = false
+
+tasks.register<Test>("updateTestSnapshots") {
+    systemProperty("updateSnapshots", "true")
 }
 
-val updateTestSnapshots by tasks.registering(Test::class) {
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     failFast = false
-
-    systemProperty("updateSnapshots", "true")
 }
 
 ////////////////////////////////////


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: CI

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixed the incorrect use of `doFirst` in `compileJava`, which broke the caching of the task.
