### PR TITLE
Fix javadoc: Removed duplicate 'with' from MessageChannel#getHistoryFromBeginning

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/channel/middleman/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/middleman/MessageChannel.java
@@ -1877,7 +1877,7 @@ public interface MessageChannel extends Channel, Formattable
      *         If this entity is {@link #isDetached() detached}
      *
      * @return {@link net.dv8tion.jda.api.entities.MessageHistory.MessageRetrieveAction MessageHistory.MessageRetrieveAction}
-     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with with the first messages of this channel loaded into it.
+     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with the first messages of this channel loaded into it.
      *         <br><b>Note: The messages are ordered from the most recent to oldest!</b>
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#retrieveFuture(int)                     MessageHistory.retrieveFuture(int)


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ 

Closes Issue: NaN

## Description

Removes a duplicate of the word "with" in the method description for MessageChannel#getHistoryFromBeginning