### PR TITLE
Use new routes to (un)pin messages

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2027,11 +2027,11 @@ public interface Message extends ISnowflake, Formattable
      * @throws IllegalStateException
      *         If this Message is ephemeral
      *
-     * @return {@link RestAction RestAction} - Type: {@link java.lang.Void}
+     * @return {@link AuditableRestAction AuditableRestAction} - Type: {@link java.lang.Void}
      */
     @Nonnull
     @CheckReturnValue
-    RestAction<Void> pin();
+    AuditableRestAction<Void> pin();
 
     /**
      * Used to remove the Message from the {@link #getChannel() MessageChannel's} pinned message list.
@@ -2066,11 +2066,11 @@ public interface Message extends ISnowflake, Formattable
      * @throws IllegalStateException
      *         If this Message is ephemeral
      *
-     * @return {@link RestAction RestAction} - Type: {@link java.lang.Void}
+     * @return {@link AuditableRestAction AuditableRestAction} - Type: {@link java.lang.Void}
      */
     @Nonnull
     @CheckReturnValue
-    RestAction<Void> unpin();
+    AuditableRestAction<Void> unpin();
 
     /**
      * Adds a reaction to this Message using an {@link Emoji}.

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/middleman/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/middleman/MessageChannel.java
@@ -2403,16 +2403,16 @@ public interface MessageChannel extends Channel, Formattable
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
      *         If this entity is {@link #isDetached() detached}
      *
-     * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction}
+     * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
     @Nonnull
     @CheckReturnValue
-    default RestAction<Void> pinMessageById(@Nonnull String messageId)
+    default AuditableRestAction<Void> pinMessageById(@Nonnull String messageId)
     {
         Checks.isSnowflake(messageId, "Message ID");
 
-        Route.CompiledRoute route = Route.Messages.ADD_PINNED_MESSAGE.compile(getId(), messageId);
-        return new RestActionImpl<>(getJDA(), route);
+        Route.CompiledRoute route = Route.Messages.PIN_MESSAGE.compile(getId(), messageId);
+        return new AuditableRestActionImpl<>(getJDA(), route);
     }
 
     /**
@@ -2452,11 +2452,11 @@ public interface MessageChannel extends Channel, Formattable
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
      *         If this entity is {@link #isDetached() detached}
      *
-     * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction}
+     * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
     @Nonnull
     @CheckReturnValue
-    default RestAction<Void> pinMessageById(long messageId)
+    default AuditableRestAction<Void> pinMessageById(long messageId)
     {
         return pinMessageById(Long.toUnsignedString(messageId));
     }
@@ -2498,16 +2498,16 @@ public interface MessageChannel extends Channel, Formattable
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
      *         If this entity is {@link #isDetached() detached}
      *
-     * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction}
+     * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
     @Nonnull
     @CheckReturnValue
-    default RestAction<Void> unpinMessageById(@Nonnull String messageId)
+    default AuditableRestAction<Void> unpinMessageById(@Nonnull String messageId)
     {
         Checks.isSnowflake(messageId, "Message ID");
 
-        Route.CompiledRoute route = Route.Messages.REMOVE_PINNED_MESSAGE.compile(getId(), messageId);
-        return new RestActionImpl<Void>(getJDA(), route);
+        Route.CompiledRoute route = Route.Messages.UNPIN_MESSAGE.compile(getId(), messageId);
+        return new AuditableRestActionImpl<>(getJDA(), route);
     }
 
     /**
@@ -2547,11 +2547,11 @@ public interface MessageChannel extends Channel, Formattable
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
      *         If this entity is {@link #isDetached() detached}
      *
-     * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction}
+     * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
     @Nonnull
     @CheckReturnValue
-    default RestAction<Void> unpinMessageById(long messageId)
+    default AuditableRestAction<Void> unpinMessageById(long messageId)
     {
         return unpinMessageById(Long.toUnsignedString(messageId));
     }

--- a/src/main/java/net/dv8tion/jda/api/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/Route.java
@@ -263,8 +263,14 @@ public class Route
         @ReplaceWith("GET_MESSAGE_PINS")
         public static final Route GET_PINNED_MESSAGES =   new Route(GET,    "channels/{channel_id}/pins");
         public static final Route GET_MESSAGE_PINS =      new Route(GET,    "channels/{channel_id}/messages/pins");
+        @Deprecated
+        @ReplaceWith("PIN_MESSAGE")
         public static final Route ADD_PINNED_MESSAGE =    new Route(PUT,    "channels/{channel_id}/pins/{message_id}");
+        public static final Route PIN_MESSAGE =           new Route(PUT,    "channels/{channel_id}/messages/pins/{message_id}");
+        @Deprecated
+        @ReplaceWith("UNPIN_MESSAGE")
         public static final Route REMOVE_PINNED_MESSAGE = new Route(DELETE, "channels/{channel_id}/pins/{message_id}");
+        public static final Route UNPIN_MESSAGE =         new Route(DELETE, "channels/{channel_id}/messages/pins/{message_id}");
 
         public static final Route ADD_REACTION =          new Route(PUT,    "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/{user_id}");
         public static final Route REMOVE_REACTION =       new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/{user_id}");

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -228,7 +228,7 @@ public class ReceivedMessage implements Message
 
     @Nonnull
     @Override
-    public RestAction<Void> pin()
+    public AuditableRestAction<Void> pin()
     {
         checkSystem("pin");
         if (isEphemeral())
@@ -237,13 +237,13 @@ public class ReceivedMessage implements Message
         if (hasChannel())
             return getChannel().pinMessageById(getIdLong());
 
-        Route.CompiledRoute route = Route.Messages.ADD_PINNED_MESSAGE.compile(getChannelId(), getId());
-        return new RestActionImpl<>(getJDA(), route);
+        Route.CompiledRoute route = Route.Messages.PIN_MESSAGE.compile(getChannelId(), getId());
+        return new AuditableRestActionImpl<>(getJDA(), route);
     }
 
     @Nonnull
     @Override
-    public RestAction<Void> unpin()
+    public AuditableRestAction<Void> unpin()
     {
         checkSystem("unpin");
         if (isEphemeral())
@@ -252,8 +252,8 @@ public class ReceivedMessage implements Message
         if (hasChannel())
             return getChannel().unpinMessageById(getIdLong());
 
-        Route.CompiledRoute route = Route.Messages.REMOVE_PINNED_MESSAGE.compile(getChannelId(), getId());
-        return new RestActionImpl<>(getJDA(), route);
+        Route.CompiledRoute route = Route.Messages.UNPIN_MESSAGE.compile(getChannelId(), getId());
+        return new AuditableRestActionImpl<>(getJDA(), route);
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/mixin/middleman/MessageChannelMixin.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/mixin/middleman/MessageChannelMixin.java
@@ -290,7 +290,7 @@ public interface MessageChannelMixin<T extends MessageChannelMixin<T>> extends
 
     @Nonnull
     @CheckReturnValue
-    default RestAction<Void> pinMessageById(@Nonnull String messageId)
+    default AuditableRestAction<Void> pinMessageById(@Nonnull String messageId)
     {
         checkCanControlMessagePins();
         return MessageChannelUnion.super.pinMessageById(messageId);
@@ -298,7 +298,7 @@ public interface MessageChannelMixin<T extends MessageChannelMixin<T>> extends
 
     @Nonnull
     @CheckReturnValue
-    default RestAction<Void> unpinMessageById(@Nonnull String messageId)
+    default AuditableRestAction<Void> unpinMessageById(@Nonnull String messageId)
     {
         checkCanControlMessagePins();
         return MessageChannelUnion.super.unpinMessageById(messageId);


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR updates the endpoints to pin/unpin messages, and returns `AuditableRestAction` as it is now supported, creating an ABI change.
