### PR TITLE
Deprecate and replace `TextInput.Builder#setId` with `setCustomId`

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/components/textinput/TextInput.java
+++ b/src/main/java/net/dv8tion/jda/api/components/textinput/TextInput.java
@@ -237,7 +237,7 @@ public interface TextInput extends ICustomId, LabelChildComponent
         public Builder setCustomId(@Nonnull String customId)
         {
             Checks.notBlank(customId, "Custom ID");
-            Checks.notLonger(this.customId, MAX_ID_LENGTH, "Custom ID");
+            Checks.notLonger(customId, MAX_ID_LENGTH, "Custom ID");
             this.customId = customId;
             return this;
         }

--- a/src/main/java/net/dv8tion/jda/api/components/textinput/TextInput.java
+++ b/src/main/java/net/dv8tion/jda/api/components/textinput/TextInput.java
@@ -177,7 +177,7 @@ public interface TextInput extends ICustomId, LabelChildComponent
      */
     class Builder
     {
-        private String id;
+        private String customId;
         private int uniqueId = -1;
         private String value;
         private String placeholder;
@@ -186,9 +186,9 @@ public interface TextInput extends ICustomId, LabelChildComponent
         private TextInputStyle style;
         private boolean required = true;
 
-        protected Builder(String id, TextInputStyle style)
+        protected Builder(String customId, TextInputStyle style)
         {
-            setId(id);
+            setCustomId(customId);
             setStyle(style);
         }
 
@@ -206,13 +206,39 @@ public interface TextInput extends ICustomId, LabelChildComponent
          *         </ul>
          *
          * @return The same Builder for chaining convenience.
+         *
+         * @deprecated
+         *         Replaced by {@link #setCustomId(String)}
          */
         @Nonnull
+        @Deprecated
+        @ReplaceWith("setCustomId(id)")
         public Builder setId(@Nonnull String id)
         {
-            Checks.notBlank(id, "ID");
-            Checks.notLonger(id, MAX_ID_LENGTH, "ID");
-            this.id = id;
+            return setCustomId(id);
+        }
+
+        /**
+         * Sets the custom ID for this TextInput
+         * <br>This can be used to uniquely identify it, or pass data to other handlers.
+         *
+         * @param  customId
+         *         The custom ID to set
+         *
+         * @throws IllegalArgumentException
+         *         <ul>
+         *             <li>If {@code customId} is null or blank</li>
+         *             <li>If {@code customId} is longer than {@value #MAX_ID_LENGTH} characters</li>
+         *         </ul>
+         *
+         * @return The same Builder for chaining convenience.
+         */
+        @Nonnull
+        public Builder setCustomId(@Nonnull String customId)
+        {
+            Checks.notBlank(customId, "Custom ID");
+            Checks.notLonger(this.customId, MAX_ID_LENGTH, "Custom ID");
+            this.customId = customId;
             return this;
         }
 
@@ -435,7 +461,7 @@ public interface TextInput extends ICustomId, LabelChildComponent
         @ReplaceWith("getCustomId()")
         public String getId()
         {
-            return id;
+            return customId;
         }
 
         /**
@@ -446,7 +472,7 @@ public interface TextInput extends ICustomId, LabelChildComponent
         @Nonnull
         public String getCustomId()
         {
-            return id;
+            return customId;
         }
 
         /**
@@ -520,7 +546,7 @@ public interface TextInput extends ICustomId, LabelChildComponent
             if (maxLength < minLength && maxLength != -1)
                 throw new IllegalStateException("maxLength cannot be smaller than minLength!");
 
-            return new TextInputImpl(id, uniqueId, style, minLength, maxLength, required, value, placeholder);
+            return new TextInputImpl(customId, uniqueId, style, minLength, maxLength, required, value, placeholder);
         }
     }
 }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The latest changes missed the `TextInput.Builder` custom ID setter, this PR fixes that.
