### PR TITLE
Add entity selects and text displays in modals

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/components/Component.java
+++ b/src/main/java/net/dv8tion/jda/api/components/Component.java
@@ -122,13 +122,13 @@ public interface Component
         /** A text input field */
         TEXT_INPUT(4, false, true),
         /** A select menu of users */
-        USER_SELECT(5, true, false),
+        USER_SELECT(5, true, true),
         /** A select menu of roles */
-        ROLE_SELECT(6, true, false),
+        ROLE_SELECT(6, true, true),
         /** A select menu of users and roles */
-        MENTIONABLE_SELECT(7, true, false),
+        MENTIONABLE_SELECT(7, true, true),
         /** A select menu of channels */
-        CHANNEL_SELECT(8, true, false),
+        CHANNEL_SELECT(8, true, true),
         SECTION(9, true, false),
         TEXT_DISPLAY(10, true, false),
         THUMBNAIL(11, true, false),

--- a/src/main/java/net/dv8tion/jda/api/components/Component.java
+++ b/src/main/java/net/dv8tion/jda/api/components/Component.java
@@ -130,7 +130,7 @@ public interface Component
         /** A select menu of channels */
         CHANNEL_SELECT(8, true, true),
         SECTION(9, true, false),
-        TEXT_DISPLAY(10, true, false),
+        TEXT_DISPLAY(10, true, true),
         THUMBNAIL(11, true, false),
         MEDIA_GALLERY(12, true, false),
         FILE_DISPLAY(13, true, false),

--- a/src/main/java/net/dv8tion/jda/api/components/Component.java
+++ b/src/main/java/net/dv8tion/jda/api/components/Component.java
@@ -198,6 +198,16 @@ public interface Component
         }
 
         /**
+         * Whether this component is an {@link net.dv8tion.jda.api.components.selections.EntitySelectMenu EntitySelectMenu}
+         *
+         * @return {@code true} is this is a type of {@link net.dv8tion.jda.api.components.selections.EntitySelectMenu EntitySelectMenu}
+         */
+        public boolean isEntitySelectMenu()
+        {
+            return this == MENTIONABLE_SELECT || this == CHANNEL_SELECT || this == USER_SELECT || this == ROLE_SELECT;
+        }
+
+        /**
          * Maps the provided type id to the respective enum instance.
          *
          * @param  type

--- a/src/main/java/net/dv8tion/jda/api/components/ModalTopLevelComponent.java
+++ b/src/main/java/net/dv8tion/jda/api/components/ModalTopLevelComponent.java
@@ -22,6 +22,7 @@ import javax.annotation.Nonnull;
  * Represents a component that can be added directly to a modal, this includes:
  * <ul>
  *     <li>{@link net.dv8tion.jda.api.components.label.Label Label}</li>
+ *     <li>{@link net.dv8tion.jda.api.components.textdisplay.TextDisplay TextDisplay}</li>
  * </ul>
  */
 public interface ModalTopLevelComponent extends Component

--- a/src/main/java/net/dv8tion/jda/api/components/ModalTopLevelComponentUnion.java
+++ b/src/main/java/net/dv8tion/jda/api/components/ModalTopLevelComponentUnion.java
@@ -17,6 +17,7 @@
 package net.dv8tion.jda.api.components;
 
 import net.dv8tion.jda.api.components.label.Label;
+import net.dv8tion.jda.api.components.textdisplay.TextDisplay;
 
 import javax.annotation.Nonnull;
 
@@ -24,6 +25,7 @@ import javax.annotation.Nonnull;
  * Represents a union of {@link ModalTopLevelComponent ModalTopLevelComponents} that can be one of:
  * <ul>
  *     <li>{@link Label}</li>
+ *     <li>{@link TextDisplay}</li>
  *     <li>{@link UnknownComponent}, detectable via {@link #isUnknownComponent()}</li>
  * </ul>
  */
@@ -50,6 +52,28 @@ public interface ModalTopLevelComponentUnion extends ModalTopLevelComponent, ICo
      */
     @Nonnull
     Label asLabel();
+
+    /**
+     * Casts this union to a {@link TextDisplay}.
+     * This method exists for developer discoverability.
+     *
+     * <p>Note: This is effectively equivalent to using the cast operator:
+     * <pre><code>
+     * //These are the same!
+     * TextDisplay textDisplay = union.asTextDisplay();
+     * TextDisplay textDisplay2 = (TextDisplay) union;
+     * </code></pre>
+     *
+     * You can use {@link #getType()} to see if the component is of type {@link net.dv8tion.jda.api.components.Component.Type#TEXT_DISPLAY TEXT_DISPLAY} to validate
+     * whether you can call this method in addition to normal instanceof checks: <code>component instanceof TextDisplay</code>
+     *
+     * @throws IllegalStateException
+     *         If the component represented by this union is not actually a {@link TextDisplay}.
+     *
+     * @return The component as a {@link TextDisplay}
+     */
+    @Nonnull
+    TextDisplay asTextDisplay();
 
     @Nonnull
     @Override

--- a/src/main/java/net/dv8tion/jda/api/components/label/LabelChildComponent.java
+++ b/src/main/java/net/dv8tion/jda/api/components/label/LabelChildComponent.java
@@ -25,6 +25,7 @@ import javax.annotation.Nonnull;
  * <ul>
  *     <li>{@link net.dv8tion.jda.api.components.textinput.TextInput TextInput}</li>
  *     <li>{@link net.dv8tion.jda.api.components.selections.StringSelectMenu StringSelectMenu}</li>
+ *     <li>{@link net.dv8tion.jda.api.components.selections.EntitySelectMenu EntitySelectMenu}</li>
  * </ul>
  */
 public interface LabelChildComponent extends Component

--- a/src/main/java/net/dv8tion/jda/api/components/label/LabelChildComponentUnion.java
+++ b/src/main/java/net/dv8tion/jda/api/components/label/LabelChildComponentUnion.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.api.components.label;
 
 import net.dv8tion.jda.api.components.Component;
 import net.dv8tion.jda.api.components.IComponentUnion;
+import net.dv8tion.jda.api.components.selections.EntitySelectMenu;
 import net.dv8tion.jda.api.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.components.textinput.TextInput;
 
@@ -28,6 +29,7 @@ import javax.annotation.Nonnull;
  * <ul>
  *     <li>{@link TextInput}</li>
  *     <li>{@link StringSelectMenu}</li>
+ *     <li>{@link EntitySelectMenu}</li>
  * </ul>
  */
 public interface LabelChildComponentUnion extends LabelChildComponent, IComponentUnion
@@ -75,6 +77,34 @@ public interface LabelChildComponentUnion extends LabelChildComponent, IComponen
      */
     @Nonnull
     StringSelectMenu asStringSelectMenu();
+
+    /**
+     * Casts this union to a {@link EntitySelectMenu}.
+     * This method exists for developer discoverability.
+     *
+     * <p>Note: This is effectively equivalent to using the cast operator:
+     * <pre><code>
+     * //These are the same!
+     * EntitySelectMenu menu = union.asEntitySelectMenu();
+     * EntitySelectMenu menu2 = (EntitySelectMenu) union;
+     * </code></pre>
+     *
+     * You can use {@link #getType()} to see if the component is one of:
+     * <ul>
+     *     <li>{@link Component.Type#USER_SELECT USER_SELECT}</li>
+     *     <li>{@link Component.Type#ROLE_SELECT ROLE_SELECT}</li>
+     *     <li>{@link Component.Type#MENTIONABLE_SELECT MENTIONABLE_SELECT}</li>
+     *     <li>{@link Component.Type#CHANNEL_SELECT CHANNEL_SELECT}</li>
+     * </ul>
+     * to validate whether you can call this method in addition to normal instanceof checks: <code>component instanceof EntitySelectMenu</code>
+     *
+     * @throws IllegalStateException
+     *         If the component represented by this union is not actually a {@link EntitySelectMenu}.
+     *
+     * @return The component as a {@link EntitySelectMenu}
+     */
+    @Nonnull
+    EntitySelectMenu asEntitySelectMenu();
 
     @Nonnull
     @Override

--- a/src/main/java/net/dv8tion/jda/api/components/selections/EntitySelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/components/selections/EntitySelectMenu.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.*;
 
 /**
@@ -133,6 +134,14 @@ public interface EntitySelectMenu extends SelectMenu, LabelChildComponent
     @Nonnull
     @Unmodifiable
     List<DefaultValue> getDefaultValues();
+
+    /**
+     * Whether the user must populate this select menu in Modals, or {@code null} if not set.
+     *
+     * @return Whether this menu must be populated, or null
+     */
+    @Nullable
+    Boolean isRequired();
 
     /**
      * Creates a new preconfigured {@link Builder} with the same settings used for this select menu.
@@ -468,10 +477,22 @@ public interface EntitySelectMenu extends SelectMenu, LabelChildComponent
         protected Component.Type componentType;
         protected EnumSet<ChannelType> channelTypes = EnumSet.noneOf(ChannelType.class);
         protected List<DefaultValue> defaultValues = new ArrayList<>();
+        protected Boolean required;
 
         protected Builder(@Nonnull String customId)
         {
             super(customId);
+        }
+
+        /**
+         * Whether the user must populate this select menu in Modals, or {@code null} if not set.
+         *
+         * @return Whether this menu must be populated, or null
+         */
+        @Nullable
+        public Boolean isRequired()
+        {
+            return required;
         }
 
         /**
@@ -642,6 +663,24 @@ public interface EntitySelectMenu extends SelectMenu, LabelChildComponent
         }
 
         /**
+         * Configure whether the user must populate this select menu if inside a Modal.
+         * <br>This defaults to {@code true} in Modals when unset.
+         *
+         * <p>This only has an effect in Modals!
+         *
+         * @param required
+         *        Whether this menu is required
+         *
+         * @return The same builder instance for chaining
+         */
+        @Nonnull
+        public Builder setRequired(@Nullable Boolean required)
+        {
+            this.required = required;
+            return this;
+        }
+
+        /**
          * Creates a new {@link EntitySelectMenu} instance if all requirements are satisfied.
          *
          * @throws IllegalArgumentException
@@ -656,7 +695,7 @@ public interface EntitySelectMenu extends SelectMenu, LabelChildComponent
             Checks.check(minValues <= maxValues, "Min values cannot be greater than max values!");
             EnumSet<ChannelType> channelTypes = componentType == Type.CHANNEL_SELECT ? this.channelTypes : EnumSet.noneOf(ChannelType.class);
             List<DefaultValue> defaultValues = new ArrayList<>(this.defaultValues);
-            return new EntitySelectMenuImpl(customId, uniqueId, placeholder, minValues, maxValues, disabled, componentType, channelTypes, defaultValues);
+            return new EntitySelectMenuImpl(customId, uniqueId, placeholder, minValues, maxValues, disabled, componentType, channelTypes, defaultValues, required);
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/components/selections/EntitySelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/components/selections/EntitySelectMenu.java
@@ -19,7 +19,6 @@ package net.dv8tion.jda.api.components.selections;
 import net.dv8tion.jda.api.components.ActionComponent;
 import net.dv8tion.jda.api.components.Component;
 import net.dv8tion.jda.api.components.actionrow.ActionRow;
-import net.dv8tion.jda.api.components.label.LabelChildComponent;
 import net.dv8tion.jda.api.entities.ISnowflake;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.UserSnowflake;
@@ -73,7 +72,7 @@ import java.util.*;
  * @see EntitySelectInteraction
  * @see StringSelectMenu
  */
-public interface EntitySelectMenu extends SelectMenu, LabelChildComponent
+public interface EntitySelectMenu extends SelectMenu
 {
     @Nonnull
     @Override

--- a/src/main/java/net/dv8tion/jda/api/components/selections/EntitySelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/components/selections/EntitySelectMenu.java
@@ -38,7 +38,6 @@ import org.jetbrains.annotations.Unmodifiable;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 
 /**
@@ -134,14 +133,6 @@ public interface EntitySelectMenu extends SelectMenu, LabelChildComponent
     @Nonnull
     @Unmodifiable
     List<DefaultValue> getDefaultValues();
-
-    /**
-     * Whether the user must populate this select menu in Modals, or {@code null} if not set.
-     *
-     * @return Whether this menu must be populated, or null
-     */
-    @Nullable
-    Boolean isRequired();
 
     /**
      * Creates a new preconfigured {@link Builder} with the same settings used for this select menu.
@@ -477,22 +468,10 @@ public interface EntitySelectMenu extends SelectMenu, LabelChildComponent
         protected Component.Type componentType;
         protected EnumSet<ChannelType> channelTypes = EnumSet.noneOf(ChannelType.class);
         protected List<DefaultValue> defaultValues = new ArrayList<>();
-        protected Boolean required;
 
         protected Builder(@Nonnull String customId)
         {
             super(customId);
-        }
-
-        /**
-         * Whether the user must populate this select menu in Modals, or {@code null} if not set.
-         *
-         * @return Whether this menu must be populated, or null
-         */
-        @Nullable
-        public Boolean isRequired()
-        {
-            return required;
         }
 
         /**
@@ -659,24 +638,6 @@ public interface EntitySelectMenu extends SelectMenu, LabelChildComponent
 
             this.defaultValues.clear();
             this.defaultValues.addAll(values);
-            return this;
-        }
-
-        /**
-         * Configure whether the user must populate this select menu if inside a Modal.
-         * <br>This defaults to {@code true} in Modals when unset.
-         *
-         * <p>This only has an effect in Modals!
-         *
-         * @param required
-         *        Whether this menu is required
-         *
-         * @return The same builder instance for chaining
-         */
-        @Nonnull
-        public Builder setRequired(@Nullable Boolean required)
-        {
-            this.required = required;
             return this;
         }
 

--- a/src/main/java/net/dv8tion/jda/api/components/selections/EntitySelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/components/selections/EntitySelectMenu.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.api.components.selections;
 import net.dv8tion.jda.api.components.ActionComponent;
 import net.dv8tion.jda.api.components.Component;
 import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.label.LabelChildComponent;
 import net.dv8tion.jda.api.entities.ISnowflake;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.UserSnowflake;
@@ -72,7 +73,7 @@ import java.util.*;
  * @see EntitySelectInteraction
  * @see StringSelectMenu
  */
-public interface EntitySelectMenu extends SelectMenu
+public interface EntitySelectMenu extends SelectMenu, LabelChildComponent
 {
     @Nonnull
     @Override

--- a/src/main/java/net/dv8tion/jda/api/components/selections/SelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/components/selections/SelectMenu.java
@@ -111,6 +111,14 @@ public interface SelectMenu extends ActionComponent, ActionRowChildComponent
     int getMaxValues();
 
     /**
+     * Whether the user must populate this select menu in Modals, or {@code null} if not set.
+     *
+     * @return Whether this menu must be populated, or null
+     */
+    @Nullable
+    Boolean isRequired();
+
+    /**
      * Creates a new preconfigured {@link SelectMenu.Builder} with the same settings used for this select menu.
      * <br>This can be useful to create an updated version of this menu without needing to rebuild it from scratch.
      *
@@ -136,6 +144,7 @@ public interface SelectMenu extends ActionComponent, ActionRowChildComponent
         protected String placeholder;
         protected int minValues = 1, maxValues = 1;
         protected boolean disabled = false;
+        protected Boolean required = null;
 
         protected Builder(@Nonnull String customId)
         {
@@ -312,6 +321,24 @@ public interface SelectMenu extends ActionComponent, ActionRowChildComponent
         }
 
         /**
+         * Configure whether the user must populate this select menu if inside a Modal.
+         * <br>This defaults to {@code true} in Modals when unset.
+         *
+         * <p>This only has an effect in Modals!
+         *
+         * @param required
+         *        Whether this menu is required
+         *
+         * @return The same builder instance for chaining
+         */
+        @Nonnull
+        public B setRequired(@Nullable Boolean required)
+        {
+            this.required = required;
+            return (B) this;
+        }
+
+        /**
          * The custom id used to identify the select menu.
          *
          * @return The custom id
@@ -388,6 +415,17 @@ public interface SelectMenu extends ActionComponent, ActionRowChildComponent
         public boolean isDisabled()
         {
             return disabled;
+        }
+
+        /**
+         * Whether the user must populate this select menu in Modals, or {@code null} if not set.
+         *
+         * @return Whether this menu must be populated, or null
+         */
+        @Nullable
+        public Boolean isRequired()
+        {
+            return required;
         }
 
         /**

--- a/src/main/java/net/dv8tion/jda/api/components/selections/SelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/components/selections/SelectMenu.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.components.ActionComponent;
 import net.dv8tion.jda.api.components.actionrow.ActionRow;
 import net.dv8tion.jda.api.components.actionrow.ActionRowChildComponent;
+import net.dv8tion.jda.api.components.label.LabelChildComponent;
 import net.dv8tion.jda.api.interactions.components.selections.SelectMenuInteraction;
 import net.dv8tion.jda.internal.utils.Checks;
 
@@ -45,7 +46,7 @@ import java.util.Collection;
  * @see EntitySelectMenu
  * @see SelectMenuInteraction
  */
-public interface SelectMenu extends ActionComponent, ActionRowChildComponent
+public interface SelectMenu extends ActionComponent, ActionRowChildComponent, LabelChildComponent
 {
     /**
      * The maximum length a select menu id can have

--- a/src/main/java/net/dv8tion/jda/api/components/selections/StringSelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/components/selections/StringSelectMenu.java
@@ -101,14 +101,6 @@ public interface StringSelectMenu extends SelectMenu, LabelChildComponent
     List<SelectOption> getOptions();
 
     /**
-     * Whether the user must populate this select menu in Modals, or {@code null} if not set.
-     *
-     * @return Whether this menu must be populated, or null
-     */
-    @Nullable
-    Boolean isRequired();
-
-    /**
      * Creates a new preconfigured {@link Builder} with the same settings used for this select menu.
      * <br>This can be useful to create an updated version of this menu without needing to rebuild it from scratch.
      *
@@ -153,7 +145,6 @@ public interface StringSelectMenu extends SelectMenu, LabelChildComponent
     class Builder extends SelectMenu.Builder<StringSelectMenu, StringSelectMenu.Builder>
     {
         private final List<SelectOption> options = new ArrayList<>();
-        private Boolean required = null;
 
         protected Builder(@Nonnull String customId)
         {
@@ -307,17 +298,6 @@ public interface StringSelectMenu extends SelectMenu, LabelChildComponent
         }
 
         /**
-         * Whether the user must populate this select menu in Modals, or {@code null} if not set.
-         *
-         * @return Whether this menu must be populated, or null
-         */
-        @Nullable
-        public Boolean isRequired()
-        {
-            return required;
-        }
-
-        /**
          * Configures which of the currently applied {@link #getOptions() options} should be selected by default.
          *
          * @param  values
@@ -393,24 +373,6 @@ public interface StringSelectMenu extends SelectMenu, LabelChildComponent
         {
             Checks.noneNull(values, "Values");
             return setDefaultOptions(Arrays.asList(values));
-        }
-
-        /**
-         * Configure whether the user must populate this select menu if inside a Modal.
-         * <br>This defaults to {@code true} in Modals when unset.
-         *
-         * <p>This only has an effect in Modals!
-         *
-         * @param required
-         *        Whether this menu is required
-         *
-         * @return The same builder instance for chaining
-         */
-        @Nonnull
-        public Builder setRequired(@Nullable Boolean required)
-        {
-            this.required = required;
-            return this;
         }
 
         /**

--- a/src/main/java/net/dv8tion/jda/api/components/selections/StringSelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/components/selections/StringSelectMenu.java
@@ -18,7 +18,6 @@ package net.dv8tion.jda.api.components.selections;
 
 import net.dv8tion.jda.api.components.ActionComponent;
 import net.dv8tion.jda.api.components.actionrow.ActionRow;
-import net.dv8tion.jda.api.components.label.LabelChildComponent;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.interactions.components.selections.SelectMenuInteraction;
 import net.dv8tion.jda.api.interactions.components.selections.StringSelectInteraction;
@@ -63,7 +62,7 @@ import java.util.stream.Collectors;
  * @see StringSelectInteraction
  * @see EntitySelectMenu
  */
-public interface StringSelectMenu extends SelectMenu, LabelChildComponent
+public interface StringSelectMenu extends SelectMenu
 {
     @Nonnull
     @Override

--- a/src/main/java/net/dv8tion/jda/api/components/textdisplay/TextDisplay.java
+++ b/src/main/java/net/dv8tion/jda/api/components/textdisplay/TextDisplay.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.api.components.textdisplay;
 
 import net.dv8tion.jda.api.components.Component;
 import net.dv8tion.jda.api.components.MessageTopLevelComponent;
+import net.dv8tion.jda.api.components.ModalTopLevelComponent;
 import net.dv8tion.jda.api.components.container.ContainerChildComponent;
 import net.dv8tion.jda.api.components.section.SectionContentComponent;
 import net.dv8tion.jda.api.entities.Message;
@@ -37,7 +38,9 @@ import javax.annotation.Nonnull;
  *
  * <p><b>Requirements:</b> {@linkplain MessageRequest#useComponentsV2() Components V2} needs to be enabled!
  */
-public interface TextDisplay extends Component, MessageTopLevelComponent, ContainerChildComponent, SectionContentComponent
+public interface TextDisplay
+        extends Component, MessageTopLevelComponent, ModalTopLevelComponent,
+        ContainerChildComponent, SectionContentComponent
 {
     /**
      * Constructs a new {@link TextDisplay} from the given content.

--- a/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalMapping.java
@@ -153,7 +153,7 @@ public class ModalMapping
     @Nonnull
     public List<String> getAsStringList()
     {
-        if (type != Component.Type.STRING_SELECT)
+        if (type != Component.Type.STRING_SELECT && !type.isEntitySelectMenu())
             typeError("List<String>");
 
         return value.getArray("values")

--- a/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalMapping.java
@@ -162,7 +162,7 @@ public class ModalMapping
     }
 
     /**
-     * Returns this component's value as a list of entity IDs.
+     * Returns this component's value as a list of Longs.
      *
      * <p>This is available if the component was an {@link net.dv8tion.jda.api.components.selections.EntitySelectMenu EntitySelectMenu}.
      *
@@ -171,7 +171,7 @@ public class ModalMapping
      * @throws IllegalStateException
      *         If this ModalMapping cannot be represented as such
      *
-     * @return This component's value as a list of entity IDs.
+     * @return This component's value as a list of Longs.
      */
     @Nonnull
     public List<Long> getAsLongList()

--- a/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalMapping.java
@@ -19,15 +19,21 @@ package net.dv8tion.jda.api.interactions.modals;
 import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.components.Component;
+import net.dv8tion.jda.api.entities.Mentions;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.entities.SelectMenuMentions;
+import net.dv8tion.jda.internal.interactions.InteractionImpl;
 import net.dv8tion.jda.internal.utils.EntityString;
 import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Objects;
+
+import static net.dv8tion.jda.api.components.Component.Type.STRING_SELECT;
+import static net.dv8tion.jda.api.components.Component.Type.TEXT_INPUT;
 
 /**
  * ID/Value pair for a {@link net.dv8tion.jda.api.events.interaction.ModalInteractionEvent ModalInteractionEvent}.
@@ -37,16 +43,20 @@ import java.util.Objects;
  */
 public class ModalMapping
 {
+    private final InteractionImpl interaction;
     private final String customId;
     private final int uniqueId;
+    private final DataObject resolved;
     private final DataObject value;
     private final Component.Type type;
 
-    public ModalMapping(DataObject object)
+    public ModalMapping(InteractionImpl interaction, DataObject resolved, DataObject object)
     {
+        this.interaction = interaction;
         this.uniqueId = object.getInt("id");
         this.customId = object.getString("custom_id");
         this.type = Component.Type.fromKey(object.getInt("type"));
+        this.resolved = resolved;
         this.value = object;
     }
 
@@ -114,7 +124,7 @@ public class ModalMapping
     @Nonnull
     public String getAsString()
     {
-        if (type != Component.Type.TEXT_INPUT)
+        if (type != TEXT_INPUT)
             typeError("String");
 
         return value.getString("value");
@@ -123,8 +133,18 @@ public class ModalMapping
     /**
      * The String list representation of this component.
      *
-     * <p>For {@link net.dv8tion.jda.api.components.selections.StringSelectMenu StringSelectMenus}, this returns
-     * the values chosen by the User.
+     * <p>Return values include:
+     * <ul>
+     *     <li>
+     *         For {@link net.dv8tion.jda.api.components.selections.StringSelectMenu StringSelectMenus},
+     *         this returns the values chosen by the User.
+     *     </li>
+     *     <li>
+     *         For {@link net.dv8tion.jda.api.components.selections.EntitySelectMenu EntitySelectMenus},
+     *         this returns the entity IDs chosen by the User.
+     *     </li>
+     * </ul>
+     * <p>
      *
      * <p>Use {@link #getType()} to check if this method can be used safely!
      *
@@ -136,12 +156,56 @@ public class ModalMapping
     @Nonnull
     public List<String> getAsStringList()
     {
-        if (type != Component.Type.STRING_SELECT)
+        if (type != STRING_SELECT)
             typeError("List<String>");
 
         return value.getArray("values")
                 .stream(DataArray::getString)
                 .collect(Helpers.toUnmodifiableList());
+    }
+
+    /**
+     * Returns this component's value as a list of entity IDs.
+     *
+     * <p>This is available if the component was an {@link net.dv8tion.jda.api.components.selections.EntitySelectMenu EntitySelectMenu}.
+     *
+     * <p>You can use {@link #getType()} and {@link Component.Type#isEntitySelectMenu()} to check if this method can be used safely.
+     *
+     * @throws IllegalStateException
+     *         If this ModalMapping cannot be represented as such
+     *
+     * @return This component's value as a list of entity IDs.
+     */
+    @Nonnull
+    public List<Long> getAsLongList()
+    {
+        if (!type.isEntitySelectMenu())
+            typeError("List<Long>");
+
+        return value.getArray("values")
+                .stream(DataArray::getLong)
+                .collect(Helpers.toUnmodifiableList());
+    }
+
+    /**
+     * Returns this component's value as a {@link Mentions} object.
+     *
+     * <p>This is available if the component was an {@link net.dv8tion.jda.api.components.selections.EntitySelectMenu EntitySelectMenu}.
+     *
+     * <p>You can use {@link #getType()} and {@link Component.Type#isEntitySelectMenu()} to check if this method can be used safely.
+     *
+     * @throws IllegalStateException
+     *         If this ModalMapping cannot be represented as such
+     *
+     * @return This component's value as a {@link Mentions} object.
+     */
+    @Nonnull
+    public Mentions getAsMentions()
+    {
+        if (!type.isEntitySelectMenu())
+            typeError("Mentions");
+
+        return new SelectMenuMentions(interaction.getJDA(), interaction.getInteractionEntityBuilder(), interaction.getGuild(), resolved, value.getArray("values"));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalMapping.java
@@ -32,9 +32,6 @@ import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Objects;
 
-import static net.dv8tion.jda.api.components.Component.Type.STRING_SELECT;
-import static net.dv8tion.jda.api.components.Component.Type.TEXT_INPUT;
-
 /**
  * ID/Value pair for a {@link net.dv8tion.jda.api.events.interaction.ModalInteractionEvent ModalInteractionEvent}.
  *
@@ -124,7 +121,7 @@ public class ModalMapping
     @Nonnull
     public String getAsString()
     {
-        if (type != TEXT_INPUT)
+        if (type != Component.Type.TEXT_INPUT)
             typeError("String");
 
         return value.getString("value");
@@ -156,7 +153,7 @@ public class ModalMapping
     @Nonnull
     public List<String> getAsStringList()
     {
-        if (type != STRING_SELECT)
+        if (type != Component.Type.STRING_SELECT)
             typeError("List<String>");
 
         return value.getArray("values")

--- a/src/main/java/net/dv8tion/jda/internal/components/selections/EntitySelectMenuImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/components/selections/EntitySelectMenuImpl.java
@@ -17,6 +17,7 @@
 package net.dv8tion.jda.internal.components.selections;
 
 import net.dv8tion.jda.api.components.Component;
+import net.dv8tion.jda.api.components.label.LabelChildComponentUnion;
 import net.dv8tion.jda.api.components.selections.EntitySelectMenu;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.utils.data.DataArray;
@@ -30,7 +31,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class EntitySelectMenuImpl extends SelectMenuImpl implements EntitySelectMenu
+public class EntitySelectMenuImpl extends SelectMenuImpl implements EntitySelectMenu, LabelChildComponentUnion
 {
     protected final Component.Type type;
     protected final EnumSet<ChannelType> channelTypes;

--- a/src/main/java/net/dv8tion/jda/internal/components/selections/EntitySelectMenuImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/components/selections/EntitySelectMenuImpl.java
@@ -36,7 +36,6 @@ public class EntitySelectMenuImpl extends SelectMenuImpl implements EntitySelect
     protected final Component.Type type;
     protected final EnumSet<ChannelType> channelTypes;
     protected final List<DefaultValue> defaultValues;
-    protected final Boolean required;
 
     public EntitySelectMenuImpl(DataObject data)
     {
@@ -50,16 +49,14 @@ public class EntitySelectMenuImpl extends SelectMenuImpl implements EntitySelect
                 .map(DefaultValue::fromData)
                 .collect(Helpers.toUnmodifiableList())
         ).orElse(Collections.emptyList());
-        this.required = data.isNull("required") ? null : data.getBoolean("required");
     }
 
     public EntitySelectMenuImpl(String id, int uniqueId, String placeholder, int minValues, int maxValues, boolean disabled, Type type, EnumSet<ChannelType> channelTypes, List<DefaultValue> defaultValues, Boolean required)
     {
-        super(id, uniqueId, placeholder, minValues, maxValues, disabled);
+        super(id, uniqueId, placeholder, minValues, maxValues, disabled, required);
         this.type = type;
         this.channelTypes = channelTypes;
         this.defaultValues = defaultValues;
-        this.required = required;
     }
 
     @Nonnull
@@ -109,12 +106,6 @@ public class EntitySelectMenuImpl extends SelectMenuImpl implements EntitySelect
         return defaultValues;
     }
 
-    @Override
-    public Boolean isRequired()
-    {
-        return required;
-    }
-
     @Nonnull
     @Override
     public DataObject toData()
@@ -124,8 +115,6 @@ public class EntitySelectMenuImpl extends SelectMenuImpl implements EntitySelect
             json.put("channel_types", DataArray.fromCollection(channelTypes.stream().map(ChannelType::getId).collect(Collectors.toList())));
         if (!defaultValues.isEmpty())
             json.put("default_values", DataArray.fromCollection(defaultValues));
-        if (required != null)
-            json.put("required", required);
         return json;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/components/selections/EntitySelectMenuImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/components/selections/EntitySelectMenuImpl.java
@@ -36,6 +36,7 @@ public class EntitySelectMenuImpl extends SelectMenuImpl implements EntitySelect
     protected final Component.Type type;
     protected final EnumSet<ChannelType> channelTypes;
     protected final List<DefaultValue> defaultValues;
+    protected final Boolean required;
 
     public EntitySelectMenuImpl(DataObject data)
     {
@@ -49,14 +50,16 @@ public class EntitySelectMenuImpl extends SelectMenuImpl implements EntitySelect
                 .map(DefaultValue::fromData)
                 .collect(Helpers.toUnmodifiableList())
         ).orElse(Collections.emptyList());
+        this.required = data.isNull("required") ? null : data.getBoolean("required");
     }
 
-    public EntitySelectMenuImpl(String id, int uniqueId, String placeholder, int minValues, int maxValues, boolean disabled, Type type, EnumSet<ChannelType> channelTypes, List<DefaultValue> defaultValues)
+    public EntitySelectMenuImpl(String id, int uniqueId, String placeholder, int minValues, int maxValues, boolean disabled, Type type, EnumSet<ChannelType> channelTypes, List<DefaultValue> defaultValues, Boolean required)
     {
         super(id, uniqueId, placeholder, minValues, maxValues, disabled);
         this.type = type;
         this.channelTypes = channelTypes;
         this.defaultValues = defaultValues;
+        this.required = required;
     }
 
     @Nonnull
@@ -106,6 +109,12 @@ public class EntitySelectMenuImpl extends SelectMenuImpl implements EntitySelect
         return defaultValues;
     }
 
+    @Override
+    public Boolean isRequired()
+    {
+        return required;
+    }
+
     @Nonnull
     @Override
     public DataObject toData()
@@ -115,6 +124,8 @@ public class EntitySelectMenuImpl extends SelectMenuImpl implements EntitySelect
             json.put("channel_types", DataArray.fromCollection(channelTypes.stream().map(ChannelType::getId).collect(Collectors.toList())));
         if (!defaultValues.isEmpty())
             json.put("default_values", DataArray.fromCollection(defaultValues));
+        if (required != null)
+            json.put("required", required);
         return json;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/components/selections/SelectMenuImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/components/selections/SelectMenuImpl.java
@@ -33,6 +33,7 @@ public abstract class SelectMenuImpl
     protected final int uniqueId;
     protected final int minValues, maxValues;
     protected final boolean disabled;
+    protected final Boolean required;
 
     public SelectMenuImpl(DataObject data)
     {
@@ -42,11 +43,12 @@ public abstract class SelectMenuImpl
             data.getString("placeholder", null),
             data.getInt("min_values", 1),
             data.getInt("max_values", 1),
-            data.getBoolean("disabled")
+            data.getBoolean("disabled"),
+            data.isNull("required") ? null : data.getBoolean("required")
         );
     }
 
-    public SelectMenuImpl(String id, int uniqueId, String placeholder, int minValues, int maxValues, boolean disabled)
+    public SelectMenuImpl(String id, int uniqueId, String placeholder, int minValues, int maxValues, boolean disabled, Boolean required)
     {
         this.id = id;
         this.uniqueId = uniqueId;
@@ -54,6 +56,7 @@ public abstract class SelectMenuImpl
         this.minValues = minValues;
         this.maxValues = maxValues;
         this.disabled = disabled;
+        this.required = required;
     }
 
     @Nonnull
@@ -98,6 +101,12 @@ public abstract class SelectMenuImpl
         return disabled;
     }
 
+    @Override
+    public Boolean isRequired()
+    {
+        return required;
+    }
+
     @Nonnull
     @Override
     public DataObject toData()
@@ -111,6 +120,8 @@ public abstract class SelectMenuImpl
         data.put("disabled", disabled);
         if (placeholder != null)
             data.put("placeholder", placeholder);
+        if (required != null)
+            data.put("required", required);
         return data;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/components/selections/StringSelectMenuImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/components/selections/StringSelectMenuImpl.java
@@ -31,20 +31,17 @@ import java.util.Objects;
 public class StringSelectMenuImpl extends SelectMenuImpl implements StringSelectMenu, LabelChildComponentUnion
 {
     private final List<SelectOption> options;
-    private final Boolean required;
 
     public StringSelectMenuImpl(DataObject data)
     {
         super(data);
         this.options = parseOptions(data.getArray("options"));
-        this.required = (Boolean) data.opt("required").orElse(null);
     }
 
     public StringSelectMenuImpl(String id, int uniqueId, String placeholder, int minValues, int maxValues, boolean disabled, List<SelectOption> options, Boolean required)
     {
-        super(id, uniqueId, placeholder, minValues, maxValues, disabled);
+        super(id, uniqueId, placeholder, minValues, maxValues, disabled, required);
         this.options = options;
-        this.required = required;
     }
 
     private static List<SelectOption> parseOptions(DataArray array)
@@ -77,24 +74,13 @@ public class StringSelectMenuImpl extends SelectMenuImpl implements StringSelect
         return Collections.unmodifiableList(options);
     }
 
-    @Override
-    public Boolean isRequired()
-    {
-        return required;
-    }
-
     @Nonnull
     @Override
     public DataObject toData()
     {
-        DataObject obj = super.toData()
+        return super.toData()
                 .put("type", Type.STRING_SELECT.getKey())
                 .put("options", DataArray.fromCollection(options));
-
-        if (required != null)
-            obj.put("required", required);
-
-        return obj;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/components/textdisplay/TextDisplayImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/components/textdisplay/TextDisplayImpl.java
@@ -17,6 +17,7 @@
 package net.dv8tion.jda.internal.components.textdisplay;
 
 import net.dv8tion.jda.api.components.MessageTopLevelComponentUnion;
+import net.dv8tion.jda.api.components.ModalTopLevelComponentUnion;
 import net.dv8tion.jda.api.components.container.ContainerChildComponentUnion;
 import net.dv8tion.jda.api.components.section.SectionContentComponentUnion;
 import net.dv8tion.jda.api.components.textdisplay.TextDisplay;
@@ -30,7 +31,8 @@ import java.util.Objects;
 
 public class TextDisplayImpl
         extends AbstractComponentImpl
-        implements TextDisplay, MessageTopLevelComponentUnion, ContainerChildComponentUnion, SectionContentComponentUnion
+        implements TextDisplay, MessageTopLevelComponentUnion, ModalTopLevelComponentUnion,
+        ContainerChildComponentUnion, SectionContentComponentUnion
 {
     private final int uniqueId;
     private final String content;

--- a/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
@@ -16,7 +16,6 @@
 
 package net.dv8tion.jda.internal.interactions;
 
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Entitlement;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
@@ -234,8 +233,14 @@ public class InteractionImpl implements Interaction
 
     @Nonnull
     @Override
-    public JDA getJDA()
+    public JDAImpl getJDA()
     {
         return api;
+    }
+
+    @Nonnull
+    public InteractionEntityBuilder getInteractionEntityBuilder()
+    {
+        return interactionEntityBuilder;
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/interactions/modal/ModalInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/modal/ModalInteractionImpl.java
@@ -47,9 +47,10 @@ public class ModalInteractionImpl extends DeferrableInteractionImpl implements M
 
         DataObject data = object.getObject("data");
         this.modalId = data.getString("custom_id");
+        DataObject resolved = data.optObject("resolved").orElseGet(DataObject::empty);
         this.mappings = data.optArray("components").orElseGet(DataArray::empty)
                 .stream(DataArray::getObject)
-                .map(ModalInteractionImpl::getMapping)
+                .map(component -> getMapping(component, resolved))
                 .filter(Objects::nonNull)
                 .collect(Helpers.toUnmodifiableList());
 
@@ -58,12 +59,12 @@ public class ModalInteractionImpl extends DeferrableInteractionImpl implements M
                 .orElse(null);
     }
 
-    private static ModalMapping getMapping(DataObject component)
+    private ModalMapping getMapping(DataObject component, DataObject resolved)
     {
         Component.Type type = Component.Type.fromKey(component.getInt("type"));
 
         if (type == Component.Type.LABEL)
-            return new ModalMapping(component.getObject("component"));
+            return new ModalMapping(this, resolved, component.getObject("component"));
 
         return null;
     }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This allows `EntitySelectMenu` and `TextDisplay` in modals and moves the `required` property to `SelectMenu`.

See https://github.com/discord/discord-api-docs/pull/7804
