### PR TITLE
Handle rate limit when requesting all members

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildMembersChunkHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildMembersChunkHandler.java
@@ -38,6 +38,8 @@ public class GuildMembersChunkHandler extends SocketHandler
     protected Long handleInternally(DataObject content)
     {
         final long guildId = content.getLong("guild_id");
+        api.getClient().getChunkingRateLimiter().onChunkReceived(guildId);
+
         DataArray members = content.getArray("members");
         GuildImpl guild = (GuildImpl) getJDA().getGuildById(guildId);
         if (guild != null)

--- a/src/main/java/net/dv8tion/jda/internal/handle/RateLimitedHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/RateLimitedHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.handle;
+
+import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.JDAImpl;
+import net.dv8tion.jda.internal.requests.WebSocketClient;
+import net.dv8tion.jda.internal.requests.WebSocketCode;
+
+public class RateLimitedHandler extends SocketHandler
+{
+    public RateLimitedHandler(JDAImpl api)
+    {
+        super(api);
+    }
+
+    @Override
+    protected Long handleInternally(DataObject content)
+    {
+        final int opcode = content.getInt("opcode");
+        final long retryAfter = Math.round(content.getDouble("retry_after") * 1000);
+        final DataObject meta = content.getObject("meta");
+        switch (opcode)
+        {
+        case WebSocketCode.MEMBER_CHUNK_REQUEST:
+            final long guildId = meta.getUnsignedLong("guild_id");
+            WebSocketClient.LOG.warn("Got rate limited from requesting member chunks of a guild. GuildId: {} Retry after: {}s",
+                    guildId, retryAfter);
+            api.getClient().getChunkingRateLimiter().onRateLimit(guildId, retryAfter);
+            break;
+        default:
+            WebSocketClient.LOG.warn("Unhandled rate limited opcode: {}", opcode);
+            break;
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketChunkingRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketChunkingRateLimiter.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.requests;
+
+import net.dv8tion.jda.api.utils.MiscUtil;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Helper class for the rate limiting logic specific to member chunking.
+ *
+ * <p>When the {@link WebSocketSendingThread} loop attempts to send a chunk request,
+ * it will:
+ * <ol>
+ *     <li>
+ *         Check if there is a chunk request in-flight for the specified guild
+ *         <ol>
+ *             <li>If there is, it will try again on the next loop</li>
+ *             <li>
+ *                 If not, it will check for a possible rate limit and:
+ *                 <ol>
+ *                     <li>If there is, it will try again on the next loop</li>
+ *                     <li>If not, it sends the WS message</li>
+ *                 </ol>
+ *             </li>
+ *         </ol>
+ *     </li>
+ * </ul>
+ */
+public class WebSocketChunkingRateLimiter
+{
+    private final ReentrantLock queueLock;
+    /** Guild ID -> Retry timestamp */
+    private final Map<Long, Long> rateLimits = new HashMap<>();
+    /** Guild ID */
+    private final Set<Long> awaitingResponses = new HashSet<>();
+
+    WebSocketChunkingRateLimiter(ReentrantLock queueLock)
+    {
+        this.queueLock = queueLock;
+    }
+
+    public void onRateLimit(long guildId, long retryAfter)
+    {
+        MiscUtil.locked(queueLock, () ->
+        {
+            rateLimits.put(guildId, System.currentTimeMillis() + retryAfter);
+            awaitingResponses.remove(guildId);
+        });
+    }
+
+    public void onChunkReceived(long guildId)
+    {
+        MiscUtil.locked(queueLock, () ->
+        {
+            awaitingResponses.remove(guildId);
+        });
+    }
+
+    /** Caller ({@link WebSocketSendingThread}) for methods below already holds the lock, but it doesn't hurt to be sure */
+    boolean isRateLimited(long guildId)
+    {
+        return MiscUtil.locked(queueLock, () ->
+        {
+            final Long retryAt = rateLimits.get(guildId);
+            return retryAt != null && retryAt > System.currentTimeMillis();
+        });
+    }
+
+    void setAwaitingResponse(long guildId)
+    {
+        MiscUtil.locked(queueLock, () ->
+        {
+            awaitingResponses.add(guildId);
+        });
+    }
+
+    boolean isAwaitingResponse(long guildId)
+    {
+        return MiscUtil.locked(queueLock, () -> awaitingResponses.contains(guildId));
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -114,6 +114,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     protected long identifyTime = 0;
 
     protected final TLongObjectMap<ConnectionRequest> queuedAudioConnections = MiscUtil.newLongMap();
+    protected final WebSocketChunkingRateLimiter chunkingRateLimiter = new WebSocketChunkingRateLimiter(queueLock);
     protected final Queue<DataObject> chunkSyncQueue = new ConcurrentLinkedQueue<>();
     protected final Queue<DataObject> ratelimitQueue = new ConcurrentLinkedQueue<>();
 
@@ -184,6 +185,11 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     public MemberChunkManager getChunkManager()
     {
         return chunkManager;
+    }
+
+    public WebSocketChunkingRateLimiter getChunkingRateLimiter()
+    {
+        return chunkingRateLimiter;
     }
 
     public void ready()
@@ -1366,6 +1372,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     protected void setupHandlers()
     {
         final SocketHandler.NOPHandler nopHandler =            new SocketHandler.NOPHandler(api);
+        handlers.put("RATE_LIMITED",                           new RateLimitedHandler(api));
         handlers.put("APPLICATION_COMMAND_PERMISSIONS_UPDATE", new ApplicationCommandPermissionsUpdateHandler(api));
         handlers.put("AUTO_MODERATION_RULE_CREATE",            new AutoModRuleHandler(api, "CREATE"));
         handlers.put("AUTO_MODERATION_RULE_UPDATE",            new AutoModRuleHandler(api, "UPDATE"));


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR handles the new rate limits when requesting all members of a guild, which can happen during startup if the chunking filter is set to `ALL`, or when explicitly loading all members, see https://discord.com/developers/docs/change-log#introducing-rate-limit-when-requesting-all-guild-members

When such a rate limit is encountered, the request will be automatically retried after the limit expires.

This PR is open for review, but is in draft as I could not trigger a rate limit yet to test it out.
