### PR TITLE
Improve error messages caused by entities relying on the cache to find themselves

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IPositionableChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IPositionableChannel.java
@@ -54,8 +54,11 @@ public interface IPositionableChannel extends GuildChannel {
         if (position > -1) {
             return position;
         }
-        throw new IllegalStateException("Somehow when determining position we never found the "
-                + getType().name() + " in the Guild's channels? wtf?");
+        throw new IllegalStateException(String.format(
+                "Could not determine position of %s channel (%d)\n"
+                        + "- Make sure you do not keep entities stored, prefer getting them by ID\n"
+                        + "- Check your bot is not processing events requiring channel positions after JDA receives events deleting this channel, this is typically caused when events are processed asynchronously",
+                getType().name(), getIdLong()));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
@@ -95,8 +95,11 @@ public class RoleImpl implements Role, RoleMixin<RoleImpl> {
             }
             i--;
         }
-        throw new IllegalStateException(
-                "Somehow when determining position we never found the role in the Guild's roles? wtf?");
+        throw new IllegalStateException(String.format(
+                "Could not determine position of role %d in guild %d\n"
+                        + "- Make sure you do not keep entities stored, prefer getting them by ID\n"
+                        + "- Check your bot is not processing events requiring role positions after JDA receives events deleting this role, this is typically caused when events are processed asynchronously",
+                getIdLong(), getGuild().getIdLong()));
     }
 
     @Override


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [X] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Should be a bit clearer when a deleted entity causes these issues.
