### PR TITLE
Fix copy paste error in Mentions#getMembers

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Mentions.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Mentions.java
@@ -295,7 +295,7 @@ public interface Mentions {
     /**
      * An immutable list of all mentioned {@link net.dv8tion.jda.api.entities.Member Members}.
      * <br>If none were mentioned, this list is empty. Elements are sorted in order of appearance. This only
-     * counts direct mentions of the role and not mentions through everyone mentions.
+     * counts direct mentions of the member and not mentions through roles or everyone mentions.
      *
      * <p>This is always empty in {@link PrivateChannel PrivateChannels} and {@link GroupChannel GroupChannels}.
      *


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [X] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes an error in the JavaDocs of Mentions, where in `getMembers()` it was falsely stated that the direct mentions of the _role_ are returned
