### PR TITLE
Fix deserialization of components without unfurled media

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/components/utils/ComponentDeserializer.java
+++ b/src/main/java/net/dv8tion/jda/api/components/utils/ComponentDeserializer.java
@@ -27,6 +27,7 @@ import net.dv8tion.jda.api.components.thumbnail.Thumbnail;
 import net.dv8tion.jda.api.components.tree.ComponentTree;
 import net.dv8tion.jda.api.components.tree.MessageComponentTree;
 import net.dv8tion.jda.api.components.tree.ModalComponentTree;
+import net.dv8tion.jda.api.exceptions.DataObjectParsingException;
 import net.dv8tion.jda.api.exceptions.ParsingException;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.data.DataArray;
@@ -55,11 +56,9 @@ import net.dv8tion.jda.internal.components.thumbnail.ThumbnailFileUpload;
 import net.dv8tion.jda.internal.components.thumbnail.ThumbnailImpl;
 import net.dv8tion.jda.internal.components.utils.ComponentsUtil;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -73,6 +72,7 @@ import javax.annotation.Nonnull;
 public class ComponentDeserializer {
     private static final String ATTACHMENT_SCHEMA = "attachment://";
     private final Map<String, FileUpload> files;
+    private final Set<DeserializerFeature> features;
 
     /**
      * Create a new deserializer instance with the provided files.
@@ -81,10 +81,24 @@ public class ComponentDeserializer {
      *        The implicit file uploads used by the components (see {@link ComponentSerializer#getFileUploads(Collection)})
      */
     public ComponentDeserializer(@Nonnull Collection<? extends FileUpload> files) {
+        this(files, Collections.emptySet());
+    }
+
+    /**
+     * Create a new deserializer instance with the provided files.
+     *
+     * @param files
+     *        The implicit file uploads used by the components (see {@link ComponentSerializer#getFileUploads(Collection)})
+     * @param features
+     *        Feature set of this deserializer
+     */
+    public ComponentDeserializer(
+            @Nonnull Collection<? extends FileUpload> files, @Nonnull Collection<DeserializerFeature> features) {
         this.files = new LinkedHashMap<>(files.size());
         for (FileUpload file : files) {
             this.files.put(file.getName(), file);
         }
+        this.features = Helpers.copyEnumSet(DeserializerFeature.class, features);
     }
 
     /**
@@ -293,7 +307,8 @@ public class ComponentDeserializer {
 
     @Nonnull
     private Thumbnail toThumbnail(@Nonnull DataObject data) {
-        String url = data.getObject("media").getString("url");
+        DataObject media = data.getObject("media");
+        String url = media.getString("url");
         if (url.startsWith(ATTACHMENT_SCHEMA)) {
             return new ThumbnailFileUpload(
                     data.getInt("id", -1),
@@ -302,14 +317,27 @@ public class ComponentDeserializer {
                     data.getBoolean("spoiler"));
         }
 
+        if (features.contains(DeserializerFeature.REQUIRE_MEDIA_PROXY_URL)) {
+            if (media.isNull("proxy_url")) {
+                throw new DataObjectParsingException(data, "media.proxy_url is missing or null");
+            }
+        }
+
         return new ThumbnailImpl(data);
     }
 
     @Nonnull
     private FileDisplay toFileDisplay(@Nonnull DataObject data) {
-        String url = data.getObject("file").getString("url");
+        DataObject file = data.getObject("file");
+        String url = file.getString("url");
         if (url.startsWith(ATTACHMENT_SCHEMA)) {
             return new FileDisplayFileUpload(data.getInt("id", -1), getFileByUri(url), data.getBoolean("spoiler"));
+        }
+
+        if (features.contains(DeserializerFeature.REQUIRE_MEDIA_PROXY_URL)) {
+            if (file.isNull("proxy_url")) {
+                throw new DataObjectParsingException(data, "file.proxy_url is missing or null");
+            }
         }
 
         return new FileDisplayImpl(data);
@@ -326,10 +354,17 @@ public class ComponentDeserializer {
 
     @Nonnull
     private MediaGalleryItem toMediaGalleryItem(@Nonnull DataObject data) {
-        String url = data.getObject("media").getString("url");
+        DataObject media = data.getObject("media");
+        String url = media.getString("url");
         if (url.startsWith(ATTACHMENT_SCHEMA)) {
             return new MediaGalleryItemFileUpload(
                     getFileByUri(url), data.getString("description", null), data.getBoolean("spoiler"));
+        }
+
+        if (features.contains(DeserializerFeature.REQUIRE_MEDIA_PROXY_URL)) {
+            if (media.isNull("proxy_url")) {
+                throw new DataObjectParsingException(data, "media.proxy_url is missing or null");
+            }
         }
 
         return new MediaGalleryItemImpl(data);
@@ -341,5 +376,15 @@ public class ComponentDeserializer {
         FileUpload file = files.get(name);
         Checks.check(file != null, "File for URI %s is missing", uri);
         return file;
+    }
+
+    /**
+     * Flags which changes the behavior of the deserializer.
+     */
+    public enum DeserializerFeature {
+        /**
+         * Throws {@link DataObjectParsingException} for {@link net.dv8tion.jda.api.components.ResolvedMedia ResolvedMedia} objects without a `proxy_url`.
+         */
+        REQUIRE_MEDIA_PROXY_URL,
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/components/filedisplay/FileDisplayImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/components/filedisplay/FileDisplayImpl.java
@@ -49,7 +49,7 @@ public class FileDisplayImpl extends AbstractComponentImpl
         this(
                 data.getInt("id", -1),
                 data.getObject("file").getString("url"),
-                new ResolvedMediaImpl(data.getObject("file")),
+                data.getObject("file").isNull("proxy_url") ? null : new ResolvedMediaImpl(data.getObject("file")),
                 data.getBoolean("spoiler", false));
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/components/mediagallery/MediaGalleryItemImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/components/mediagallery/MediaGalleryItemImpl.java
@@ -45,7 +45,7 @@ public class MediaGalleryItemImpl implements MediaGalleryItem, FileContainerMixi
         this(
                 obj.getObject("media").getString("url"),
                 obj.getString("description", null),
-                new ResolvedMediaImpl(obj.getObject("media")),
+                obj.getObject("media").isNull("proxy_url") ? null : new ResolvedMediaImpl(obj.getObject("media")),
                 obj.getBoolean("spoiler", false));
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/components/thumbnail/ThumbnailImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/components/thumbnail/ThumbnailImpl.java
@@ -49,7 +49,7 @@ public class ThumbnailImpl extends AbstractComponentImpl
         this(
                 data.getInt("id", -1),
                 data.getObject("media").getString("url"),
-                new ResolvedMediaImpl(data.getObject("media")),
+                data.getObject("media").isNull("proxy_url") ? null : new ResolvedMediaImpl(data.getObject("media")),
                 data.getString("description", null),
                 data.getBoolean("spoiler", false));
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -104,8 +104,8 @@ public class EntityBuilder extends AbstractEntityBuilder {
     public static final String MISSING_CHANNEL = "MISSING_CHANNEL";
     public static final String MISSING_USER = "MISSING_USER";
     public static final String UNKNOWN_MESSAGE_TYPE = "UNKNOWN_MESSAGE_TYPE";
-    public static final ComponentDeserializer DEFAULT_COMPONENT_DESERIALIZER =
-            new ComponentDeserializer(Collections.emptyList());
+    public static final ComponentDeserializer DEFAULT_COMPONENT_DESERIALIZER = new ComponentDeserializer(
+            Collections.emptyList(), EnumSet.of(ComponentDeserializer.DeserializerFeature.REQUIRE_MEDIA_PROXY_URL));
     private static final Set<String> richGameFields;
 
     static {

--- a/src/test/java/net/dv8tion/jda/test/components/ComponentDeserializerTest.java
+++ b/src/test/java/net/dv8tion/jda/test/components/ComponentDeserializerTest.java
@@ -16,27 +16,43 @@
 
 package net.dv8tion.jda.test.components;
 
+import net.dv8tion.jda.api.components.Component;
 import net.dv8tion.jda.api.components.MessageTopLevelComponentUnion;
+import net.dv8tion.jda.api.components.filedisplay.FileDisplay;
+import net.dv8tion.jda.api.components.mediagallery.MediaGallery;
+import net.dv8tion.jda.api.components.mediagallery.MediaGalleryItem;
+import net.dv8tion.jda.api.components.thumbnail.Thumbnail;
 import net.dv8tion.jda.api.components.tree.ComponentTree;
 import net.dv8tion.jda.api.components.tree.MessageComponentTree;
 import net.dv8tion.jda.api.components.tree.ModalComponentTree;
 import net.dv8tion.jda.api.components.utils.ComponentDeserializer;
 import net.dv8tion.jda.api.components.utils.ComponentSerializer;
+import net.dv8tion.jda.api.exceptions.DataObjectParsingException;
+import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.data.DataArray;
+import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.components.filedisplay.FileDisplayImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.*;
 
 class ComponentDeserializerTest extends AbstractComponentTest {
+
+    private static final String EXAMPLE_FILE_URL =
+            "https://github.com/discord-jda/JDA/blob/970afafb99ff35cd55cb91eb167022253247bce4/assets/readme/logo.png";
+    private static final FileUpload EMPTY_FILE = FileUpload.fromData(new byte[0], "logo.png");
+
     @Test
     void testDeserializeMessageComponentTree() throws Exception {
         ComponentDeserializer deserializer = new ComponentDeserializer(Collections.emptyList());
@@ -75,5 +91,54 @@ class ComponentDeserializerTest extends AbstractComponentTest {
             case MESSAGE -> MessageComponentTree.class;
             case MODAL -> ModalComponentTree.class;
         };
+    }
+
+    @MethodSource("componentsWithUrlMediaToBeSent")
+    @ParameterizedTest
+    void testRequireMediaProxyFeature(DataObject json) {
+        ComponentDeserializer lenientDeserializer = new ComponentDeserializer(List.of());
+        ComponentDeserializer strictDeserializer = new ComponentDeserializer(
+                List.of(), EnumSet.of(ComponentDeserializer.DeserializerFeature.REQUIRE_MEDIA_PROXY_URL));
+
+        assertThatNoException().isThrownBy(() -> lenientDeserializer.deserializeAs(Component.class, json));
+
+        assertThatExceptionOfType(DataObjectParsingException.class)
+                .isThrownBy(() -> strictDeserializer.deserializeAs(Component.class, json))
+                .withMessageContaining("proxy_url is missing or null");
+    }
+
+    static List<Arguments> componentsWithUrlMediaToBeSent() {
+        ComponentSerializer serializer = new ComponentSerializer();
+
+        MediaGallery gallery = MediaGallery.of(MediaGalleryItem.fromUrl(EXAMPLE_FILE_URL));
+        FileDisplay fileDisplay = new FileDisplayImpl(EXAMPLE_FILE_URL);
+        Thumbnail thumbnail = Thumbnail.fromUrl(EXAMPLE_FILE_URL);
+
+        return List.of(
+                Arguments.argumentSet("Media gallery", serializer.serialize(gallery)),
+                Arguments.argumentSet("File display", serializer.serialize(fileDisplay)),
+                Arguments.argumentSet("Thumbnail", serializer.serialize(thumbnail)));
+    }
+
+    @MethodSource("componentsWithLocalMediaToBeSent")
+    @ParameterizedTest
+    void testRequireMediaProxyFeatureIsNotCheckedForLocalAttachments(DataObject json) {
+        ComponentDeserializer strictDeserializer = new ComponentDeserializer(
+                List.of(EMPTY_FILE), EnumSet.of(ComponentDeserializer.DeserializerFeature.REQUIRE_MEDIA_PROXY_URL));
+
+        assertThatNoException().isThrownBy(() -> strictDeserializer.deserializeAs(Component.class, json));
+    }
+
+    static List<Arguments> componentsWithLocalMediaToBeSent() {
+        ComponentSerializer serializer = new ComponentSerializer();
+
+        MediaGallery gallery = MediaGallery.of(MediaGalleryItem.fromUrl("attachment://logo.png"));
+        FileDisplay fileDisplay = FileDisplay.fromFileName("logo.png");
+        Thumbnail thumbnail = Thumbnail.fromUrl("attachment://logo.png");
+
+        return List.of(
+                Arguments.argumentSet("Media gallery", serializer.serialize(gallery)),
+                Arguments.argumentSet("File display", serializer.serialize(fileDisplay)),
+                Arguments.argumentSet("Thumbnail", serializer.serialize(thumbnail)));
     }
 }


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [X] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #3076

## Description

This makes deserialization of unfurled media optional if `proxy_url` (a required property sent only from real messages) isn't set.

To restore the old behavior, a new `ComponentDeserializer.DeserializationFeature.REQUIRE_MEDIA_PROXY_URL` was added, it can be passed to the constructor.

Deserialization of inbound messages uses the new flag, making the behavior unchanged from current releases.