### PR TITLE
fix: handle integer sound ids in voice channel effects

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/channel/VoiceChannelEffect.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/VoiceChannelEffect.java
@@ -34,7 +34,7 @@ public class VoiceChannelEffect {
     private final long userId;
     private final EmojiUnion emoji;
     private final Animation animation;
-    private final SoundboardSound soundboardSound;
+    private final long soundboardSoundId;
     private final double soundVolume;
 
     public VoiceChannelEffect(
@@ -42,13 +42,13 @@ public class VoiceChannelEffect {
             long userId,
             EmojiUnion emoji,
             Animation animation,
-            SoundboardSound soundboardSound,
+            long soundboardSoundId,
             double soundVolume) {
         this.channel = channel;
         this.userId = userId;
         this.emoji = emoji;
         this.animation = animation;
-        this.soundboardSound = soundboardSound;
+        this.soundboardSoundId = soundboardSoundId;
         this.soundVolume = soundVolume;
     }
 
@@ -124,13 +124,34 @@ public class VoiceChannelEffect {
     }
 
     /**
-     * The soundboard sound sent with the effect, this is only present for soundboard sound effects.
+     * The ID of the soundboard sound sent with the effect, this is only present for soundboard sound effects.
+     *
+     * @return The soundboard sound ID, or {@code null}
+     */
+    @Nullable
+    public String getSoundboardSoundId() {
+        return soundboardSoundId == 0 ? null : Long.toUnsignedString(soundboardSoundId);
+    }
+
+    /**
+     * The ID of the soundboard sound sent with the effect, this is only present for soundboard sound effects.
+     *
+     * @return The soundboard sound ID, or {@code 0}
+     */
+    public long getSoundboardSoundIdLong() {
+        return soundboardSoundId;
+    }
+
+    /**
+     * The soundboard sound sent with the effect, this is only present for guild soundboard sound effects.
+     * <br>This may be {@code null} for default sounds or uncached guild sounds, use {@link #getSoundboardSoundId()}
+     * to get the ID instead.
      *
      * @return The soundboard sound sent with the effect, or {@code null}
      */
     @Nullable
     public SoundboardSound getSoundboardSound() {
-        return soundboardSound;
+        return soundboardSoundId == 0 ? null : channel.getGuild().getSoundboardSoundById(soundboardSoundId);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/VoiceChannelEffect.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/VoiceChannelEffect.java
@@ -144,8 +144,7 @@ public class VoiceChannelEffect {
 
     /**
      * The soundboard sound sent with the effect, this is only present for guild soundboard sound effects.
-     * <br>This may be {@code null} for default sounds or uncached guild sounds, use {@link #getSoundboardSoundId()}
-     * to get the ID instead.
+     * <br>This may be {@code null} for default sounds or {@linkplain net.dv8tion.jda.api.utils.cache.CacheFlag#SOUNDBOARD_SOUNDS uncached} guild sounds, you can use {@link #getSoundboardSoundId()} in these cases.
      *
      * @return The soundboard sound sent with the effect, or {@code null}
      */

--- a/src/main/java/net/dv8tion/jda/internal/handle/VoiceChannelEffectSendHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/VoiceChannelEffectSendHandler.java
@@ -16,7 +16,6 @@
 
 package net.dv8tion.jda.internal.handle;
 
-import net.dv8tion.jda.api.entities.SoundboardSound;
 import net.dv8tion.jda.api.entities.channel.VoiceChannelEffect;
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
 import net.dv8tion.jda.api.entities.emoji.EmojiUnion;
@@ -64,12 +63,11 @@ public class VoiceChannelEffectSendHandler extends SocketHandler {
                     return new VoiceChannelEffect.Animation(animationId, type);
                 })
                 .orElse(null);
-        SoundboardSound soundboardSound =
-                content.isNull("sound_id") ? null : guild.getSoundboardSoundById(content.getUnsignedLong("sound_id"));
+        long soundboardSoundId = content.getUnsignedLong("sound_id", 0);
         double soundVolume = content.getDouble("sound_volume", 0);
 
         VoiceChannelEffect effect =
-                new VoiceChannelEffect(channel, userId, emoji, animation, soundboardSound, soundVolume);
+                new VoiceChannelEffect(channel, userId, emoji, animation, soundboardSoundId, soundVolume);
 
         api.handleEvent(new VoiceChannelEffectSendEvent(api, responseNumber, effect));
 

--- a/src/main/java/net/dv8tion/jda/internal/handle/VoiceChannelEffectSendHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/VoiceChannelEffectSendHandler.java
@@ -64,9 +64,8 @@ public class VoiceChannelEffectSendHandler extends SocketHandler {
                     return new VoiceChannelEffect.Animation(animationId, type);
                 })
                 .orElse(null);
-        SoundboardSound soundboardSound = content.opt("sound_id")
-                .map(id -> guild.getSoundboardSoundById((String) id))
-                .orElse(null);
+        SoundboardSound soundboardSound =
+                content.isNull("sound_id") ? null : guild.getSoundboardSoundById(content.getUnsignedLong("sound_id"));
         double soundVolume = content.getDouble("sound_volume", 0);
 
         VoiceChannelEffect effect =


### PR DESCRIPTION
Fixes a ClassCastException in VOICE_CHANNEL_EFFECT_SEND by resolving sound_id as an unsigned long instead of assuming a string. Integer/default sound IDs no longer crash the handler and unresolved sounds remain null.