### PR TITLE
Fix Guild#invalidate not removing thread channels from global cache

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -176,7 +176,7 @@ public class GuildImpl implements Guild {
 
         ChannelCacheViewImpl<Channel> channelsView = getJDA().getChannelsView();
         try (UnlockHook hook = channelsView.writeLock()) {
-            getChannels().forEach(channel -> channelsView.remove(channel.getType(), channel.getIdLong()));
+            this.channelCache.forEachUnordered(channel -> channelsView.remove(channel.getType(), channel.getIdLong()));
         }
 
         // Clear audio connection
@@ -194,7 +194,7 @@ public class GuildImpl implements Guild {
         // Use a new HashSet so that we don't actually modify the Member map so it doesn't affect
         // Guild#getMembers for the leave event.
         TLongSet memberIds = getMembersView().keySet(); // copies keys
-        getJDA().getGuildCache().stream()
+        getJDA().getGuildsView().stream()
                 .map(GuildImpl.class::cast)
                 .forEach(g -> memberIds.removeAll(g.getMembersView().keySet()));
         // Remember, everything left in memberIds is removed from the userMap

--- a/src/test/java/net/dv8tion/jda/test/entities/guild/GuildTest.java
+++ b/src/test/java/net/dv8tion/jda/test/entities/guild/GuildTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.test.entities.guild;
+
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+import net.dv8tion.jda.api.utils.cache.CacheFlag;
+import net.dv8tion.jda.internal.entities.GuildImpl;
+import net.dv8tion.jda.internal.utils.cache.ChannelCacheViewImpl;
+import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
+import net.dv8tion.jda.test.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class GuildTest extends IntegrationTest {
+    private static EnumSet<ChannelType> getGuildChannelTypes() {
+        return EnumSet.copyOf(
+                Arrays.stream(ChannelType.values()).filter(ChannelType::isGuild).toList());
+    }
+
+    @Test
+    void testInvalidateRemovesAllChannelTypes() {
+        ChannelCacheViewImpl<?> globalChannelCache = mock(ChannelCacheViewImpl.class);
+        doReturn(globalChannelCache).when(jda).getChannelsView();
+        doReturn(EnumSet.noneOf(CacheFlag.class)).when(jda).getCacheFlags();
+        doAnswer(Answers.RETURNS_MOCKS).when(jda).getGuildsView();
+        doAnswer(Answers.RETURNS_MOCKS).when(jda).getClient();
+        doAnswer(Answers.RETURNS_MOCKS).when(jda).getAudioManagersView();
+        doAnswer(Answers.RETURNS_MOCKS).when(jda).getSelfUser();
+        doReturn(new SnowflakeCacheViewImpl<>(User.class, User::getName))
+                .when(jda)
+                .getUsersView();
+
+        GuildImpl guild = new GuildImpl(jda, 42L);
+        EnumSet<ChannelType> channelTypes = getGuildChannelTypes();
+
+        for (ChannelType type : channelTypes) {
+            GuildChannel channel = mock(GuildChannel.class);
+            doReturn(type).when(channel).getType();
+            doReturn((long) type.getId()).when(channel).getIdLong();
+            guild.getChannelView().put(channel);
+        }
+
+        guild.invalidate();
+
+        assertThat(channelTypes)
+                .allSatisfy(type -> verify(globalChannelCache, times(1)).remove(eq(type), anyLong()));
+    }
+}


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [x] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes a bug in GuildImpl#invalidate that caused thread channels to be skipped in the cleanup.
