### PR TITLE
Add support for image descriptions in embeds

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -567,6 +567,50 @@ public class EmbedBuilder {
     }
 
     /**
+     * Sets the Thumbnail of the embed.
+     *
+     * <p><b><a href="https://raw.githubusercontent.com/discord-jda/JDA/assets/assets/docs/embeds/06-setThumbnail.png">Example</a></b>
+     *
+     * <p><b>Uploading images with Embeds</b>
+     * <br>When uploading an <u>image</u>
+     * (using {@link net.dv8tion.jda.api.entities.channel.middleman.MessageChannel#sendFiles(net.dv8tion.jda.api.utils.FileUpload...) MessageChannel.sendFiles(...)})
+     * you can reference said image using the specified filename as URI {@code attachment://filename.ext}.
+     *
+     * <p><u>Example</u>
+     * {@snippet lang="java":
+     * MessageChannel channel; // = reference of a MessageChannel
+     * EmbedBuilder embed = new EmbedBuilder();
+     * InputStream file = new URL("https://http.cat/500").openStream();
+     * embed.setThumbnail("attachment://cat.png", "Image of a cat") // we specify this in sendFile as "cat.png"
+     *      .setDescription("This is a cute cat :3");
+     * channel.sendFiles(FileUpload.fromData(file, "cat.png")).setEmbeds(embed.build()).queue();
+     * }
+     *
+     * @param  url
+     *         the url of the thumbnail of the embed
+     * @param  description
+     *         The description of the thumbnail, used as alt-text for accessibility
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If null is provided</li>
+     *             <li>If the character limit for {@code url}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the provided {@code url} is not a properly formatted http or https url.</li>
+     *         </ul>
+     *
+     * @return the builder after the thumbnail has been set
+     */
+    @Nonnull
+    public EmbedBuilder setThumbnail(@Nonnull String url, @Nonnull String description) {
+        Checks.notEmpty(url, "Url");
+        Checks.notNull(description, "Description");
+        urlCheck(url);
+        this.thumbnail = new MessageEmbed.Thumbnail(url, null, 0, 0, description, null, null, 0);
+        return this;
+    }
+
+    /**
      * Sets the Image of the embed.
      *
      * <p><b><a href="https://raw.githubusercontent.com/discord-jda/JDA/assets/assets/docs/embeds/11-setImage.png">Example</a></b>

--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -612,6 +612,52 @@ public class EmbedBuilder {
     }
 
     /**
+     * Sets the Image of the embed.
+     *
+     * <p><b><a href="https://raw.githubusercontent.com/discord-jda/JDA/assets/assets/docs/embeds/11-setImage.png">Example</a></b>
+     *
+     * <p><b>Uploading images with Embeds</b>
+     * <br>When uploading an <u>image</u>
+     * (using {@link net.dv8tion.jda.api.entities.channel.middleman.MessageChannel#sendFiles(net.dv8tion.jda.api.utils.FileUpload...) MessageChannel.sendFiles(...)})
+     * you can reference said image using the specified filename as URI {@code attachment://filename.ext}.
+     *
+     * <p><u>Example</u>
+     * {@snippet lang="java":
+     * MessageChannel channel; // = reference of a MessageChannel
+     * EmbedBuilder embed = new EmbedBuilder();
+     * InputStream file = new URL("https://http.cat/500").openStream();
+     * embed.setImage("attachment://cat.png", "Image of a cat") // we specify this in sendFile as "cat.png"
+     *      .setDescription("This is a cute cat :3");
+     * channel.sendFiles(FileUpload.fromData(file, "cat.png")).setEmbeds(embed.build()).queue();
+     * }
+     *
+     * @param  url
+     *         the url of the image of the embed
+     * @param  description
+     *         The description of the image, used as alt-text for accessibility
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If null is provided</li>
+     *             <li>If the character limit for {@code url}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the provided {@code url} is not a properly formatted http or https url.</li>
+     *         </ul>
+     *
+     * @return the builder after the image has been set
+     *
+     * @see    net.dv8tion.jda.api.entities.channel.middleman.MessageChannel#sendFiles(net.dv8tion.jda.api.utils.FileUpload...) MessageChannel.sendFiles(...)
+     */
+    @Nonnull
+    public EmbedBuilder setImage(@Nonnull String url, @Nonnull String description) {
+        Checks.notEmpty(url, "Url");
+        Checks.notNull(description, "Description");
+        urlCheck(url);
+        this.image = new MessageEmbed.ImageInfo(url, null, 0, 0, description, null, null, 0);
+        return this;
+    }
+
+    /**
      * Sets the Author of the embed. The author appears in the top left of the embed and can have a small
      * image beside it along with the author's name being made clickable by way of providing a url.
      * This convenience method just sets the name.

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -1080,20 +1080,23 @@ public class MessageEmbed implements SerializableData {
 
         @Override
         public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
             if (!(obj instanceof ImageInfo)) {
                 return false;
             }
             ImageInfo image = (ImageInfo) obj;
-            return image == this
-                    || (Objects.equals(image.url, url)
-                            && Objects.equals(image.proxyUrl, proxyUrl)
-                            && image.width == width
-                            && image.height == height);
+            return Objects.equals(image.getUrl(), url)
+                    && Objects.equals(image.getDescription(), description)
+                    && Objects.equals(image.getProxyUrl(), proxyUrl)
+                    && image.getWidth() == width
+                    && image.getHeight() == height;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(url, proxyUrl, width, height);
+            return Objects.hash(url, description, proxyUrl, width, height);
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -535,7 +535,11 @@ public class MessageEmbed implements SerializableData {
                 obj.put("footer", footerObj);
             }
             if (image != null) {
-                obj.put("image", DataObject.empty().put("url", image.getUrl()));
+                DataObject imageData = DataObject.empty().put("url", image.getUrl());
+                if (!Helpers.isEmpty(image.getDescription())) {
+                    imageData.put("description", image.getDescription());
+                }
+                obj.put("image", imageData);
             }
             if (!fields.isEmpty()) {
                 DataArray fieldsArray = DataArray.empty();

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -496,7 +496,11 @@ public class MessageEmbed implements SerializableData {
                 obj.put("color", color & 0xFFFFFF);
             }
             if (thumbnail != null) {
-                obj.put("thumbnail", DataObject.empty().put("url", thumbnail.getUrl()));
+                DataObject thumbnailData = DataObject.empty().put("url", thumbnail.getUrl());
+                if (!Helpers.isEmpty(thumbnail.getDescription())) {
+                    thumbnailData.put("description", thumbnail.getDescription());
+                }
+                obj.put("thumbnail", thumbnailData);
             }
             if (siteProvider != null) {
                 DataObject siteProviderObj = DataObject.empty();
@@ -701,20 +705,23 @@ public class MessageEmbed implements SerializableData {
 
         @Override
         public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
             if (!(obj instanceof Thumbnail)) {
                 return false;
             }
             Thumbnail thumbnail = (Thumbnail) obj;
-            return thumbnail == this
-                    || (Objects.equals(thumbnail.url, url)
-                            && Objects.equals(thumbnail.proxyUrl, proxyUrl)
-                            && thumbnail.width == width
-                            && thumbnail.height == height);
+            return Objects.equals(thumbnail.getUrl(), url)
+                    && Objects.equals(thumbnail.getDescription(), description)
+                    && Objects.equals(thumbnail.getProxyUrl(), proxyUrl)
+                    && thumbnail.getWidth() == width
+                    && thumbnail.getHeight() == height;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(url, proxyUrl, width, height);
+            return Objects.hash(url, description, proxyUrl, width, height);
         }
     }
 

--- a/src/test/java/net/dv8tion/jda/test/entities/message/EmbedBuilderTest.java
+++ b/src/test/java/net/dv8tion/jda/test/entities/message/EmbedBuilderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.test.entities.message;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.test.AbstractSnapshotTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EmbedBuilderTest extends AbstractSnapshotTest {
+    @Test
+    void imageAltText() {
+        MessageEmbed embed = new EmbedBuilder()
+                .setImage("https://jda.wiki/image.png", "Test Image")
+                .build();
+
+        assertThat(embed.getLength()).isEqualTo(0);
+        assertThat(embed.isSendable()).isTrue();
+        assertWithSnapshot(embed);
+    }
+}

--- a/src/test/java/net/dv8tion/jda/test/entities/message/EmbedBuilderTest.java
+++ b/src/test/java/net/dv8tion/jda/test/entities/message/EmbedBuilderTest.java
@@ -28,6 +28,7 @@ class EmbedBuilderTest extends AbstractSnapshotTest {
     void imageAltText() {
         MessageEmbed embed = new EmbedBuilder()
                 .setImage("https://jda.wiki/image.png", "Test Image")
+                .setThumbnail("https://jda.wiki/image.png", "Test Thumbnail")
                 .build();
 
         assertThat(embed.getLength()).isEqualTo(0);

--- a/src/test/resources/net/dv8tion/jda/test/entities/message/EmbedBuilderTest/imageAltText.json
+++ b/src/test/resources/net/dv8tion/jda/test/entities/message/EmbedBuilderTest/imageAltText.json
@@ -2,5 +2,9 @@
   "image" : {
     "description" : "Test Image",
     "url" : "https://jda.wiki/image.png"
+  },
+  "thumbnail" : {
+    "description" : "Test Thumbnail",
+    "url" : "https://jda.wiki/image.png"
   }
 }

--- a/src/test/resources/net/dv8tion/jda/test/entities/message/EmbedBuilderTest/imageAltText.json
+++ b/src/test/resources/net/dv8tion/jda/test/entities/message/EmbedBuilderTest/imageAltText.json
@@ -1,0 +1,6 @@
+{
+  "image" : {
+    "description" : "Test Image",
+    "url" : "https://jda.wiki/image.png"
+  }
+}


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [x] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #3100

## Description

You can now set the alt text for embed images.
