### PR TITLE
Add toolchain resolver to formatter-recipes

### DIFF
--- a/formatter-recipes/settings.gradle.kts
+++ b/formatter-recipes/settings.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "formatter-recipes"
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [ ] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: build logic

## Description

On a fresh install Gradle won't build with the toolchain resolver plugin only in the root project. It probably flew under the radar as  existing contributors already had the toolchain installed.

Otherwise the build will fail with this:
```
Could not determine the dependencies of task ':rewriteDryRun'.
> Could not resolve all dependencies for configuration ':rewrite'.
   > Could not resolve net.dv8tion.jda:formatter-recipes.
     Required by:
         root project 'JDA'
      > Failed to calculate the value of task ':formatter-recipes:compileJava' property 'javaCompiler'.
         > Cannot find a Java installation on your machine (Linux 7.0.9-arch1-1 amd64) matching: {languageVersion=25, vendor=Eclipse Temurin, implementation=vendor-specific, nativeImageCapable=false}. Toolchain download repositories have not been configured.
```
