### PR TITLE
Update Kotlin version used by formatter

### DIFF
--- a/formatter-recipes/build.gradle.kts
+++ b/formatter-recipes/build.gradle.kts
@@ -1,6 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.jvm.JvmTargetValidationMode
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 /*
  * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
  *
@@ -18,7 +15,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
  */
 
 plugins {
-    kotlin("jvm") version "2.2.21"
+    alias(libs.plugins.kotlin)
 }
 
 repositories {
@@ -39,8 +36,4 @@ java {
         languageVersion.set(JavaLanguageVersion.of(25))
         vendor.set(JvmVendorSpec.ADOPTIUM)
     }
-}
-
-tasks.withType(KotlinCompile::class).configureEach {
-    jvmTargetValidationMode.set(JvmTargetValidationMode.IGNORE)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ junit-java8 = [
 errorprone = "net.ltgt.errorprone:5.1.0"
 ideax = "org.jetbrains.gradle.plugin.idea-ext:1.4.1"
 jreleaser = "org.jreleaser:1.24.0"
+kotlin = "org.jetbrains.kotlin.jvm:2.4.0"
 openrewrite = "org.openrewrite.rewrite:7.34.0"
 shadow = "com.gradleup.shadow:9.4.2"
 # @pin Version 8.0.0 is incompatible with jreleaser (see https://github.com/jreleaser/jreleaser/issues/1989)


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [X] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [X] Other: Formatter

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Moved the plugin to the version catalog, updated it, and changed JVM target validation to the default. This removes warnings since the version used had no idea about Java 25.
