### PR TITLE
 Specify `Message#getStartedThread` returns `null` if the thread is being created

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2434,7 +2434,16 @@ public interface Message extends ISnowflake, Formattable {
 
     /**
      * Returns a possibly {@code null} {@link ThreadChannel ThreadChannel} that was started from this message.
-     * This can be {@code null} due to no ThreadChannel being started from it or the ThreadChannel later being deleted.
+     *
+     * <p>This can be {@code null} if:
+     * <ul>
+     *     <li>No ThreadChannel was started from it</li>
+     *     <li>The ThreadChannel was deleted</li>
+     *     <li>This message is from a create/update event in response to a thread being created,
+     *         which happens <b>before</b> the thread is created.
+     *     <br>To know about new threads, listen to {@link net.dv8tion.jda.api.events.channel.ChannelCreateEvent ChannelCreateEvent} instead.
+     *     </li>
+     * </ul>
      *
      * @return The {@link ThreadChannel ThreadChannel} that was started from this message.
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageType.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageType.java
@@ -114,7 +114,7 @@ public enum MessageType {
     GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING(17, true, true),
 
     /**
-     * This is sent to a TextChannel when a message thread is created if the message from which the thread was started is "old".
+     * This is sent to a TextChannel when a message thread is created on no specific message, or if the message from which the thread was started is "old".
      * The definition of "old" is loose, but is currently a very liberal definition.
      */
     THREAD_CREATED(18, true, true),


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [X] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #3114 

## Description

This documents threads being created after the system message is created, or after the starter message's flags are updated.
