### PR TITLE
Add partial API for Discord's messages resource

### DIFF
--- a/src/main/java/net/dv8tion/jda/annotations/ExperimentalRestApi.java
+++ b/src/main/java/net/dv8tion/jda/annotations/ExperimentalRestApi.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.annotations;
+
+import kotlin.RequiresOptIn;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks a REST API that is considered unstable and might change in a future release,
+ * in other words, the application/binary interface can change at any time.
+ */
+@Documented
+@RequiresOptIn(level = RequiresOptIn.Level.ERROR)
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
+public @interface ExperimentalRestApi {}

--- a/src/main/java/net/dv8tion/jda/api/endpoints/ApiEndpoints.java
+++ b/src/main/java/net/dv8tion/jda/api/endpoints/ApiEndpoints.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.endpoints;
+
+import net.dv8tion.jda.annotations.ExperimentalRestApi;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.internal.endpoints.MessageApiImpl;
+import net.dv8tion.jda.internal.utils.Checks;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Entrypoint for REST-only APIs.
+ *
+ * <h3>Stability note</h3>
+ * The API and ABI of this interface and all objects returned by it, are <b>subject to changes without warning</b>.
+ */
+@ExperimentalRestApi
+public interface ApiEndpoints {
+    /**
+     * Creates a {@link MessageApi} instance to interact with the messages of the provided channel.
+     *
+     * @param  jda
+     *         The JDA instance
+     * @param  channelId
+     *         The ID of the channel to interact in
+     *
+     * @throws IllegalArgumentException
+     *         If an argument is {@code null}
+     *
+     * @return The {@link MessageApi} instance
+     *
+     * @see <a href="https://docs.discord.com/developers/resources/message" target="_blank">Message Resource - Discord docs</a>
+     */
+    @Nonnull
+    static MessageApi messages(@Nonnull JDA jda, long channelId) {
+        Checks.notNull(jda, "JDA");
+        return new MessageApiImpl(jda, Long.toUnsignedString(channelId));
+    }
+
+    /**
+     * Creates a {@link MessageApi} instance to interact with the messages of the provided channel.
+     *
+     * @param  jda
+     *         The JDA instance
+     * @param  channelId
+     *         The ID of the channel to interact in
+     *
+     * @throws IllegalArgumentException
+     *         If an argument is {@code null}
+     *
+     * @return The {@link MessageApi} instance
+     *
+     * @see <a href="https://docs.discord.com/developers/resources/message" target="_blank">Message Resource - Discord docs</a>
+     */
+    @Nonnull
+    static MessageApi messages(@Nonnull JDA jda, @Nonnull String channelId) {
+        Checks.notNull(jda, "JDA");
+        Checks.isSnowflake(channelId, "Channel ID");
+        return new MessageApiImpl(jda, channelId);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/endpoints/ApiEndpoints.java
+++ b/src/main/java/net/dv8tion/jda/api/endpoints/ApiEndpoints.java
@@ -26,7 +26,7 @@ import javax.annotation.Nonnull;
 /**
  * Entrypoint for REST-only APIs.
  *
- * <h3>Stability note</h3>
+ * <h2>Stability note</h2>
  * The API and ABI of this interface and all objects returned by it, are <b>subject to changes without warning</b>.
  */
 @ExperimentalRestApi

--- a/src/main/java/net/dv8tion/jda/api/endpoints/MessageApi.java
+++ b/src/main/java/net/dv8tion/jda/api/endpoints/MessageApi.java
@@ -1,0 +1,671 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.endpoints;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.components.Component;
+import net.dv8tion.jda.api.components.MessageTopLevelComponent;
+import net.dv8tion.jda.api.components.tree.ComponentTree;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
+import net.dv8tion.jda.api.utils.FileUpload;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import net.dv8tion.jda.api.utils.messages.MessagePollData;
+import net.dv8tion.jda.api.utils.messages.MessageRequest;
+import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.*;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
+/**
+ * Common interface for API requests relative to messages.
+ *
+ * <h3>Stability note</h3>
+ * The API and ABI of this interface is <b>subject to changes without warning</b>.
+ *
+ * @see ApiEndpoints#messages(JDA, long)
+ * @see net.dv8tion.jda.api.entities.channel.middleman.MessageChannel MessageChannel
+ */
+public interface MessageApi {
+    /**
+     * Send a message to this channel.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>if this channel was deleted</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         cannot message the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         does not share any Guilds with the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
+     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
+     *     <br>If this message was blocked by the harmful link filter</li>
+     * </ul>
+     *
+     * @param  text
+     *         The message content
+     *
+     * @throws UnsupportedOperationException
+     *         If this is a {@link PrivateChannel} and the recipient is a bot
+     * @throws IllegalArgumentException
+     *         If the content is null or longer than {@value Message#MAX_CONTENT_LENGTH} characters
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link GuildMessageChannel} and this account does not have
+     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
+     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
+     *         If this is a {@link net.dv8tion.jda.api.entities.detached.IDetachableEntity#isDetached() detached} channel
+     *
+     * @return {@link MessageCreateAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    MessageCreateAction sendMessage(@Nonnull CharSequence text);
+
+    /**
+     * Send a message to this channel.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>if this channel was deleted</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         cannot message the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         does not share any Guilds with the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
+     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
+     *     <br>If this message was blocked by the harmful link filter</li>
+     * </ul>
+     *
+     * @param  msg
+     *         The {@link MessageCreateData} to send
+     *
+     * @throws UnsupportedOperationException
+     *         If this is a {@link PrivateChannel} and the recipient is a bot
+     * @throws IllegalArgumentException
+     *         If null is provided
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link GuildMessageChannel} and this account does not have
+     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
+     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
+     *         If this is a {@link net.dv8tion.jda.api.entities.detached.IDetachableEntity#isDetached() detached} channel
+     *
+     * @return {@link MessageCreateAction}
+     *
+     * @see    net.dv8tion.jda.api.utils.messages.MessageCreateBuilder MessageCreateBuilder
+     */
+    @Nonnull
+    @CheckReturnValue
+    MessageCreateAction sendMessage(@Nonnull MessageCreateData msg);
+
+    /**
+     * Send a message to this channel.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>if this channel was deleted</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         cannot message the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         does not share any Guilds with the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
+     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
+     *     <br>If this message was blocked by the harmful link filter</li>
+     * </ul>
+     *
+     * @param  format
+     *         Format string for the message content
+     * @param  args
+     *         Format arguments for the content
+     *
+     * @throws UnsupportedOperationException
+     *         If this is a {@link PrivateChannel} and the recipient is a bot
+     * @throws IllegalArgumentException
+     *         If the format string is null or the resulting content is longer than {@value Message#MAX_CONTENT_LENGTH} characters
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link GuildMessageChannel} and this account does not have
+     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
+     * @throws java.util.IllegalFormatException
+     *         If a format string contains an illegal syntax, a format
+     *         specifier that is incompatible with the given arguments,
+     *         insufficient arguments given the format string, or other
+     *         illegal conditions.  For specification of all possible
+     *         formatting errors, see the <a href="../util/Formatter.html#detail">Details</a> section of the
+     *         formatter class specification.
+     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
+     *         If this is a {@link net.dv8tion.jda.api.entities.detached.IDetachableEntity#isDetached() detached} channel
+     *
+     * @return {@link MessageCreateAction}
+     */
+    @Nonnull
+    @FormatMethod
+    @CheckReturnValue
+    default MessageCreateAction sendMessageFormat(@Nonnull @FormatString String format, @Nonnull Object... args) {
+        Checks.notEmpty(format, "Format");
+        return sendMessage(String.format(format, args));
+    }
+
+    /**
+     * Send a message to this channel.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>if this channel was deleted</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         cannot message the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         does not share any Guilds with the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
+     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
+     *     <br>If this message was blocked by the harmful link filter</li>
+     * </ul>
+     *
+     * <p><b>Example: Attachment Images</b>
+     * {@snippet lang="java":
+     * // Make a file upload instance which refers to a local file called "myFile.png"
+     * // The second parameter "image.png" is the filename we tell discord to use for the attachment
+     * FileUpload file = FileUpload.fromData(new File("myFile.png"), "image.png");
+     *
+     * // Build a message embed which refers to this attachment by the given name.
+     * // Note that this must be the same name as configured for the attachment, not your local filename.
+     * MessageEmbed embed = new EmbedBuilder()
+     *   .setDescription("This is my cute cat :)")
+     *   .setImage("attachment://image.png") // refer to the file by using the "attachment://" schema with the filename we gave it above
+     *   .build();
+     *
+     * channel.sendMessageEmbeds(embed) // send the embed
+     *        .addFiles(file) // add the file as attachment
+     *        .queue();
+     * }
+     *
+     * @param  embed
+     *         {@link MessageEmbed} to send
+     * @param  other
+     *         Additional {@link MessageEmbed MessageEmbeds} to use (up to {@value Message#MAX_EMBED_COUNT})
+     *
+     * @throws UnsupportedOperationException
+     *         If this is a {@link PrivateChannel} and the recipient is a bot
+     * @throws IllegalArgumentException
+     *         If any of the embeds are null, more than {@value Message#MAX_EMBED_COUNT}, or longer than {@link MessageEmbed#EMBED_MAX_LENGTH_BOT}.
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link GuildMessageChannel} and this account does not have
+     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
+     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
+     *         If this is a {@link net.dv8tion.jda.api.entities.detached.IDetachableEntity#isDetached() detached} channel
+     *
+     * @return {@link MessageCreateAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    default MessageCreateAction sendMessageEmbeds(@Nonnull MessageEmbed embed, @Nonnull MessageEmbed... other) {
+        Checks.notNull(embed, "MessageEmbeds");
+        Checks.noneNull(other, "MessageEmbeds");
+        List<MessageEmbed> embeds = new ArrayList<>(1 + other.length);
+        embeds.add(embed);
+        Collections.addAll(embeds, other);
+        return sendMessageEmbeds(embeds);
+    }
+
+    /**
+     * Send a message to this channel.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>if this channel was deleted</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
+     *     <br>If this is a {@link PrivateChannel PrivateChannel} and the currently logged in account
+     *         cannot message the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         does not share any Guilds with the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
+     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
+     *     <br>If this message was blocked by the harmful link filter</li>
+     * </ul>
+     *
+     * <p><b>Example: Attachment Images</b>
+     * {@snippet lang="java":
+     * // Make a file upload instance which refers to a local file called "myFile.png"
+     * // The second parameter "image.png" is the filename we tell discord to use for the attachment
+     * FileUpload file = FileUpload.fromData(new File("myFile.png"), "image.png");
+     *
+     * // Build a message embed which refers to this attachment by the given name.
+     * // Note that this must be the same name as configured for the attachment, not your local filename.
+     * MessageEmbed embed = new EmbedBuilder()
+     *   .setDescription("This is my cute cat :)")
+     *   .setImage("attachment://image.png") // refer to the file by using the "attachment://" schema with the filename we gave it above
+     *   .build();
+     *
+     * channel.sendMessageEmbeds(Collections.singleton(embed)) // send the embeds
+     *        .addFiles(file) // add the file as attachment
+     *        .queue();
+     * }
+     *
+     * @param  embeds
+     *         {@link MessageEmbed MessageEmbeds} to use (up to {@value Message#MAX_EMBED_COUNT})
+     *
+     * @throws UnsupportedOperationException
+     *         If this is a {@link PrivateChannel} and the recipient is a bot
+     * @throws IllegalArgumentException
+     *         If any of the embeds are null, more than {@value Message#MAX_EMBED_COUNT}, or longer than {@link MessageEmbed#EMBED_MAX_LENGTH_BOT}.
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link GuildMessageChannel} and this account does not have
+     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
+     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
+     *         If this is a {@link net.dv8tion.jda.api.entities.detached.IDetachableEntity#isDetached() detached} channel
+     *
+     * @return {@link MessageCreateAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    MessageCreateAction sendMessageEmbeds(@Nonnull Collection<? extends MessageEmbed> embeds);
+
+    /**
+     * Send a message to this channel.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>if this channel was deleted</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
+     *     <br>If this is a {@link PrivateChannel} and the currently logged in account
+     *         cannot message the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         does not share any Guilds with the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
+     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
+     *     <br>If this message was blocked by the harmful link filter</li>
+     * </ul>
+     *
+     * @param  components
+     *         The {@link MessageTopLevelComponent MessageTopLevelComponents} to send,
+     *         can contain up to {@value Message#MAX_COMPONENT_COUNT} V1 components.
+     *         There are no limits for {@linkplain MessageRequest#isUsingComponentsV2() V2 components}
+     *         outside the {@linkplain Message#MAX_COMPONENT_COUNT_IN_COMPONENT_TREE total tree size} ({@value Message#MAX_COMPONENT_COUNT_IN_COMPONENT_TREE}).
+     *
+     * @throws UnsupportedOperationException
+     *         If this is a {@link PrivateChannel} and the recipient is a bot
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If {@code null} is provided</li>
+     *             <li>If any of the provided components are not {@linkplain Component.Type#isMessageCompatible() compatible with messages}</li>
+     *         </ul>
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link GuildMessageChannel} and this account does not have
+     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
+     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
+     *         If this is a {@link net.dv8tion.jda.api.entities.detached.IDetachableEntity#isDetached() detached} channel
+     *
+     * @return {@link MessageCreateAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    MessageCreateAction sendMessageComponents(@Nonnull Collection<? extends MessageTopLevelComponent> components);
+
+    /**
+     * Send a message to this channel.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>if this channel was deleted</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
+     *     <br>If this is a {@link PrivateChannel} and the currently logged in account
+     *         cannot message the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         does not share any Guilds with the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
+     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
+     *     <br>If this message was blocked by the harmful link filter</li>
+     * </ul>
+     *
+     * @param  component
+     *         The {@link MessageTopLevelComponent} to send
+     * @param  other
+     *         Additional {@link MessageTopLevelComponent MessageTopLevelComponents} to send,
+     *         can contain up to {@value Message#MAX_COMPONENT_COUNT} V1 components.
+     *         There are no limits for {@linkplain MessageRequest#isUsingComponentsV2() V2 components}
+     *         outside the {@linkplain Message#MAX_COMPONENT_COUNT_IN_COMPONENT_TREE total tree size} ({@value Message#MAX_COMPONENT_COUNT_IN_COMPONENT_TREE}).
+     *
+     * @throws UnsupportedOperationException
+     *         If this is a {@link PrivateChannel} and the recipient is a bot
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If {@code null} is provided</li>
+     *             <li>If any of the provided components are not {@linkplain Component.Type#isMessageCompatible() compatible with messages}</li>
+     *         </ul>
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link GuildMessageChannel} and this account does not have
+     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
+     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
+     *         If this is a {@link net.dv8tion.jda.api.entities.detached.IDetachableEntity#isDetached() detached} channel
+     *
+     * @return {@link MessageCreateAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    default MessageCreateAction sendMessageComponents(
+            @Nonnull MessageTopLevelComponent component, @Nonnull MessageTopLevelComponent... other) {
+        Checks.notNull(component, "MessageTopLevelComponent");
+        Checks.noneNull(other, "MessageTopLevelComponents");
+        return sendMessageComponents(Helpers.mergeVararg(component, other));
+    }
+
+    /**
+     * Send a message to this channel.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>if this channel was deleted</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
+     *     <br>If this is a {@link PrivateChannel} and the currently logged in account
+     *         cannot message the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         does not share any Guilds with the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
+     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
+     *     <br>If this message was blocked by the harmful link filter</li>
+     * </ul>
+     *
+     * @param  tree
+     *         The {@link ComponentTree} to send,
+     *         containing up to {@value Message#MAX_COMPONENT_COUNT} V1 components.
+     *         There are no limits for {@linkplain MessageRequest#isUsingComponentsV2() V2 components}
+     *         outside the {@linkplain Message#MAX_COMPONENT_COUNT_IN_COMPONENT_TREE total tree size} ({@value Message#MAX_COMPONENT_COUNT_IN_COMPONENT_TREE}).
+     *
+     * @throws UnsupportedOperationException
+     *         If this is a {@link PrivateChannel} and the recipient is a bot
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If {@code null} is provided</li>
+     *             <li>If any of the provided components are not {@linkplain Component.Type#isMessageCompatible() compatible with messages}</li>
+     *         </ul>
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link GuildMessageChannel} and this account does not have
+     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
+     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
+     *         If this is a {@link net.dv8tion.jda.api.entities.detached.IDetachableEntity#isDetached() detached} channel
+     *
+     * @return {@link MessageCreateAction}
+     *
+     * @see    net.dv8tion.jda.api.components.tree.MessageComponentTree MessageComponentTree
+     */
+    @Nonnull
+    @CheckReturnValue
+    default MessageCreateAction sendMessageComponents(@Nonnull ComponentTree<? extends MessageTopLevelComponent> tree) {
+        Checks.notNull(tree, "ComponentTree");
+        return sendMessageComponents(tree.getComponents());
+    }
+
+    /**
+     * Send a message to this channel.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>if this channel was deleted</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
+     *     <br>If this is a {@link PrivateChannel} and the currently logged in account
+     *         cannot message the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         does not share any Guilds with the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
+     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
+     *     <br>If this message was blocked by the harmful link filter</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#POLL_INVALID_CHANNEL_TYPE POLL_INVALID_CHANNEL_TYPE}
+     *     <br>This channel does not allow polls</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#POLL_WITH_UNUSABLE_EMOJI POLL_WITH_UNUSABLE_EMOJI}
+     *     <br>This poll uses an external emoji that the bot is not allowed to use</li>
+     * </ul>
+     *
+     * @param  poll
+     *         The poll to send
+     *
+     * @throws UnsupportedOperationException
+     *         If this is a {@link PrivateChannel} and the recipient is a bot
+     * @throws IllegalArgumentException
+     *         If the poll is null
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link GuildMessageChannel} and this account does not have
+     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
+     *
+     * @return {@link MessageCreateAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    MessageCreateAction sendMessagePoll(@Nonnull MessagePollData poll);
+
+    /**
+     * Send a message to this channel.
+     *
+     * <p><b>Resource Handling Note:</b> Once the request is handed off to the requester, for example when you call {@link RestAction#queue()},
+     * the requester will automatically clean up all opened files by itself. You are only responsible to close them yourself if it is never handed off properly.
+     * For instance, if an exception occurs after using {@link FileUpload#fromData(File)}, before calling {@link RestAction#queue()}.
+     * You can safely use a try-with-resources to handle this, since {@link FileUpload#close()} becomes ineffective once the request is handed off.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>if this channel was deleted</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         cannot message the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         does not share any Guilds with the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
+     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
+     *     <br>If this message was blocked by the harmful link filter</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#REQUEST_ENTITY_TOO_LARGE REQUEST_ENTITY_TOO_LARGE}
+     *     <br>If the total sum of uploaded bytes exceeds the guild's {@link Guild#getMaxFileSize() upload limit}</li>
+     * </ul>
+     *
+     * <p><b>Example: Attachment Images</b>
+     * {@snippet lang="java":
+     * // Make a file upload instance which refers to a local file called "myFile.png"
+     * // The second parameter "image.png" is the filename we tell discord to use for the attachment
+     * FileUpload file = FileUpload.fromData(new File("myFile.png"), "image.png");
+     *
+     * // Build a message embed which refers to this attachment by the given name.
+     * // Note that this must be the same name as configured for the attachment, not your local filename.
+     * MessageEmbed embed = new EmbedBuilder()
+     *   .setDescription("This is my cute cat :)")
+     *   .setImage("attachment://image.png") // refer to the file by using the "attachment://" schema with the filename we gave it above
+     *   .build();
+     *
+     * channel.sendFiles(Collections.singleton(file)) // send the file upload
+     *        .addEmbeds(embed) // add the embed you want to reference the file with
+     *        .queue();
+     * }
+     *
+     * @param  files
+     *         The {@link FileUpload FileUploads} to attach to the message
+     *
+     * @throws UnsupportedOperationException
+     *         If this is a {@link PrivateChannel} and the recipient is a bot
+     * @throws IllegalArgumentException
+     *         If null is provided
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link GuildMessageChannel} and this account does not have
+     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
+     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
+     *         If this is a {@link net.dv8tion.jda.api.entities.detached.IDetachableEntity#isDetached() detached} channel
+     *
+     * @return {@link MessageCreateAction}
+     *
+     * @see    FileUpload#fromData(InputStream, String)
+     */
+    @Nonnull
+    @CheckReturnValue
+    MessageCreateAction sendFiles(@Nonnull Collection<? extends FileUpload> files);
+
+    /**
+     * Send a message to this channel.
+     *
+     * <p><b>Resource Handling Note:</b> Once the request is handed off to the requester, for example when you call {@link RestAction#queue()},
+     * the requester will automatically clean up all opened files by itself. You are only responsible to close them yourself if it is never handed off properly.
+     * For instance, if an exception occurs after using {@link FileUpload#fromData(File)}, before calling {@link RestAction#queue()}.
+     * You can safely use a try-with-resources to handle this, since {@link FileUpload#close()} becomes ineffective once the request is handed off.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>if this channel was deleted</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
+     *     <br>If this is a {@link PrivateChannel PrivateChannel} and the currently logged in account
+     *         cannot message the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
+     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
+     *         does not share any Guilds with the recipient User</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
+     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
+     *     <br>If this message was blocked by the harmful link filter</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#REQUEST_ENTITY_TOO_LARGE REQUEST_ENTITY_TOO_LARGE}
+     *     <br>If the total sum of uploaded bytes exceeds the guild's {@link Guild#getMaxFileSize() upload limit}</li>
+     * </ul>
+     *
+     * <p><b>Example: Attachment Images</b>
+     * {@snippet lang="java":
+     * // Make a file upload instance which refers to a local file called "myFile.png"
+     * // The second parameter "image.png" is the filename we tell discord to use for the attachment
+     * FileUpload file = FileUpload.fromData(new File("myFile.png"), "image.png");
+     *
+     * // Build a message embed which refers to this attachment by the given name.
+     * // Note that this must be the same name as configured for the attachment, not your local filename.
+     * MessageEmbed embed = new EmbedBuilder()
+     *   .setDescription("This is my cute cat :)")
+     *   .setImage("attachment://image.png") // refer to the file by using the "attachment://" schema with the filename we gave it above
+     *   .build();
+     *
+     * channel.sendFiles(file) // send the file upload
+     *        .addEmbeds(embed) // add the embed you want to reference the file with
+     *        .queue();
+     * }
+     *
+     * @param  files
+     *         The {@link FileUpload FileUploads} to attach to the message
+     *
+     * @throws UnsupportedOperationException
+     *         If this is a {@link PrivateChannel} and the recipient is a bot
+     * @throws IllegalArgumentException
+     *         If null is provided
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link GuildMessageChannel} and this account does not have
+     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
+     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
+     *         If this is a {@link net.dv8tion.jda.api.entities.detached.IDetachableEntity#isDetached() detached} channel
+     *
+     * @return {@link MessageCreateAction}
+     *
+     * @see    FileUpload#fromData(InputStream, String)
+     */
+    @Nonnull
+    @CheckReturnValue
+    default MessageCreateAction sendFiles(@Nonnull FileUpload... files) {
+        Checks.notEmpty(files, "File Collection");
+        Checks.noneNull(files, "Files");
+        return sendFiles(Arrays.asList(files));
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/endpoints/MessageApi.java
+++ b/src/main/java/net/dv8tion/jda/api/endpoints/MessageApi.java
@@ -46,7 +46,7 @@ import javax.annotation.Nonnull;
 /**
  * Common interface for API requests relative to messages.
  *
- * <h3>Stability note</h3>
+ * <h2>Stability note</h2>
  * The API and ABI of this interface is <b>subject to changes without warning</b>.
  *
  * @see ApiEndpoints#messages(JDA, long)

--- a/src/main/java/net/dv8tion/jda/api/endpoints/package-info.java
+++ b/src/main/java/net/dv8tion/jda/api/endpoints/package-info.java
@@ -17,7 +17,7 @@
 /**
  * Contains REST-only interfaces to work with the Discord API.
  *
- * <h3>Stability note</h3>
+ * <h2>Stability note</h2>
  * The API and ABI of all contained classes are <b>subject to changes without warning</b>.
  *
  * @see net.dv8tion.jda.api.endpoints.ApiEndpoints

--- a/src/main/java/net/dv8tion/jda/api/endpoints/package-info.java
+++ b/src/main/java/net/dv8tion/jda/api/endpoints/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains REST-only interfaces to work with the Discord API.
+ *
+ * <h3>Stability note</h3>
+ * The API and ABI of all contained classes are <b>subject to changes without warning</b>.
+ *
+ * @see net.dv8tion.jda.api.endpoints.ApiEndpoints
+ */
+package net.dv8tion.jda.api.endpoints;

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -557,7 +557,8 @@ public interface Message extends ISnowflake, Formattable {
     /**
      * Whether this message instance has an available {@link #getChannel()}.
      *
-     * <p>This can be {@code false} for messages sent via webhooks, or in the context of interactions.
+     * <p>This can be {@code false} for messages sent via webhooks, or in the context of interactions,
+     * or if the message was created by a REST-only API and the channel isn't in our cache (typically due to sharding).
      *
      * @return True, if {@link #getChannel()} is available
      */
@@ -626,7 +627,8 @@ public interface Message extends ISnowflake, Formattable {
      * <br>This is different from {@link #isFromGuild()}, which checks whether the message was sent in a guild.
      * This method describes whether {@link #getGuild()} is usable.
      *
-     * <p>This can be {@code false} for messages sent via webhooks, or in the context of interactions.
+     * <p>This can be {@code false} for messages sent via webhooks, or in the context of interactions,
+     * or if the message was created by a REST-only API and the channel isn't in our cache (typically due to sharding).
      *
      * @return True, if {@link #getGuild()} is provided
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/middleman/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/middleman/MessageChannel.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.components.actionrow.ActionRow;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.components.selections.SelectMenu;
 import net.dv8tion.jda.api.components.tree.ComponentTree;
+import net.dv8tion.jda.api.endpoints.MessageApi;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.concrete.GroupChannel;
@@ -54,7 +55,6 @@ import net.dv8tion.jda.internal.requests.restaction.pagination.PinnedMessagePagi
 import net.dv8tion.jda.internal.requests.restaction.pagination.PollVotersPaginationActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.pagination.ReactionPaginationActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
-import net.dv8tion.jda.internal.utils.Helpers;
 
 import java.io.File;
 import java.io.InputStream;
@@ -97,7 +97,7 @@ import javax.annotation.Nonnull;
  * @see TextChannel
  * @see PrivateChannel
  */
-public interface MessageChannel extends Channel, Formattable {
+public interface MessageChannel extends Channel, MessageApi, Formattable {
     /**
      * The id for the most recent message sent
      * in this current MessageChannel.
@@ -311,329 +311,31 @@ public interface MessageChannel extends Channel, Formattable {
         return list;
     }
 
-    /**
-     * Send a message to this channel.
-     *
-     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
-     *     <br>if this channel was deleted</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         cannot message the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         does not share any Guilds with the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
-     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
-     *     <br>If this message was blocked by the harmful link filter</li>
-     * </ul>
-     *
-     * @param  text
-     *         The message content
-     *
-     * @throws UnsupportedOperationException
-     *         If this is a {@link PrivateChannel} and the recipient is a bot
-     * @throws IllegalArgumentException
-     *         If the content is null or longer than {@value Message#MAX_CONTENT_LENGTH} characters
-     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If this is a {@link GuildMessageChannel} and this account does not have
-     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
-     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
-     *         If this entity is {@link #isDetached() detached}
-     *
-     * @return {@link MessageCreateAction}
-     */
     @Nonnull
+    @Override
     @CheckReturnValue
     default MessageCreateAction sendMessage(@Nonnull CharSequence text) {
         Checks.notNull(text, "Content");
         return new MessageCreateActionImpl(this).setContent(text.toString());
     }
 
-    /**
-     * Send a message to this channel.
-     *
-     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
-     *     <br>if this channel was deleted</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         cannot message the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         does not share any Guilds with the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
-     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
-     *     <br>If this message was blocked by the harmful link filter</li>
-     * </ul>
-     *
-     * @param  msg
-     *         The {@link MessageCreateData} to send
-     *
-     * @throws UnsupportedOperationException
-     *         If this is a {@link PrivateChannel} and the recipient is a bot
-     * @throws IllegalArgumentException
-     *         If null is provided
-     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If this is a {@link GuildMessageChannel} and this account does not have
-     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
-     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
-     *         If this entity is {@link #isDetached() detached}
-     *
-     * @return {@link MessageCreateAction}
-     *
-     * @see    net.dv8tion.jda.api.utils.messages.MessageCreateBuilder MessageCreateBuilder
-     */
     @Nonnull
+    @Override
     @CheckReturnValue
     default MessageCreateAction sendMessage(@Nonnull MessageCreateData msg) {
         Checks.notNull(msg, "Message");
         return new MessageCreateActionImpl(this).applyData(msg);
     }
 
-    /**
-     * Send a message to this channel.
-     *
-     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
-     *     <br>if this channel was deleted</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         cannot message the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         does not share any Guilds with the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
-     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
-     *     <br>If this message was blocked by the harmful link filter</li>
-     * </ul>
-     *
-     * @param  format
-     *         Format string for the message content
-     * @param  args
-     *         Format arguments for the content
-     *
-     * @throws UnsupportedOperationException
-     *         If this is a {@link PrivateChannel} and the recipient is a bot
-     * @throws IllegalArgumentException
-     *         If the format string is null or the resulting content is longer than {@value Message#MAX_CONTENT_LENGTH} characters
-     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If this is a {@link GuildMessageChannel} and this account does not have
-     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
-     * @throws java.util.IllegalFormatException
-     *         If a format string contains an illegal syntax, a format
-     *         specifier that is incompatible with the given arguments,
-     *         insufficient arguments given the format string, or other
-     *         illegal conditions.  For specification of all possible
-     *         formatting errors, see the <a href="../util/Formatter.html#detail">Details</a> section of the
-     *         formatter class specification.
-     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
-     *         If this entity is {@link #isDetached() detached}
-     *
-     * @return {@link MessageCreateAction}
-     */
     @Nonnull
-    @FormatMethod
-    @CheckReturnValue
-    default MessageCreateAction sendMessageFormat(@Nonnull @FormatString String format, @Nonnull Object... args) {
-        Checks.notEmpty(format, "Format");
-        return sendMessage(String.format(format, args));
-    }
-
-    /**
-     * Send a message to this channel.
-     *
-     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
-     *     <br>if this channel was deleted</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         cannot message the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         does not share any Guilds with the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
-     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
-     *     <br>If this message was blocked by the harmful link filter</li>
-     * </ul>
-     *
-     * <p><b>Example: Attachment Images</b>
-     * {@snippet lang="java":
-     * // Make a file upload instance which refers to a local file called "myFile.png"
-     * // The second parameter "image.png" is the filename we tell discord to use for the attachment
-     * FileUpload file = FileUpload.fromData(new File("myFile.png"), "image.png");
-     *
-     * // Build a message embed which refers to this attachment by the given name.
-     * // Note that this must be the same name as configured for the attachment, not your local filename.
-     * MessageEmbed embed = new EmbedBuilder()
-     *   .setDescription("This is my cute cat :)")
-     *   .setImage("attachment://image.png") // refer to the file by using the "attachment://" schema with the filename we gave it above
-     *   .build();
-     *
-     * channel.sendMessageEmbeds(embed) // send the embed
-     *        .addFiles(file) // add the file as attachment
-     *        .queue();
-     * }
-     *
-     * @param  embed
-     *         {@link MessageEmbed} to send
-     * @param  other
-     *         Additional {@link MessageEmbed MessageEmbeds} to use (up to {@value Message#MAX_EMBED_COUNT})
-     *
-     * @throws UnsupportedOperationException
-     *         If this is a {@link PrivateChannel} and the recipient is a bot
-     * @throws IllegalArgumentException
-     *         If any of the embeds are null, more than {@value Message#MAX_EMBED_COUNT}, or longer than {@link MessageEmbed#EMBED_MAX_LENGTH_BOT}.
-     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If this is a {@link GuildMessageChannel} and this account does not have
-     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
-     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
-     *         If this entity is {@link #isDetached() detached}
-     *
-     * @return {@link MessageCreateAction}
-     */
-    @Nonnull
-    @CheckReturnValue
-    default MessageCreateAction sendMessageEmbeds(@Nonnull MessageEmbed embed, @Nonnull MessageEmbed... other) {
-        Checks.notNull(embed, "MessageEmbeds");
-        Checks.noneNull(other, "MessageEmbeds");
-        List<MessageEmbed> embeds = new ArrayList<>(1 + other.length);
-        embeds.add(embed);
-        Collections.addAll(embeds, other);
-        return new MessageCreateActionImpl(this).setEmbeds(embeds);
-    }
-
-    /**
-     * Send a message to this channel.
-     *
-     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
-     *     <br>if this channel was deleted</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
-     *     <br>If this is a {@link PrivateChannel PrivateChannel} and the currently logged in account
-     *         cannot message the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         does not share any Guilds with the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
-     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
-     *     <br>If this message was blocked by the harmful link filter</li>
-     * </ul>
-     *
-     * <p><b>Example: Attachment Images</b>
-     * {@snippet lang="java":
-     * // Make a file upload instance which refers to a local file called "myFile.png"
-     * // The second parameter "image.png" is the filename we tell discord to use for the attachment
-     * FileUpload file = FileUpload.fromData(new File("myFile.png"), "image.png");
-     *
-     * // Build a message embed which refers to this attachment by the given name.
-     * // Note that this must be the same name as configured for the attachment, not your local filename.
-     * MessageEmbed embed = new EmbedBuilder()
-     *   .setDescription("This is my cute cat :)")
-     *   .setImage("attachment://image.png") // refer to the file by using the "attachment://" schema with the filename we gave it above
-     *   .build();
-     *
-     * channel.sendMessageEmbeds(Collections.singleton(embed)) // send the embeds
-     *        .addFiles(file) // add the file as attachment
-     *        .queue();
-     * }
-     *
-     * @param  embeds
-     *         {@link MessageEmbed MessageEmbeds} to use (up to {@value Message#MAX_EMBED_COUNT})
-     *
-     * @throws UnsupportedOperationException
-     *         If this is a {@link PrivateChannel} and the recipient is a bot
-     * @throws IllegalArgumentException
-     *         If any of the embeds are null, more than {@value Message#MAX_EMBED_COUNT}, or longer than {@link MessageEmbed#EMBED_MAX_LENGTH_BOT}.
-     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If this is a {@link GuildMessageChannel} and this account does not have
-     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
-     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
-     *         If this entity is {@link #isDetached() detached}
-     *
-     * @return {@link MessageCreateAction}
-     */
-    @Nonnull
+    @Override
     @CheckReturnValue
     default MessageCreateAction sendMessageEmbeds(@Nonnull Collection<? extends MessageEmbed> embeds) {
         return new MessageCreateActionImpl(this).setEmbeds(embeds);
     }
 
-    /**
-     * Send a message to this channel.
-     *
-     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
-     *     <br>if this channel was deleted</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
-     *     <br>If this is a {@link PrivateChannel} and the currently logged in account
-     *         cannot message the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         does not share any Guilds with the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
-     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
-     *     <br>If this message was blocked by the harmful link filter</li>
-     * </ul>
-     *
-     * @param  components
-     *         The {@link MessageTopLevelComponent MessageTopLevelComponents} to send,
-     *         can contain up to {@value Message#MAX_COMPONENT_COUNT} V1 components.
-     *         There are no limits for {@linkplain MessageRequest#isUsingComponentsV2() V2 components}
-     *         outside the {@linkplain Message#MAX_COMPONENT_COUNT_IN_COMPONENT_TREE total tree size} ({@value Message#MAX_COMPONENT_COUNT_IN_COMPONENT_TREE}).
-     *
-     * @throws UnsupportedOperationException
-     *         If this is a {@link PrivateChannel} and the recipient is a bot
-     * @throws IllegalArgumentException
-     *         <ul>
-     *             <li>If {@code null} is provided</li>
-     *             <li>If any of the provided components are not {@linkplain Component.Type#isMessageCompatible() compatible with messages}</li>
-     *         </ul>
-     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If this is a {@link GuildMessageChannel} and this account does not have
-     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
-     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
-     *         If this entity is {@link #isDetached() detached}
-     *
-     * @return {@link MessageCreateAction}
-     */
     @Nonnull
+    @Override
     @CheckReturnValue
     default MessageCreateAction sendMessageComponents(
             @Nonnull Collection<? extends MessageTopLevelComponent> components) {
@@ -641,309 +343,21 @@ public interface MessageChannel extends Channel, Formattable {
         return new MessageCreateActionImpl(this).setComponents(components);
     }
 
-    /**
-     * Send a message to this channel.
-     *
-     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
-     *     <br>if this channel was deleted</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
-     *     <br>If this is a {@link PrivateChannel} and the currently logged in account
-     *         cannot message the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         does not share any Guilds with the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
-     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
-     *     <br>If this message was blocked by the harmful link filter</li>
-     * </ul>
-     *
-     * @param  component
-     *         The {@link MessageTopLevelComponent} to send
-     * @param  other
-     *         Additional {@link MessageTopLevelComponent MessageTopLevelComponents} to send,
-     *         can contain up to {@value Message#MAX_COMPONENT_COUNT} V1 components.
-     *         There are no limits for {@linkplain MessageRequest#isUsingComponentsV2() V2 components}
-     *         outside the {@linkplain Message#MAX_COMPONENT_COUNT_IN_COMPONENT_TREE total tree size} ({@value Message#MAX_COMPONENT_COUNT_IN_COMPONENT_TREE}).
-     *
-     * @throws UnsupportedOperationException
-     *         If this is a {@link PrivateChannel} and the recipient is a bot
-     * @throws IllegalArgumentException
-     *         <ul>
-     *             <li>If {@code null} is provided</li>
-     *             <li>If any of the provided components are not {@linkplain Component.Type#isMessageCompatible() compatible with messages}</li>
-     *         </ul>
-     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If this is a {@link GuildMessageChannel} and this account does not have
-     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
-     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
-     *         If this entity is {@link #isDetached() detached}
-     *
-     * @return {@link MessageCreateAction}
-     */
     @Nonnull
-    @CheckReturnValue
-    default MessageCreateAction sendMessageComponents(
-            @Nonnull MessageTopLevelComponent component, @Nonnull MessageTopLevelComponent... other) {
-        Checks.notNull(component, "MessageTopLevelComponent");
-        Checks.noneNull(other, "MessageTopLevelComponents");
-        return sendMessageComponents(Helpers.mergeVararg(component, other));
-    }
-
-    /**
-     * Send a message to this channel.
-     *
-     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
-     *     <br>if this channel was deleted</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
-     *     <br>If this is a {@link PrivateChannel} and the currently logged in account
-     *         cannot message the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         does not share any Guilds with the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
-     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
-     *     <br>If this message was blocked by the harmful link filter</li>
-     * </ul>
-     *
-     * @param  tree
-     *         The {@link ComponentTree} to send,
-     *         containing up to {@value Message#MAX_COMPONENT_COUNT} V1 components.
-     *         There are no limits for {@linkplain MessageRequest#isUsingComponentsV2() V2 components}
-     *         outside the {@linkplain Message#MAX_COMPONENT_COUNT_IN_COMPONENT_TREE total tree size} ({@value Message#MAX_COMPONENT_COUNT_IN_COMPONENT_TREE}).
-     *
-     * @throws UnsupportedOperationException
-     *         If this is a {@link PrivateChannel} and the recipient is a bot
-     * @throws IllegalArgumentException
-     *         <ul>
-     *             <li>If {@code null} is provided</li>
-     *             <li>If any of the provided components are not {@linkplain Component.Type#isMessageCompatible() compatible with messages}</li>
-     *         </ul>
-     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If this is a {@link GuildMessageChannel} and this account does not have
-     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
-     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
-     *         If this entity is {@link #isDetached() detached}
-     *
-     * @return {@link MessageCreateAction}
-     *
-     * @see    net.dv8tion.jda.api.components.tree.MessageComponentTree MessageComponentTree
-     */
-    @Nonnull
-    @CheckReturnValue
-    default MessageCreateAction sendMessageComponents(@Nonnull ComponentTree<? extends MessageTopLevelComponent> tree) {
-        Checks.notNull(tree, "ComponentTree");
-        return sendMessageComponents(tree.getComponents());
-    }
-
-    /**
-     * Send a message to this channel.
-     *
-     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
-     *     <br>if this channel was deleted</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
-     *     <br>If this is a {@link PrivateChannel} and the currently logged in account
-     *         cannot message the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         does not share any Guilds with the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
-     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
-     *     <br>If this message was blocked by the harmful link filter</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#POLL_INVALID_CHANNEL_TYPE POLL_INVALID_CHANNEL_TYPE}
-     *     <br>This channel does not allow polls</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#POLL_WITH_UNUSABLE_EMOJI POLL_WITH_UNUSABLE_EMOJI}
-     *     <br>This poll uses an external emoji that the bot is not allowed to use</li>
-     * </ul>
-     *
-     * @param  poll
-     *         The poll to send
-     *
-     * @throws UnsupportedOperationException
-     *         If this is a {@link PrivateChannel} and the recipient is a bot
-     * @throws IllegalArgumentException
-     *         If the poll is null
-     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If this is a {@link GuildMessageChannel} and this account does not have
-     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
-     *
-     * @return {@link MessageCreateAction}
-     */
-    @Nonnull
+    @Override
     @CheckReturnValue
     default MessageCreateAction sendMessagePoll(@Nonnull MessagePollData poll) {
         Checks.notNull(poll, "Poll");
         return new MessageCreateActionImpl(this).setPoll(poll);
     }
 
-    /**
-     * Send a message to this channel.
-     *
-     * <p><b>Resource Handling Note:</b> Once the request is handed off to the requester, for example when you call {@link RestAction#queue()},
-     * the requester will automatically clean up all opened files by itself. You are only responsible to close them yourself if it is never handed off properly.
-     * For instance, if an exception occurs after using {@link FileUpload#fromData(File)}, before calling {@link RestAction#queue()}.
-     * You can safely use a try-with-resources to handle this, since {@link FileUpload#close()} becomes ineffective once the request is handed off.
-     *
-     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
-     *     <br>if this channel was deleted</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         cannot message the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         does not share any Guilds with the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
-     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
-     *     <br>If this message was blocked by the harmful link filter</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#REQUEST_ENTITY_TOO_LARGE REQUEST_ENTITY_TOO_LARGE}
-     *     <br>If the total sum of uploaded bytes exceeds the guild's {@link Guild#getMaxFileSize() upload limit}</li>
-     * </ul>
-     *
-     * <p><b>Example: Attachment Images</b>
-     * {@snippet lang="java":
-     * // Make a file upload instance which refers to a local file called "myFile.png"
-     * // The second parameter "image.png" is the filename we tell discord to use for the attachment
-     * FileUpload file = FileUpload.fromData(new File("myFile.png"), "image.png");
-     *
-     * // Build a message embed which refers to this attachment by the given name.
-     * // Note that this must be the same name as configured for the attachment, not your local filename.
-     * MessageEmbed embed = new EmbedBuilder()
-     *   .setDescription("This is my cute cat :)")
-     *   .setImage("attachment://image.png") // refer to the file by using the "attachment://" schema with the filename we gave it above
-     *   .build();
-     *
-     * channel.sendFiles(Collections.singleton(file)) // send the file upload
-     *        .addEmbeds(embed) // add the embed you want to reference the file with
-     *        .queue();
-     * }
-     *
-     * @param  files
-     *         The {@link FileUpload FileUploads} to attach to the message
-     *
-     * @throws UnsupportedOperationException
-     *         If this is a {@link PrivateChannel} and the recipient is a bot
-     * @throws IllegalArgumentException
-     *         If null is provided
-     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If this is a {@link GuildMessageChannel} and this account does not have
-     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
-     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
-     *         If this entity is {@link #isDetached() detached}
-     *
-     * @return {@link MessageCreateAction}
-     *
-     * @see    FileUpload#fromData(InputStream, String)
-     */
     @Nonnull
+    @Override
     @CheckReturnValue
     default MessageCreateAction sendFiles(@Nonnull Collection<? extends FileUpload> files) {
         Checks.notEmpty(files, "File Collection");
         Checks.noneNull(files, "Files");
         return new MessageCreateActionImpl(this).addFiles(files);
-    }
-
-    /**
-     * Send a message to this channel.
-     *
-     * <p><b>Resource Handling Note:</b> Once the request is handed off to the requester, for example when you call {@link RestAction#queue()},
-     * the requester will automatically clean up all opened files by itself. You are only responsible to close them yourself if it is never handed off properly.
-     * For instance, if an exception occurs after using {@link FileUpload#fromData(File)}, before calling {@link RestAction#queue()}.
-     * You can safely use a try-with-resources to handle this, since {@link FileUpload#close()} becomes ineffective once the request is handed off.
-     *
-     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} include:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
-     *     <br>if this channel was deleted</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
-     *     <br>If this is a {@link PrivateChannel PrivateChannel} and the currently logged in account
-     *         cannot message the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#NO_MUTUAL_GUILDS NO_MUTUAL_GUILDS}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel PrivateChannel} and the currently logged in account
-     *         does not share any Guilds with the recipient User</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_AUTOMOD MESSAGE_BLOCKED_BY_AUTOMOD}
-     *     <br>If this message was blocked by an {@link net.dv8tion.jda.api.entities.automod.AutoModRule AutoModRule}</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER MESSAGE_BLOCKED_BY_HARMFUL_LINK_FILTER}
-     *     <br>If this message was blocked by the harmful link filter</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#REQUEST_ENTITY_TOO_LARGE REQUEST_ENTITY_TOO_LARGE}
-     *     <br>If the total sum of uploaded bytes exceeds the guild's {@link Guild#getMaxFileSize() upload limit}</li>
-     * </ul>
-     *
-     * <p><b>Example: Attachment Images</b>
-     * {@snippet lang="java":
-     * // Make a file upload instance which refers to a local file called "myFile.png"
-     * // The second parameter "image.png" is the filename we tell discord to use for the attachment
-     * FileUpload file = FileUpload.fromData(new File("myFile.png"), "image.png");
-     *
-     * // Build a message embed which refers to this attachment by the given name.
-     * // Note that this must be the same name as configured for the attachment, not your local filename.
-     * MessageEmbed embed = new EmbedBuilder()
-     *   .setDescription("This is my cute cat :)")
-     *   .setImage("attachment://image.png") // refer to the file by using the "attachment://" schema with the filename we gave it above
-     *   .build();
-     *
-     * channel.sendFiles(file) // send the file upload
-     *        .addEmbeds(embed) // add the embed you want to reference the file with
-     *        .queue();
-     * }
-     *
-     * @param  files
-     *         The {@link FileUpload FileUploads} to attach to the message
-     *
-     * @throws UnsupportedOperationException
-     *         If this is a {@link PrivateChannel} and the recipient is a bot
-     * @throws IllegalArgumentException
-     *         If null is provided
-     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If this is a {@link GuildMessageChannel} and this account does not have
-     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} or {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}
-     * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException
-     *         If this entity is {@link #isDetached() detached}
-     *
-     * @return {@link MessageCreateAction}
-     *
-     * @see    FileUpload#fromData(InputStream, String)
-     */
-    @Nonnull
-    @CheckReturnValue
-    default MessageCreateAction sendFiles(@Nonnull FileUpload... files) {
-        Checks.notEmpty(files, "File Collection");
-        Checks.noneNull(files, "Files");
-        return sendFiles(Arrays.asList(files));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageCreateAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageCreateAction.java
@@ -16,6 +16,7 @@
 
 package net.dv8tion.jda.api.requests.restaction;
 
+import net.dv8tion.jda.api.endpoints.MessageApi;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageReference.MessageReferenceType;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
@@ -40,6 +41,7 @@ import javax.annotation.Nullable;
  * Specialized {@link net.dv8tion.jda.api.requests.RestAction RestAction} used for sending messages to {@link MessageChannel MessageChannels}.
  *
  * @see MessageChannel#sendMessage(MessageCreateData) MessageChannel.sendMessage(...)
+ * @see MessageApi#sendMessage(MessageCreateData) MessageApi.sendMessage(...)
  */
 public interface MessageCreateAction
         extends MessageCreateRequest<MessageCreateAction>, FluentRestAction<Message, MessageCreateAction> {

--- a/src/main/java/net/dv8tion/jda/internal/endpoints/MessageApiImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/endpoints/MessageApiImpl.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.endpoints;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.components.MessageTopLevelComponent;
+import net.dv8tion.jda.api.endpoints.MessageApi;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
+import net.dv8tion.jda.api.utils.FileUpload;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import net.dv8tion.jda.api.utils.messages.MessagePollData;
+import net.dv8tion.jda.internal.requests.restaction.RestMessageCreateActionImpl;
+import net.dv8tion.jda.internal.utils.Checks;
+
+import java.util.Collection;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
+public class MessageApiImpl implements MessageApi {
+    private final JDA jda;
+    private final String channelId;
+
+    public MessageApiImpl(JDA jda, String channelId) {
+        this.jda = jda;
+        this.channelId = channelId;
+    }
+
+    @Nonnull
+    @Override
+    @CheckReturnValue
+    public MessageCreateAction sendMessage(@Nonnull MessageCreateData data) {
+        Checks.notNull(data, "Message");
+        return new RestMessageCreateActionImpl(jda, channelId).applyData(data);
+    }
+
+    @Nonnull
+    @Override
+    @CheckReturnValue
+    public MessageCreateAction sendMessage(@Nonnull CharSequence content) {
+        Checks.notNull(content, "Content");
+        return new RestMessageCreateActionImpl(jda, channelId).setContent(content.toString());
+    }
+
+    @Nonnull
+    @Override
+    @CheckReturnValue
+    public MessageCreateAction sendMessageEmbeds(@Nonnull Collection<? extends MessageEmbed> embeds) {
+        return new RestMessageCreateActionImpl(jda, channelId).setEmbeds(embeds);
+    }
+
+    @Nonnull
+    @Override
+    @CheckReturnValue
+    public MessageCreateAction sendMessageComponents(
+            @Nonnull Collection<? extends MessageTopLevelComponent> components) {
+        Checks.noneNull(components, "MessageTopLevelComponents");
+        return new RestMessageCreateActionImpl(jda, channelId).setComponents(components);
+    }
+
+    @Nonnull
+    @Override
+    @CheckReturnValue
+    public MessageCreateAction sendMessagePoll(@Nonnull MessagePollData poll) {
+        Checks.notNull(poll, "Poll");
+        return new RestMessageCreateActionImpl(jda, channelId).setPoll(poll);
+    }
+
+    @Nonnull
+    @Override
+    @CheckReturnValue
+    public MessageCreateAction sendFiles(@Nonnull Collection<? extends FileUpload> files) {
+        Checks.notEmpty(files, "File Collection");
+        Checks.noneNull(files, "Files");
+        return new RestMessageCreateActionImpl(jda, channelId).addFiles(files);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/mixin/middleman/MessageChannelMixin.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/mixin/middleman/MessageChannelMixin.java
@@ -148,15 +148,6 @@ public interface MessageChannelMixin<T extends MessageChannelMixin<T>>
     @Override
     @Nonnull
     @CheckReturnValue
-    default MessageCreateAction sendMessageEmbeds(@Nonnull MessageEmbed embed, @Nonnull MessageEmbed... other) {
-        checkCanSendMessage();
-        checkCanSendMessageEmbeds();
-        return MessageChannelUnion.super.sendMessageEmbeds(embed, other);
-    }
-
-    @Override
-    @Nonnull
-    @CheckReturnValue
     default MessageCreateAction sendMessageEmbeds(@Nonnull Collection<? extends MessageEmbed> embeds) {
         checkCanSendMessage();
         checkCanSendMessageEmbeds();

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/AbstractMessageCreateActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/AbstractMessageCreateActionImpl.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.requests.restaction;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageReference;
+import net.dv8tion.jda.api.entities.sticker.GuildSticker;
+import net.dv8tion.jda.api.entities.sticker.StickerSnowflake;
+import net.dv8tion.jda.api.requests.Request;
+import net.dv8tion.jda.api.requests.Response;
+import net.dv8tion.jda.api.requests.Route;
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
+import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.api.utils.data.SerializableData;
+import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
+import net.dv8tion.jda.api.utils.messages.MessageCreateData;
+import net.dv8tion.jda.internal.requests.RestActionImpl;
+import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.message.MessageCreateBuilderMixin;
+import okhttp3.RequestBody;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+abstract class AbstractMessageCreateActionImpl extends RestActionImpl<Message>
+        implements MessageCreateAction, MessageCreateBuilderMixin<MessageCreateAction> {
+    protected static final SecureRandom nonceGenerator = new SecureRandom();
+    protected static boolean defaultFailOnInvalidReply = false;
+
+    private final String channelId;
+    private final MessageCreateBuilder builder = new MessageCreateBuilder();
+    private final List<String> stickers = new ArrayList<>();
+    private String nonce;
+    private MessageReferenceData messageReference;
+    private boolean failOnInvalidReply = defaultFailOnInvalidReply;
+
+    public static void setDefaultFailOnInvalidReply(boolean fail) {
+        defaultFailOnInvalidReply = fail;
+    }
+
+    public AbstractMessageCreateActionImpl(JDA jda, String channelId) {
+        super(jda, Route.Messages.SEND_MESSAGE.compile(channelId));
+        this.channelId = channelId;
+    }
+
+    @Override
+    public MessageCreateBuilder getBuilder() {
+        return builder;
+    }
+
+    @Override
+    protected RequestBody finalizeData() {
+        if (builder.isUsingComponentsV2()) {
+            Checks.check(stickers.isEmpty(), "Cannot send stickers when using Components V2!");
+        }
+
+        if (builder.isEmpty()) {
+            // Special cases where builder is empty but can still send message on this endpoint
+            DataObject body = DataObject.empty().put("flags", builder.getMessageFlagsRaw());
+            populateBody(body);
+
+            if (!stickers.isEmpty()
+                    || messageReference != null
+                            && messageReference.type == MessageReference.MessageReferenceType.FORWARD) {
+                return getRequestBody(body);
+            }
+
+            throw new IllegalStateException(
+                    "Cannot build empty messages! Must provide at least one of: content, embed, file, poll, or stickers");
+        }
+
+        try (MessageCreateData data = builder.build()) {
+            DataObject json = data.toData();
+            populateBody(json);
+
+            return getMultipartBody(data.getAllDistinctFiles(), json);
+        }
+    }
+
+    private void populateBody(DataObject json) {
+        json.put("enforce_nonce", true);
+        if (nonce != null && !nonce.isEmpty()) {
+            json.put("nonce", nonce);
+        } else {
+            json.put("nonce", Long.toUnsignedString(nonceGenerator.nextLong()));
+        }
+        if (stickers != null && !stickers.isEmpty()) {
+            json.put("sticker_ids", stickers);
+        }
+        if (messageReference != null) {
+            json.put("message_reference", messageReference.toData().put("fail_if_not_exists", failOnInvalidReply));
+        }
+    }
+
+    @Override
+    protected abstract void handleSuccess(Response response, Request<Message> request);
+
+    @Nonnull
+    @Override
+    public MessageCreateAction setNonce(@Nullable String nonce) {
+        if (nonce != null) {
+            Checks.notLonger(nonce, Message.MAX_NONCE_LENGTH, "Nonce");
+        }
+        this.nonce = nonce;
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public MessageCreateAction setMessageReference(
+            @Nonnull MessageReference.MessageReferenceType type,
+            @Nullable String guildId,
+            @Nonnull String channelId,
+            @Nonnull String messageId) {
+        Checks.notNull(type, "Type");
+        if (guildId != null) {
+            Checks.isSnowflake(guildId, "Guild ID");
+        }
+        Checks.isSnowflake(channelId, "Channel ID");
+        Checks.isSnowflake(messageId, "Message ID");
+        Checks.check(
+                type != MessageReference.MessageReferenceType.UNKNOWN,
+                "Cannot create a message reference of UNKNOWN type");
+        this.messageReference = new MessageReferenceData(type, guildId, channelId, messageId);
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public MessageCreateAction setMessageReference(@Nullable String messageId) {
+        if (messageId == null) {
+            this.messageReference = null;
+            return this;
+        }
+
+        Checks.isSnowflake(messageId);
+        this.messageReference =
+                new MessageReferenceData(MessageReference.MessageReferenceType.DEFAULT, null, channelId, messageId);
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public MessageCreateAction failOnInvalidReply(boolean fail) {
+        failOnInvalidReply = fail;
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public MessageCreateAction setStickers(@Nullable Collection<? extends StickerSnowflake> stickers) {
+        this.stickers.clear();
+        if (stickers == null || stickers.isEmpty()) {
+            return this;
+        }
+
+        requireGuildChannel("Cannot send stickers in direct messages!");
+
+        Checks.noneNull(stickers, "Stickers");
+        Checks.check(
+                stickers.size() <= Message.MAX_STICKER_COUNT,
+                "Cannot send more than %d stickers in a message!",
+                Message.MAX_STICKER_COUNT);
+        for (StickerSnowflake sticker : stickers) {
+            if (sticker instanceof GuildSticker) {
+                GuildSticker guildSticker = (GuildSticker) sticker;
+                Checks.check(
+                        guildSticker.isAvailable(),
+                        "Cannot use unavailable sticker. The guild may have lost the boost level required to use this sticker!");
+                checkStickerProvenance(guildSticker);
+            }
+        }
+
+        this.stickers.addAll(stickers.stream().map(StickerSnowflake::getId).collect(Collectors.toList()));
+        return this;
+    }
+
+    protected abstract void requireGuildChannel(String message);
+
+    protected abstract void checkStickerProvenance(GuildSticker sticker);
+
+    @Nonnull
+    @Override
+    public MessageCreateAction setCheck(BooleanSupplier checks) {
+        return (MessageCreateAction) super.setCheck(checks);
+    }
+
+    @Nonnull
+    @Override
+    public MessageCreateAction deadline(long timestamp) {
+        return (MessageCreateAction) super.deadline(timestamp);
+    }
+
+    private static class MessageReferenceData implements SerializableData {
+        private final MessageReference.MessageReferenceType type;
+        private final String messageId;
+        private final String channelId;
+        private final String guildId;
+
+        private MessageReferenceData(
+                MessageReference.MessageReferenceType type, String guildId, String channelId, String messageId) {
+            this.type = type;
+            this.messageId = messageId;
+            this.guildId = guildId;
+            this.channelId = channelId;
+        }
+
+        @Nonnull
+        @Override
+        public DataObject toData() {
+            DataObject data = DataObject.empty()
+                    .put("type", type.getId())
+                    .put("message_id", messageId)
+                    .put("channel_id", channelId);
+            if (guildId != null) {
+                data.put("guild_id", guildId);
+            }
+            return data;
+        }
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/RestMessageCreateActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/RestMessageCreateActionImpl.java
@@ -16,41 +16,36 @@
 
 package net.dv8tion.jda.internal.requests.restaction;
 
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.sticker.GuildSticker;
 import net.dv8tion.jda.api.requests.Request;
 import net.dv8tion.jda.api.requests.Response;
-import net.dv8tion.jda.internal.utils.Checks;
 
-public class MessageCreateActionImpl extends AbstractMessageCreateActionImpl {
+public class RestMessageCreateActionImpl extends AbstractMessageCreateActionImpl {
 
-    private final MessageChannel channel;
+    private final String channelId;
 
-    public MessageCreateActionImpl(MessageChannel channel) {
-        super(channel.getJDA(), channel.getId());
-        this.channel = channel;
+    public RestMessageCreateActionImpl(JDA jda, String channelId) {
+        super(jda, channelId);
+        this.channelId = channelId;
     }
 
     @Override
     protected void handleSuccess(Response response, Request<Message> request) {
-        request.onSuccess(api.getEntityBuilder().createMessageWithChannel(response.getObject(), channel, false));
-    }
+        MessageChannel channel = api.getChannelById(MessageChannel.class, channelId);
 
-    @Override
-    protected void requireGuildChannel(String message) {
-        if (!channel.getType().isGuild()) {
-            throw new IllegalStateException(message);
+        if (channel != null) {
+            request.onSuccess(api.getEntityBuilder().createMessageWithChannel(response.getObject(), channel, false));
+        } else {
+            request.onSuccess(api.getEntityBuilder().createMessageFromWebhook(response.getObject(), null));
         }
     }
 
     @Override
-    protected void checkStickerProvenance(GuildSticker sticker) {
-        GuildChannel guildChannel = (GuildChannel) channel;
+    protected void requireGuildChannel(String message) {}
 
-        Checks.check(
-                sticker.getGuildIdLong() == guildChannel.getGuild().getIdLong(),
-                "Sticker must be from the same guild. Cross-guild sticker posting is not supported!");
-    }
+    @Override
+    protected void checkStickerProvenance(GuildSticker sticker) {}
 }


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [X] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

As there is an increasing demand to send/edit messages from potentially archived threads (and thus absent from the thread cache), this PR adds an API that lets users interact with part of Discord's messages resource, without requiring a channel instance.

The new API (`ApiEndpoints`) is marked as experimental (and requires an opt-in for Kotlin users), it may change in the future as it can differ from a future, proper REST-only API.