### PR TITLE
Add support for guild member banners

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Member.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Member.java
@@ -421,6 +421,81 @@ public interface Member extends IMentionable, IPermissionHolder, IDetachableEnti
     }
 
     /**
+     * The Discord Id for this member's per guild banner image.
+     * If the member has not set a per guild banner, this will return null.
+     *
+     * @return Possibly-null String containing the {@link net.dv8tion.jda.api.entities.Member} per guild banner id.
+     */
+    @Nullable
+    String getBannerId();
+
+    /**
+     * The URL for the member's per guild banner image.
+     * If the member has not set a per guild banner, this will return null.
+     *
+     * @return Possibly-null String containing the {@link net.dv8tion.jda.api.entities.Member} per guild banner url.
+     */
+    @Nullable
+    default String getBannerUrl() {
+        String bannerId = getBannerId();
+        return bannerId == null
+                ? null
+                : getBannerUrl(bannerId.startsWith("a_") ? ImageFormat.ANIMATED_WEBP : ImageFormat.PNG);
+    }
+
+    /**
+     * The URL for the member's per guild banner image.
+     * If the member has not set a per guild banner, this will return null.
+     *
+     * @param  format
+     *         The format in which the image should be
+     *
+     * @throws IllegalArgumentException
+     *         If the format is {@code null}
+     *
+     * @return Possibly-null String containing the {@link net.dv8tion.jda.api.entities.Member} per guild banner url.
+     *
+     * @see    DiscordAssets#memberBanner(ImageFormat, String, String, String)
+     */
+    @Nullable
+    default String getBannerUrl(@Nonnull ImageFormat format) {
+        ImageProxy proxy = getBanner(format);
+        return proxy == null ? null : proxy.getUrl();
+    }
+
+    /**
+     * Returns an {@link ImageProxy} for this member's banner.
+     *
+     * @return Possibly-null {@link ImageProxy} of this member's banner
+     *
+     * @see    #getBannerUrl()
+     */
+    @Nullable
+    default ImageProxy getBanner() {
+        String bannerUrl = getBannerUrl();
+        return bannerUrl == null ? null : new ImageProxy(bannerUrl);
+    }
+
+    /**
+     * Returns an {@link ImageProxy} for this member's banner.
+     *
+     * @param  format
+     *         The format in which the image should be
+     *
+     * @throws IllegalArgumentException
+     *         If the format is {@code null}
+     *
+     * @return Possibly-null {@link ImageProxy} of this member's banner
+     *
+     * @see    #getBannerUrl(ImageFormat)
+     * @see    DiscordAssets#memberBanner(ImageFormat, String, String, String)
+     */
+    @Nullable
+    default ImageProxy getBanner(@Nonnull ImageFormat format) {
+        return DiscordAssets.memberBanner(format, getGuild().getId(), getId(), getBannerId());
+    }
+
+    /**
      * The roles applied to this Member.
      * <br>The roles are ordered based on their position. The highest role being at index 0
      * and the lowest at the last index. Prefer {@link #getUnsortedRoles()} if the order is not relevant.

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateBannerEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateBannerEvent.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.guild.member.update;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.utils.DiscordAssets;
+import net.dv8tion.jda.api.utils.ImageFormat;
+import net.dv8tion.jda.api.utils.ImageProxy;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} updated their {@link net.dv8tion.jda.api.entities.Guild Guild} banner.
+ *
+ * <p>Can be used to retrieve members who change their per guild banner, the triggering guild, the old banner id and the new banner id.
+ *
+ * <p>Identifier: {@code banner}
+ *
+ * <p><b>Requirements</b><br>
+ *
+ * <p>This event requires the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent to be enabled.
+ * <br>{@link net.dv8tion.jda.api.JDABuilder#createDefault(String) createDefault(String)} and
+ * {@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disable this by default!
+ *
+ * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
+ * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
+ * member was updated and gives us the updated member object. In order to fire a specific event like this we
+ * need to have the old member cached to compare against.
+ */
+public class GuildMemberUpdateBannerEvent extends GenericGuildMemberUpdateEvent<String> {
+    public static final String IDENTIFIER = "banner";
+
+    public GuildMemberUpdateBannerEvent(
+            @Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nullable String oldBannerId) {
+        super(api, responseNumber, member, oldBannerId, member.getBannerId(), IDENTIFIER);
+    }
+
+    /**
+     * The old banner id
+     *
+     * @return The old banner id
+     */
+    @Nullable
+    public String getOldBannerId() {
+        return getOldValue();
+    }
+
+    /**
+     * The previous banner url
+     *
+     * @return The previous banner url
+     */
+    @Nullable
+    public String getOldBannerUrl() {
+        return previous == null
+                ? null
+                : getOldBannerUrl(previous.startsWith("a_") ? ImageFormat.ANIMATED_WEBP : ImageFormat.PNG);
+    }
+
+    /**
+     * The previous banner url
+     *
+     * @param  format
+     *         The format in which the image should be
+     *
+     * @throws IllegalArgumentException
+     *         If the format is {@code null}
+     *
+     * @return The previous banner url
+     *
+     * @see    DiscordAssets#memberBanner(ImageFormat, String, String, String)
+     */
+    @Nullable
+    public String getOldBannerUrl(@Nonnull ImageFormat format) {
+        ImageProxy proxy = getOldBanner(format);
+        return proxy == null ? null : proxy.getUrl();
+    }
+
+    /**
+     * Returns an {@link ImageProxy} for this member's old banner.
+     * <p>
+     * <b>Note:</b> the old banner may not always be downloadable as it might have been removed from Discord.
+     *
+     * @return Possibly-null {@link ImageProxy} of this member's old banner
+     *
+     * @see    #getOldBannerUrl()
+     */
+    @Nullable
+    public ImageProxy getOldBanner() {
+        String oldBannerUrl = getOldBannerUrl();
+        return oldBannerUrl == null ? null : new ImageProxy(oldBannerUrl);
+    }
+
+    /**
+     * Returns an {@link ImageProxy} for this member's old banner.
+     * <p>
+     * <b>Note:</b> the old banner may not always be downloadable as it might have been removed from Discord.
+     *
+     * @param  format
+     *         The format in which the image should be
+     *
+     * @throws IllegalArgumentException
+     *         If the format is {@code null}
+     *
+     * @return Possibly-null {@link ImageProxy} of this member's old banner
+     *
+     * @see    #getOldBannerUrl(ImageFormat)
+     * @see    DiscordAssets#memberBanner(ImageFormat, String, String, String)
+     */
+    @Nullable
+    public ImageProxy getOldBanner(@Nonnull ImageFormat format) {
+        return DiscordAssets.memberBanner(format, getGuild().getId(), getUser().getId(), previous);
+    }
+
+    /**
+     * The new banner id
+     *
+     * @return The new banner id
+     */
+    @Nullable
+    public String getNewBannerId() {
+        return getNewValue();
+    }
+
+    /**
+     * The url of the new banner
+     *
+     * @return The url of the new banner
+     */
+    @Nullable
+    public String getNewBannerUrl() {
+        return next == null
+                ? null
+                : getNewBannerUrl(next.startsWith("a_") ? ImageFormat.ANIMATED_WEBP : ImageFormat.PNG);
+    }
+
+    /**
+     * The url of the new banner
+     *
+     * @param  format
+     *         The format in which the image should be
+     *
+     * @throws IllegalArgumentException
+     *         If the format is {@code null}
+     *
+     * @return The url of the new banner
+     *
+     * @see    DiscordAssets#memberBanner(ImageFormat, String, String, String)
+     */
+    @Nullable
+    public String getNewBannerUrl(@Nonnull ImageFormat format) {
+        ImageProxy proxy = getNewBanner(format);
+        return proxy == null ? null : proxy.getUrl();
+    }
+
+    /**
+     * Returns an {@link ImageProxy} for this member's new banner.
+     *
+     * @return Possibly-null {@link ImageProxy} of this member's new banner
+     *
+     * @see    #getNewBannerUrl()
+     */
+    @Nullable
+    public ImageProxy getNewBanner() {
+        String newBannerUrl = getNewBannerUrl();
+        return newBannerUrl == null ? null : new ImageProxy(newBannerUrl);
+    }
+
+    /**
+     * Returns an {@link ImageProxy} for this member's new banner.
+     *
+     * @param  format
+     *         The format in which the image should be
+     *
+     * @throws IllegalArgumentException
+     *         If the format is {@code null}
+     *
+     * @return Possibly-null {@link ImageProxy} of this member's new banner
+     *
+     * @see    #getNewBannerUrl(ImageFormat)
+     * @see    DiscordAssets#memberBanner(ImageFormat, String, String, String)
+     */
+    @Nullable
+    public ImageProxy getNewBanner(@Nonnull ImageFormat format) {
+        return DiscordAssets.memberBanner(format, getGuild().getId(), getUser().getId(), next);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -458,6 +458,8 @@ public abstract class ListenerAdapter implements EventListener {
 
     public void onGuildMemberUpdateAvatar(@Nonnull GuildMemberUpdateAvatarEvent event) {}
 
+    public void onGuildMemberUpdateBanner(@Nonnull GuildMemberUpdateBannerEvent event) {}
+
     public void onGuildMemberUpdateBoostTime(@Nonnull GuildMemberUpdateBoostTimeEvent event) {}
 
     public void onGuildMemberUpdatePending(@Nonnull GuildMemberUpdatePendingEvent event) {}

--- a/src/main/java/net/dv8tion/jda/api/utils/DiscordAssets.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/DiscordAssets.java
@@ -363,6 +363,51 @@ public final class DiscordAssets {
     }
 
     /**
+     * Returns an {@link ImageProxy} of a member's banner.
+     * <br>This returns {@code null} if the banner ID is {@code null}.
+     *
+     * <p>At the time of writing, the supported formats are:
+     * <ul>
+     *     <li>{@link ImageFormat#PNG PNG}</li>
+     *     <li>{@link ImageFormat#JPG JPG}</li>
+     *     <li>{@link ImageFormat#STATIC_WEBP STATIC_WEBP}</li>
+     *     <li>{@link ImageFormat#ANIMATED_WEBP ANIMATED_WEBP}</li>
+     *     <li>{@link ImageFormat#GIF GIF}</li>
+     * </ul>
+     *
+     * @param  format
+     *         The image format to request the image as
+     * @param  guildId
+     *         The guild ID
+     * @param  userId
+     *         The user ID
+     * @param  bannerId
+     *         The member's banner ID
+     *
+     * @throws IllegalArgumentException
+     *         If an argument is {@code null}, except for the banner ID
+     *
+     * @return An {@link ImageProxy} of the member's banner, or {@code null}
+     */
+    @Contract("_, _, _, null -> null; _, _, _, !null -> !null")
+    public static ImageProxy memberBanner(
+            @Nonnull ImageFormat format, @Nonnull String guildId, @Nonnull String userId, @Nullable String bannerId) {
+        Checks.notNull(format, "Format");
+        Checks.isSnowflake(guildId, "Guild ID");
+        Checks.isSnowflake(userId, "User ID");
+        if (bannerId == null) {
+            return null;
+        }
+
+        HttpUrl.Builder builder = newUrl().addEncodedPathSegment("guilds")
+                .addPathSegment(guildId)
+                .addEncodedPathSegment("users")
+                .addPathSegment(userId)
+                .addEncodedPathSegment("banners");
+        return format.finishProxy(builder, bannerId);
+    }
+
+    /**
      * Returns an {@link ImageProxy} of a role's icon.
      * <br>This returns {@code null} if the icon ID is {@code null}.
      *

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractEntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractEntityBuilder.java
@@ -195,6 +195,7 @@ public abstract class AbstractEntityBuilder {
     protected void configureMember(DataObject memberJson, MemberMixin<?> member) {
         member.setNickname(memberJson.getString("nick", null));
         member.setAvatarId(memberJson.getString("avatar", null));
+        member.setBannerId(memberJson.getString("banner", null));
         if (!memberJson.isNull("flags")) {
             member.setFlags(memberJson.getInt("flags"));
         }

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -787,6 +787,14 @@ public class EntityBuilder extends AbstractEntityBuilder {
                 getJDA().handleEvent(new GuildMemberUpdateAvatarEvent(getJDA(), responseNumber, member, oldAvatarId));
             }
         }
+        if (content.hasKey("banner")) {
+            String oldBannerId = member.getBannerId();
+            String newBannerId = content.getString("banner", null);
+            if (!Objects.equals(oldBannerId, newBannerId)) {
+                member.setBannerId(newBannerId);
+                getJDA().handleEvent(new GuildMemberUpdateBannerEvent(getJDA(), responseNumber, member, oldBannerId));
+            }
+        }
         if (content.hasKey("premium_since")) {
             long epoch = 0;
             if (!content.isNull("premium_since")) {

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -52,6 +52,7 @@ public class MemberImpl implements Member, MemberMixin<MemberImpl> {
     private User user;
     private String nickname;
     private String avatarId;
+    private String bannerId;
     private long joinDate, boostDate, timeOutEnd;
     private boolean pending = false;
     private int flags;
@@ -181,6 +182,11 @@ public class MemberImpl implements Member, MemberMixin<MemberImpl> {
     @Override
     public String getAvatarId() {
         return avatarId;
+    }
+
+    @Override
+    public String getBannerId() {
+        return bannerId;
     }
 
     @Nonnull
@@ -363,6 +369,12 @@ public class MemberImpl implements Member, MemberMixin<MemberImpl> {
     @Override
     public MemberImpl setAvatarId(String avatarId) {
         this.avatarId = avatarId;
+        return this;
+    }
+
+    @Override
+    public MemberImpl setBannerId(String bannerId) {
+        this.bannerId = bannerId;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/detached/DetachedMemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/detached/DetachedMemberImpl.java
@@ -49,6 +49,7 @@ public class DetachedMemberImpl implements Member, MemberMixin<DetachedMemberImp
     private User user;
     private String nickname;
     private String avatarId;
+    private String bannerId;
     private long joinDate, boostDate, timeOutEnd;
     private boolean pending = false;
     private int flags;
@@ -161,6 +162,11 @@ public class DetachedMemberImpl implements Member, MemberMixin<DetachedMemberImp
     @Override
     public String getAvatarId() {
         return avatarId;
+    }
+
+    @Override
+    public String getBannerId() {
+        return bannerId;
     }
 
     @Nonnull
@@ -317,6 +323,12 @@ public class DetachedMemberImpl implements Member, MemberMixin<DetachedMemberImp
     @Override
     public DetachedMemberImpl setAvatarId(String avatarId) {
         this.avatarId = avatarId;
+        return this;
+    }
+
+    @Override
+    public DetachedMemberImpl setBannerId(String bannerId) {
+        this.bannerId = bannerId;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/mixin/MemberMixin.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/mixin/MemberMixin.java
@@ -28,6 +28,8 @@ public interface MemberMixin<T extends MemberMixin<T>> extends Member, IDetachab
 
     T setAvatarId(String avatarId);
 
+    T setBannerId(String bannerId);
+
     T setJoinDate(long joinDate);
 
     T setBoostDate(long boostDate);

--- a/src/test/java/net/dv8tion/jda/test/util/DiscordAssetsTest.java
+++ b/src/test/java/net/dv8tion/jda/test/util/DiscordAssetsTest.java
@@ -65,6 +65,10 @@ public class DiscordAssetsTest extends AbstractSnapshotTest {
                 memberAvatar(EXAMPLE_FORMAT, EXAMPLE_SNOWFLAKE, EXAMPLE_SNOWFLAKE, EXAMPLE_HASH)
                         .getUrl());
         data.put(
+                "memberBanner",
+                memberBanner(EXAMPLE_FORMAT, EXAMPLE_SNOWFLAKE, EXAMPLE_SNOWFLAKE, EXAMPLE_HASH)
+                        .getUrl());
+        data.put(
                 "roleIcon",
                 roleIcon(EXAMPLE_FORMAT, EXAMPLE_SNOWFLAKE, EXAMPLE_HASH).getUrl());
         data.put(

--- a/src/test/resources/net/dv8tion/jda/test/util/DiscordAssetsTest/testDiscordAssetsOutputIsChecked.json
+++ b/src/test/resources/net/dv8tion/jda/test/util/DiscordAssetsTest/testDiscordAssetsOutputIsChecked.json
@@ -8,6 +8,7 @@
   "guildIcon" : "https://cdn.discordapp.com/icons/222046562543468545/86185a18d168f88b91c.webp?animated=true",
   "guildSplash" : "https://cdn.discordapp.com/splashes/222046562543468545/86185a18d168f88b91c.webp?animated=true",
   "memberAvatar" : "https://cdn.discordapp.com/guilds/222046562543468545/users/222046562543468545/avatars/86185a18d168f88b91c.webp?animated=true",
+  "memberBanner" : "https://cdn.discordapp.com/guilds/222046562543468545/users/222046562543468545/banners/86185a18d168f88b91c.webp?animated=true",
   "roleIcon" : "https://cdn.discordapp.com/role-icons/222046562543468545/86185a18d168f88b91c.webp?animated=true",
   "scheduledEventCoverImage" : "https://cdn.discordapp.com/guild-events/222046562543468545/86185a18d168f88b91c.webp?animated=true",
   "stickerPackBanner" : "https://cdn.discordapp.com/app-assets/710982414301790216/store/86185a18d168f88b91c.webp?animated=true",


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [x] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____

Closes Issue: NaN

## Description

Discord supports per-guild member banners through the `banner` field of the [guild member object](https://docs.discord.com/developers/resources/guild#guild-member-object), but JDA currently only supports *modifying* the self member banner (#2915) and has no way to *read* member banners.

This PR adds read support, following the exact same pattern as per-guild member avatars:

- `Member#getBannerId()`, `getBannerUrl()`, `getBanner()` (+ `ImageFormat` overloads)
- `DiscordAssets#memberBanner(format, guildId, userId, bannerId)` for the `guilds/{guild_id}/users/{user_id}/banners/{hash}` CDN endpoint
- Parsing of the `banner` field in member payloads (guild cache + interaction/detached members)
- New `GuildMemberUpdateBannerEvent` fired on `GUILD_MEMBER_UPDATE` (identifier: `banner`), with the matching `ListenerAdapter#onGuildMemberUpdateBanner` hook
- `DiscordAssetsTest` extended with `memberBanner` + updated snapshot

Notes:
- No `getEffectiveBanner*()` methods were added: the global user banner is only available through `User.Profile` (`retrieveProfile()`), so a synchronous fallback like `getEffectiveAvatar` is not possible.
- The `GUILD_MEMBER_UPDATE` gateway event documents the `banner` field, so the update event fires reliably for cached members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)