### PR TITLE
Guild member pruning: Check for admin if `PRUNE_REQUIRES_ADMIN` is enabled

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2912,7 +2912,15 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      *         Minimum number of days since a member has been offline to get affected.
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If the account doesn't have {@link net.dv8tion.jda.api.Permission#KICK_MEMBERS KICK_MEMBER} Permission.
+     *         <ul>
+     *             <li>If the server has the {@code PRUNE_REQUIRES_ADMIN} feature enabled,
+     *                 and the account doesn't have {@link net.dv8tion.jda.api.Permission#ADMINISTRATOR ADMINISTRATOR} Permission
+     *             </li>
+     *             <li>If the server <b>does not</b> have the {@code PRUNE_REQUIRES_ADMIN} feature enabled,
+     *                 and the account doesn't have {@link net.dv8tion.jda.api.Permission#KICK_MEMBERS KICK_MEMBERS}
+     *                 and {@link net.dv8tion.jda.api.Permission#MANAGE_SERVER MANAGE_SERVER} Permission
+     *             </li>
+     *         </ul>
      * @throws IllegalArgumentException
      *         If the provided days are less than {@code 1} or more than {@code 30}
      * @throws net.dv8tion.jda.api.exceptions.DetachedEntityException

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -4229,7 +4229,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * the returned {@link RestAction RestAction} include the following:
      * <ul>
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
-     *     <br>The prune cannot finished due to a permission discrepancy</li>
+     *     <br>The prune cannot be finished due to a permission discrepancy</li>
      * </ul>
      *
      * @param  days
@@ -4238,7 +4238,15 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      *         Optional roles to include in prune filter
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If the account doesn't have {@link net.dv8tion.jda.api.Permission#KICK_MEMBERS KICK_MEMBER} Permission.
+     *         <ul>
+     *             <li>If the server has the {@code PRUNE_REQUIRES_ADMIN} feature enabled,
+     *                 and the account doesn't have {@link net.dv8tion.jda.api.Permission#ADMINISTRATOR ADMINISTRATOR} Permission
+     *             </li>
+     *             <li>If the server <b>does not</b> have the {@code PRUNE_REQUIRES_ADMIN} feature enabled,
+     *                 and the account doesn't have {@link net.dv8tion.jda.api.Permission#KICK_MEMBERS KICK_MEMBERS}
+     *                 and {@link net.dv8tion.jda.api.Permission#MANAGE_SERVER MANAGE_SERVER} Permission
+     *             </li>
+     *         </ul>
      * @throws IllegalArgumentException
      *         <ul>
      *             <li>If the provided days are not in the range from 1 to 30 (inclusive)</li>
@@ -4269,7 +4277,7 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      * the returned {@link RestAction RestAction} include the following:
      * <ul>
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
-     *     <br>The prune cannot finished due to a permission discrepancy</li>
+     *     <br>The prune cannot be finished due to a permission discrepancy</li>
      * </ul>
      *
      * @param  days
@@ -4280,7 +4288,15 @@ public interface Guild extends IGuildChannelContainer<GuildChannel>, ISnowflake,
      *         Optional roles to include in prune filter
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If the account doesn't have {@link net.dv8tion.jda.api.Permission#KICK_MEMBERS KICK_MEMBER} Permission.
+     *         <ul>
+     *             <li>If the server has the {@code PRUNE_REQUIRES_ADMIN} feature enabled,
+     *                 and the account doesn't have {@link net.dv8tion.jda.api.Permission#ADMINISTRATOR ADMINISTRATOR} Permission
+     *             </li>
+     *             <li>If the server <b>does not</b> have the {@code PRUNE_REQUIRES_ADMIN} feature enabled,
+     *                 and the account doesn't have {@link net.dv8tion.jda.api.Permission#KICK_MEMBERS KICK_MEMBERS}
+     *                 and {@link net.dv8tion.jda.api.Permission#MANAGE_SERVER MANAGE_SERVER} Permission
+     *             </li>
+     *         </ul>
      * @throws IllegalArgumentException
      *         <ul>
      *             <li>If the provided days are not in the range from 1 to 30 (inclusive)</li>

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1031,9 +1031,7 @@ public class GuildImpl implements Guild {
     @Nonnull
     @Override
     public RestAction<Integer> retrievePrunableMemberCount(int days) {
-        if (!getSelfMember().hasPermission(Permission.KICK_MEMBERS)) {
-            throw new InsufficientPermissionException(this, Permission.KICK_MEMBERS);
-        }
+        checkPrunePermissions();
 
         Checks.check(days >= 1 && days <= 30, "Provided %d days must be between 1 and 30.", days);
 
@@ -1511,12 +1509,7 @@ public class GuildImpl implements Guild {
     @Nonnull
     @Override
     public AuditableRestAction<Integer> prune(int days, boolean wait, @Nonnull Role... roles) {
-        if (features.contains("PRUNE_REQUIRES_ADMIN")) {
-            checkPermission(Permission.ADMINISTRATOR);
-        } else {
-            checkPermission(Permission.MANAGE_SERVER);
-            checkPermission(Permission.KICK_MEMBERS);
-        }
+        checkPrunePermissions();
 
         Checks.check(days >= 1 && days <= 30, "Provided %d days must be between 1 and 30.", days);
         Checks.notNull(roles, "Roles");
@@ -1536,6 +1529,15 @@ public class GuildImpl implements Guild {
         }
         return new AuditableRestActionImpl<>(getJDA(), route, body, (response, request) -> response.getObject()
                 .getInt("pruned", 0));
+    }
+
+    private void checkPrunePermissions() {
+        if (features.contains("PRUNE_REQUIRES_ADMIN")) {
+            checkPermission(Permission.ADMINISTRATOR);
+        } else {
+            checkPermission(Permission.MANAGE_SERVER);
+            checkPermission(Permission.KICK_MEMBERS);
+        }
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1511,7 +1511,12 @@ public class GuildImpl implements Guild {
     @Nonnull
     @Override
     public AuditableRestAction<Integer> prune(int days, boolean wait, @Nonnull Role... roles) {
-        checkPermission(Permission.KICK_MEMBERS);
+        if (features.contains("PRUNE_REQUIRES_ADMIN")) {
+            checkPermission(Permission.ADMINISTRATOR);
+        } else {
+            checkPermission(Permission.MANAGE_SERVER);
+            checkPermission(Permission.KICK_MEMBERS);
+        }
 
         Checks.check(days >= 1 && days <= 30, "Provided %d days must be between 1 and 30.", days);
         Checks.notNull(roles, "Roles");


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [X] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR checks for administrator permissions when pruning members or fetching the prune count, if the `PRUNE_REQUIRES_ADMIN` feature is enabled.

Also added `MANAGE_SERVER` checks in the other case, as required since March 15th 2024.

**Docs PR**: https://github.com/discord/discord-api-docs/pull/8540