### PR TITLE
Read `flags_new` of `ApplicationInfo` instead of `flags`

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -2649,7 +2649,7 @@ public class EntityBuilder extends AbstractEntityBuilder {
         boolean doesBotRequireCodeGrant = object.getBoolean("bot_require_code_grant");
         String iconId = object.getString("icon", null);
         long id = object.getUnsignedLong("id");
-        long flags = object.getUnsignedLong("flags", 0);
+        long flags = object.getUnsignedLong("flags_new", 0);
         String name = object.getString("name");
         boolean isBotPublic = object.getBoolean("bot_public");
         User owner = createUser(object.getObject("owner"));


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [X] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Reads the string flags instead of a 32 bit integer.

Changelog: https://docs.discord.com/developers/change-log#new-flags_new-field-on-application-object
