### PR TITLE
docs: fix typo inheritence -> inheritance

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/mixin/README.md
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/mixin/README.md
@@ -1,6 +1,6 @@
 # Entity Mixins
 Entity Mixins are a system in JDA that provide the following core functionalities:
-- Code reuse through composition instead of purely through inheritence
+- Code reuse through composition instead of purely through inheritance
 - A way to expose internal state setters and getters without exposing them to the library user
 
 ## Example Mixin with Usage


### PR DESCRIPTION
One-word typo fix in `src/main/java/net/dv8tion/jda/internal/entities/channel/mixin/README.md:3`: "Code reuse through composition instead of inheritence" → "inheritance".
