### PR TITLE
Fix `MarkdownUtil#monospace` not correctly applying monospace formatting to strings with backticks

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownUtil.java
@@ -89,9 +89,6 @@ public final class MarkdownUtil {
      */
     @Nonnull
     public static String monospace(@Nonnull String input) {
-        if (input.isEmpty()) {
-            return "` `";
-        }
         if (input.contains("`") && !input.contains("``")) {
             String prefix = input.startsWith("`") ? "`` " : "``";
             String suffix = input.endsWith("`") ? " ``" : "``";

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownUtil.java
@@ -89,8 +89,10 @@ public final class MarkdownUtil {
      */
     @Nonnull
     public static String monospace(@Nonnull String input) {
-        if(input.isEmpty()) return "` `";
-        if(input.contains("`") && !input.contains("``")) {
+        if (input.isEmpty()) {
+            return "` `";
+        }
+        if (input.contains("`") && !input.contains("``")) {
             String prefix = input.startsWith("`") ? "`` " : "``";
             String suffix = input.endsWith("`") ? " ``" : "``";
             return prefix + input + suffix;

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownUtil.java
@@ -74,9 +74,13 @@ public final class MarkdownUtil {
     }
 
     /**
-     * Escapes already existing monospace (single backtick) regions in the input
-     * and applies monospace formatting to the entire string.
-     * <br>The resulting string will be {@code "`" + escaped(input) + "`"}.
+     * Applies monospace formatting to the input, checking for
+     * backticks present and handling them appropriately.
+     * <br>The resulting string will be {@code "`" + input + "`"}
+     * or {@code "``" + input + "``"} depending on whether backticks
+     * are present. If there are backticks directly in the beginning
+     * or end of the input, an extra space will be added before or
+     * after them to ensure the input is properly monospaced.
      *
      * @param  input
      *         The input to monospace
@@ -85,8 +89,15 @@ public final class MarkdownUtil {
      */
     @Nonnull
     public static String monospace(@Nonnull String input) {
-        String sanitized = MarkdownSanitizer.escape(input, ~MarkdownSanitizer.MONO);
-        return "`" + sanitized + "`";
+        if(input.isEmpty()) return "` `";
+        if(input.contains("`") && !input.contains("``")) {
+            String prefix = input.startsWith("`") ? "`` " : "``";
+            String suffix = input.endsWith("`") ? " ``" : "``";
+            return prefix + input + suffix;
+        }
+        String prefix = input.startsWith("`") ? "` " : "`";
+        String suffix = input.endsWith("`") ? " `" : "`";
+        return prefix + input + suffix;
     }
 
     /**

--- a/src/test/java/net/dv8tion/jda/test/util/MarkdownUtilTest.java
+++ b/src/test/java/net/dv8tion/jda/test/util/MarkdownUtilTest.java
@@ -46,8 +46,12 @@ public class MarkdownUtilTest {
     @Test
     void testMonospace() {
         assertThat(monospace("Hello World")).isEqualTo("`Hello World`");
-        assertThat(monospace("Hello `Test` World")).isEqualTo("`Hello \\`Test\\` World`");
+        assertThat(monospace("Hello `Test` World")).isEqualTo("``Hello `Test` World``");
         assertThat(monospace("Hello ``Test`` World")).isEqualTo("`Hello ``Test`` World`");
+        assertThat(monospace("`Hello` World")).isEqualTo("`` `Hello` World``");
+        assertThat(monospace("Hello `World`")).isEqualTo("``Hello `World` ``");
+        assertThat(monospace("``Hello`` World")).isEqualTo("` ``Hello`` World`");
+        assertThat(monospace("Hello ``World``")).isEqualTo("`Hello ``World`` `");
     }
 
     @Test


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [x] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #3071

## Description

Modifies the logic of `MarkdownUtil#monospace`, so that it:
- Correctly applies monospace formatting even when the input string contains backticks, and
- Does not add backslashes, since they have no effect on backticks and are actually visible in the Discord client, meaning the result string is not faithful to the input string.

Single backticks are allowed in monospace text by using double backticks as delimiters instead, and monospace text can start with backticks by inserting an extra space between the delimiter and the string, which does not appear on the client. These improvements allow the method to properly monospace text with backticks.

It is impossible to apply monospace formatting to text that contains both single and double backticks, so that case is not handled.

This should not be "out of scope" for JDA, since there is no complex parser logic involved. The current implementation is worse for text with backticks than just manually concatenating a backtick before and after the string, since it adds backslashes to the text which are shown on the client. This PR fixes the implementation enough to bring it on par with other methods in `MarkdownUtil`.