### PR TITLE
Fix icon URLs for GIF stickers

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/sticker/Sticker.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/sticker/Sticker.java
@@ -100,7 +100,11 @@ public interface Sticker extends StickerSnowflake {
      */
     @Nonnull
     default String getIconUrl() {
-        return Helpers.format(ICON_URL, getId(), getFormatType().getExtension());
+        StickerFormat format = getFormatType();
+        if (format == StickerFormat.GIF) {
+            return Helpers.format("https://media.discordapp.net/stickers/%s.%s", getId(), format.getExtension());
+        }
+        return Helpers.format(ICON_URL, getId(), format.getExtension());
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/sticker/Sticker.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/sticker/Sticker.java
@@ -102,7 +102,8 @@ public interface Sticker extends StickerSnowflake {
     default String getIconUrl() {
         StickerFormat format = getFormatType();
         if (format == StickerFormat.GIF) {
-            // See https://github.com/discord/discord-api-docs/blob/26471f899141bd0148a870e965ca36b87e9739e2/developers/reference.mdx?plain=1#L393
+            // See
+            // https://github.com/discord/discord-api-docs/blob/26471f899141bd0148a870e965ca36b87e9739e2/developers/reference.mdx?plain=1#L393
             return Helpers.format("https://media.discordapp.net/stickers/%s.%s", getId(), format.getExtension());
         }
         return Helpers.format(ICON_URL, getId(), format.getExtension());

--- a/src/main/java/net/dv8tion/jda/api/entities/sticker/Sticker.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/sticker/Sticker.java
@@ -102,6 +102,7 @@ public interface Sticker extends StickerSnowflake {
     default String getIconUrl() {
         StickerFormat format = getFormatType();
         if (format == StickerFormat.GIF) {
+            // See https://github.com/discord/discord-api-docs/blob/26471f899141bd0148a870e965ca36b87e9739e2/developers/reference.mdx?plain=1#L393
             return Helpers.format("https://media.discordapp.net/stickers/%s.%s", getId(), format.getExtension());
         }
         return Helpers.format(ICON_URL, getId(), format.getExtension());

--- a/src/test/java/net/dv8tion/jda/test/entities/sticker/StickerTest.java
+++ b/src/test/java/net/dv8tion/jda/test/entities/sticker/StickerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.test.entities.sticker;
+
+import net.dv8tion.jda.api.entities.sticker.Sticker.StickerFormat;
+import net.dv8tion.jda.internal.entities.sticker.StickerItemImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StickerTest {
+    private static final long STICKER_ID = 749054660769218631L;
+
+    @Test
+    void getIconUrlUsesCdnForNonGifFormats() {
+        assertThat(createSticker(StickerFormat.PNG).getIconUrl())
+                .isEqualTo("https://cdn.discordapp.com/stickers/749054660769218631.png");
+        assertThat(createSticker(StickerFormat.APNG).getIconUrl())
+                .isEqualTo("https://cdn.discordapp.com/stickers/749054660769218631.png");
+        assertThat(createSticker(StickerFormat.LOTTIE).getIconUrl())
+                .isEqualTo("https://cdn.discordapp.com/stickers/749054660769218631.json");
+    }
+
+    @Test
+    void getIconUrlUsesMediaCdnForGifFormat() {
+        assertThat(createSticker(StickerFormat.GIF).getIconUrl())
+                .isEqualTo("https://media.discordapp.net/stickers/749054660769218631.gif");
+    }
+
+    private StickerItemImpl createSticker(StickerFormat format) {
+        return new StickerItemImpl(STICKER_ID, format, "test-sticker");
+    }
+}


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [x] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code)
- [ ] Documentation
- [ ] Other: _____

Closes #3136

## Description

Routes GIF sticker icon URLs through `media.discordapp.net`, as required
by Discord's image-formatting documentation.

PNG, APNG, and Lottie sticker URLs continue to use `cdn.discordapp.com`.
This is necessary because the media endpoint does not serve Lottie sticker
JSON correctly.

Adds focused regression tests covering PNG, APNG, Lottie, and GIF sticker
icon URLs.

## Testing

- `./gradlew test --tests net.dv8tion.jda.test.entities.sticker.StickerTest`
- `./gradlew format`
- `./gradlew build`
