### PR TITLE
Update `Message.MAX_FILE_SIZE` to 20 MiB

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -147,11 +147,11 @@ public interface Message extends ISnowflake, Formattable {
     String JUMP_URL = "https://discord.com/channels/%s/%s/%s";
 
     /**
-     * The maximum sendable file size (10 MiB)
+     * The maximum sendable file size (20 MiB)
      *
      *  @see MessageRequest#setFiles(Collection)
      */
-    int MAX_FILE_SIZE = 10 << 20;
+    int MAX_FILE_SIZE = 20 << 20;
 
     /**
      * The maximum amount of files sendable within a single message ({@value})


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [X] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [X] Other: Constants

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Here we go again.

**Changelog:** https://docs.discord.com/developers/change-log#default-file-upload-limit-increase
